### PR TITLE
Implement end 2 end test for navigation through top level destination

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/endtoend/NavigationBarEndToEnd.kt
+++ b/app/src/androidTest/java/com/android/bookswap/endtoend/NavigationBarEndToEnd.kt
@@ -1,0 +1,47 @@
+package com.android.bookswap.endtoend
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.android.bookswap.MainActivity
+import com.android.bookswap.data.source.network.BooksFirestoreRepository
+import com.android.bookswap.data.source.network.MessageFirestoreSource
+import com.google.firebase.firestore.FirebaseFirestore
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class NavigationBarEndToEnd {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Before
+    fun setUp() {
+
+        composeTestRule.setContent {
+            val db = FirebaseFirestore.getInstance()
+
+            val messageRepository = MessageFirestoreSource(db)
+            val bookRepository = BooksFirestoreRepository(db)
+            MainActivity().BookSwapApp(messageRepository, bookRepository)
+        }
+    }
+
+    @Test
+    fun testNavigationBar() {
+        // Check if the navigation bar is displayed
+        composeTestRule.onNodeWithTag("bottomNavigationMenu").assertExists()
+
+        // Click on the Map tab and check if the MapScreen is displayed
+        composeTestRule.onNodeWithTag("Map").assertExists().performClick()
+        composeTestRule.onNodeWithTag("mapScreen").assertExists()
+
+        // Click on the Add Book tab and check if the AddToBookScreen is displayed
+        composeTestRule.onNodeWithTag("New Book").assertExists().performClick()
+        composeTestRule.onNodeWithTag("addBookChoiceScreen").assertExists()
+
+        // Click on the Chat tab and check if the ListChatScreen is displayed
+        composeTestRule.onNodeWithTag("Chat").assertExists().performClick()
+        composeTestRule.onNodeWithTag("chat_listScreen").assertExists()
+    }
+}

--- a/app/src/androidTest/java/com/android/bookswap/endtoend/NavigationBarEndToEnd.kt
+++ b/app/src/androidTest/java/com/android/bookswap/endtoend/NavigationBarEndToEnd.kt
@@ -29,11 +29,6 @@ class NavigationBarEndToEnd {
 
   @Test
   fun testNavigationBar() {
-
-    // Click on the Map tab and check if the MapScreen is displayed
-    composeTestRule.onNodeWithTag("Map").assertExists().performClick()
-    composeTestRule.onNodeWithTag("mapScreen").assertExists()
-
     // Click on the Add Book tab and check if the AddToBookScreen is displayed
     composeTestRule.onNodeWithTag("New Book").assertExists().performClick()
     composeTestRule.onNodeWithTag("addBookChoiceScreen").assertExists()
@@ -41,5 +36,10 @@ class NavigationBarEndToEnd {
     // Click on the Chat tab and check if the ListChatScreen is displayed
     composeTestRule.onNodeWithTag("Chat").assertExists().performClick()
     composeTestRule.onNodeWithTag("chat_listScreen").assertExists()
+
+    // Click on the Map tab and check if the MapScreen is displayed
+    composeTestRule.onNodeWithTag("Map").assertExists().performClick()
+    composeTestRule.onNodeWithTag("mapScreen").assertExists()
+
   }
 }

--- a/app/src/androidTest/java/com/android/bookswap/endtoend/NavigationBarEndToEnd.kt
+++ b/app/src/androidTest/java/com/android/bookswap/endtoend/NavigationBarEndToEnd.kt
@@ -40,6 +40,5 @@ class NavigationBarEndToEnd {
     // Click on the Map tab and check if the MapScreen is displayed
     composeTestRule.onNodeWithTag("Map").assertExists().performClick()
     composeTestRule.onNodeWithTag("mapScreen").assertExists()
-
   }
 }

--- a/app/src/androidTest/java/com/android/bookswap/endtoend/NavigationBarEndToEnd.kt
+++ b/app/src/androidTest/java/com/android/bookswap/endtoend/NavigationBarEndToEnd.kt
@@ -6,42 +6,40 @@ import androidx.compose.ui.test.performClick
 import com.android.bookswap.MainActivity
 import com.android.bookswap.data.source.network.BooksFirestoreRepository
 import com.android.bookswap.data.source.network.MessageFirestoreSource
+import com.android.bookswap.ui.navigation.Route
 import com.google.firebase.firestore.FirebaseFirestore
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
 class NavigationBarEndToEnd {
-    @get:Rule
-    val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    @Before
-    fun setUp() {
+  @Before
+  fun setUp() {
 
-        composeTestRule.setContent {
-            val db = FirebaseFirestore.getInstance()
+    composeTestRule.setContent {
+      val db = FirebaseFirestore.getInstance()
 
-            val messageRepository = MessageFirestoreSource(db)
-            val bookRepository = BooksFirestoreRepository(db)
-            MainActivity().BookSwapApp(messageRepository, bookRepository)
-        }
+      val messageRepository = MessageFirestoreSource(db)
+      val bookRepository = BooksFirestoreRepository(db)
+      MainActivity().BookSwapApp(messageRepository, bookRepository, Route.MAP)
     }
+  }
 
-    @Test
-    fun testNavigationBar() {
-        // Check if the navigation bar is displayed
-        composeTestRule.onNodeWithTag("bottomNavigationMenu").assertExists()
+  @Test
+  fun testNavigationBar() {
 
-        // Click on the Map tab and check if the MapScreen is displayed
-        composeTestRule.onNodeWithTag("Map").assertExists().performClick()
-        composeTestRule.onNodeWithTag("mapScreen").assertExists()
+    // Click on the Map tab and check if the MapScreen is displayed
+    composeTestRule.onNodeWithTag("Map").assertExists().performClick()
+    composeTestRule.onNodeWithTag("mapScreen").assertExists()
 
-        // Click on the Add Book tab and check if the AddToBookScreen is displayed
-        composeTestRule.onNodeWithTag("New Book").assertExists().performClick()
-        composeTestRule.onNodeWithTag("addBookChoiceScreen").assertExists()
+    // Click on the Add Book tab and check if the AddToBookScreen is displayed
+    composeTestRule.onNodeWithTag("New Book").assertExists().performClick()
+    composeTestRule.onNodeWithTag("addBookChoiceScreen").assertExists()
 
-        // Click on the Chat tab and check if the ListChatScreen is displayed
-        composeTestRule.onNodeWithTag("Chat").assertExists().performClick()
-        composeTestRule.onNodeWithTag("chat_listScreen").assertExists()
-    }
+    // Click on the Chat tab and check if the ListChatScreen is displayed
+    composeTestRule.onNodeWithTag("Chat").assertExists().performClick()
+    composeTestRule.onNodeWithTag("chat_listScreen").assertExists()
+  }
 }

--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -66,7 +66,7 @@ class MainActivity : ComponentActivity() {
   @Composable
   fun BookSwapApp(
       messageRepository: MessageFirestoreSource,
-      bookRepository: BooksFirestoreRepository
+      bookRepository: BooksFirestoreRepository,
   ) {
     val navController = rememberNavController()
     val navigationActions = NavigationActions(navController)
@@ -84,7 +84,7 @@ class MainActivity : ComponentActivity() {
     val userid1 = "user123"
     val userid2 = "user124"
 
-    NavHost(navController = navController, startDestination = Route.AUTH) {
+    NavHost(navController = navController, startDestination = Route.MAP) {
       navigation(startDestination = Screen.AUTH, route = Route.AUTH) {
         composable(Screen.AUTH) { SignInScreen(navigationActions) }
       }

--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -67,6 +67,7 @@ class MainActivity : ComponentActivity() {
   fun BookSwapApp(
       messageRepository: MessageFirestoreSource,
       bookRepository: BooksFirestoreRepository,
+      startDestination: String = Route.AUTH
   ) {
     val navController = rememberNavController()
     val navigationActions = NavigationActions(navController)
@@ -84,7 +85,7 @@ class MainActivity : ComponentActivity() {
     val userid1 = "user123"
     val userid2 = "user124"
 
-    NavHost(navController = navController, startDestination = Route.MAP) {
+    NavHost(navController = navController, startDestination = startDestination) {
       navigation(startDestination = Screen.AUTH, route = Route.AUTH) {
         composable(Screen.AUTH) { SignInScreen(navigationActions) }
       }

--- a/app/src/main/java/com/android/bookswap/ui/books/add/BookAdditionChoiceScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/add/BookAdditionChoiceScreen.kt
@@ -43,6 +43,7 @@ fun BookAdditionChoiceScreen(navController: NavigationActions) {
   val columnPadding = 16.dp
   val buttonWidth = (LocalConfiguration.current.screenWidthDp.dp * (0.75f))
   Scaffold(
+      modifier = Modifier.testTag("addBookChoiceScreen"),
       topBar = {
         TopAppBar(
             title = { Text("Book Addition Choice", color = ColorVariable.BackGround) },

--- a/app/src/main/java/com/android/bookswap/ui/chat/listChat.kt
+++ b/app/src/main/java/com/android/bookswap/ui/chat/listChat.kt
@@ -50,6 +50,7 @@ fun ListChatScreen(
     navigationActions: NavigationActions
 ) {
   Scaffold(
+      modifier = Modifier.testTag("chat_listScreen"),
       topBar = {
         TopAppBar(
             colors =


### PR DESCRIPTION
This PR introduces a new test that navigates through all top-level destinations already connected to the NavHost. It will be necessary to add the path to the profile route once this route is linked in the NavHost. I also modified the signature of BookSwapApp to allow selecting the start destination.