### PR TITLE
Feature: apply the filter system also to the book's marker 

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/map/MapScreenTest.kt
@@ -224,4 +224,20 @@ class MapScreenTest {
     composeTestRule.onAllNodesWithTag("mapBoxMarkerListBox").assertCountEquals(1)
     composeTestRule.onNodeWithTag("mapBoxMarkerListBoxTitle").assertTextContains("Book 3")
   }
+
+  @Test
+  fun noBooksTextDisplayedWhenNoBooksFound() {
+    val bookFilter = BookFilter()
+    bookFilter.setGenres(listOf("Dystopian"))
+    composeTestRule.setContent {
+      val navController = rememberNavController()
+      val navigationActions = NavigationActions(navController)
+      MapScreen(user, user[0], navigationActions, bookFilter)
+    }
+    composeTestRule
+        .onNodeWithTag("mapDraggableMenuNoBook")
+        .assertIsDisplayed()
+        .assertTextContains("No books found")
+    composeTestRule.onNodeWithTag("mapDraggableMenuBookBox").assertIsNotDisplayed()
+  }
 }

--- a/app/src/androidTest/java/com/android/bookswap/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/map/MapScreenTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
@@ -208,5 +209,19 @@ class MapScreenTest {
     }
     composeTestRule.onNodeWithTag("mapDraggableMenuBookBox").assertIsDisplayed()
     composeTestRule.onAllNodesWithTag("mapDraggableMenuBookBox").assertCountEquals(1)
+  }
+
+  @Test
+  fun listMarkerBookChangedWhenFilterApplied() {
+    val bookFilter = BookFilter()
+    bookFilter.setGenres(listOf("Horror"))
+    composeTestRule.setContent {
+        val navController = rememberNavController()
+        val navigationActions = NavigationActions(navController)
+        MapScreen(user, user[0], navigationActions, bookFilter)
+    }
+    composeTestRule.onNodeWithTag("mapBoxMarkerListBox").assertIsDisplayed()
+    composeTestRule.onAllNodesWithTag("mapBoxMarkerListBox").assertCountEquals(1)
+    composeTestRule.onNodeWithTag("mapBoxMarkerListBoxTitle").assertTextContains("Book 3")
   }
 }

--- a/app/src/androidTest/java/com/android/bookswap/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/map/MapScreenTest.kt
@@ -216,9 +216,9 @@ class MapScreenTest {
     val bookFilter = BookFilter()
     bookFilter.setGenres(listOf("Horror"))
     composeTestRule.setContent {
-        val navController = rememberNavController()
-        val navigationActions = NavigationActions(navController)
-        MapScreen(user, user[0], navigationActions, bookFilter)
+      val navController = rememberNavController()
+      val navigationActions = NavigationActions(navController)
+      MapScreen(user, user[0], navigationActions, bookFilter)
     }
     composeTestRule.onNodeWithTag("mapBoxMarkerListBox").assertIsDisplayed()
     composeTestRule.onAllNodesWithTag("mapBoxMarkerListBox").assertCountEquals(1)

--- a/app/src/main/java/com/android/bookswap/ui/map/Map.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/Map.kt
@@ -336,81 +336,98 @@ private fun DraggableMenu(listAllBooks: List<DataBook>) {
                   thickness = DIVIDER_THICKNESS_DP.dp,
                   color = ColorVariable.Accent)
               LazyColumn() {
-                items(listAllBooks) { book ->
-                  Spacer(modifier = Modifier.height(PADDING_VERTICAL_DP.dp))
-                  Row(
-                      modifier =
-                          Modifier.heightIn(min = MIN_BOX_BOOK_HEIGHT_DP.dp)
-                              .testTag("mapDraggableMenuBookBox")) {
-                        // Image Box
-                        Box(
-                            modifier =
-                                Modifier.height(IMAGE_HEIGHT_DP.dp)
-                                    .width(IMAGE_WIDTH_DP.dp)
-                                    .padding(
-                                        start = PADDING_HORIZONTAL_DP.dp,
-                                        end = PADDING_HORIZONTAL_DP.dp)
-                                    .testTag("mapDraggableMenuBookBoxImage")) {
-                              // Image of the books, will be added at a later date
-                              // We didn't discussed about how we will store the image or how we
-                              // will
-                              // encode them
-                              Box(
-                                  modifier =
-                                      Modifier.fillMaxSize()
-                                          .background(Color.Gray) // Placeholder for the image
-                                  )
-                            }
+                if (listAllBooks.isEmpty()) {
+                  item {
+                    Text(
+                        text = "No books found",
+                        color = ColorVariable.Accent,
+                        fontSize = PRIMARY_TEXT_FONT_SP.sp,
+                        textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                        modifier =
+                            Modifier.padding(PADDING_HORIZONTAL_DP.dp)
+                                .fillMaxWidth()
+                                .align(Alignment.CenterHorizontally)
+                                .testTag("mapDraggableMenuNoBook"))
+                  }
+                } else {
+                  items(listAllBooks) { book ->
+                    Spacer(modifier = Modifier.height(PADDING_VERTICAL_DP.dp))
+                    Row(
+                        modifier =
+                            Modifier.heightIn(min = MIN_BOX_BOOK_HEIGHT_DP.dp)
+                                .testTag("mapDraggableMenuBookBox")) {
+                          // Image Box
+                          Box(
+                              modifier =
+                                  Modifier.height(IMAGE_HEIGHT_DP.dp)
+                                      .width(IMAGE_WIDTH_DP.dp)
+                                      .padding(
+                                          start = PADDING_HORIZONTAL_DP.dp,
+                                          end = PADDING_HORIZONTAL_DP.dp)
+                                      .testTag("mapDraggableMenuBookBoxImage")) {
+                                // Image of the books, will be added at a later date
+                                // We didn't discussed about how we will store the image or how we
+                                // will
+                                // encode them
+                                Box(
+                                    modifier =
+                                        Modifier.fillMaxSize()
+                                            .background(Color.Gray) // Placeholder for the image
+                                    )
+                              }
 
-                        // Column for text content
-                        Column(
-                            modifier =
-                                Modifier.padding(vertical = PADDING_VERTICAL_DP.dp)
-                                    .width(WIDTH_TITLE_BOX_DP.dp)
-                                    .testTag("mapDraggableMenuBookBoxMiddle")) {
-                              Text(
-                                  text = book.title,
-                                  color = ColorVariable.Accent,
-                                  fontSize = PRIMARY_TEXT_FONT_SP.sp,
-                                  modifier =
-                                      Modifier.padding(bottom = PADDING_VERTICAL_DP.dp)
-                                          .width(WIDTH_TITLE_BOX_DP.dp)
-                                          .testTag("mapDraggableMenuBookBoxTitle"))
-                              Text(
-                                  text = book.author ?: "",
-                                  color = ColorVariable.AccentSecondary,
-                                  fontSize = SECONDARY_TEXT_FONT_SP.sp,
-                                  modifier =
-                                      Modifier.width(WIDTH_TITLE_BOX_DP.dp)
-                                          .testTag("mapDraggableMenuBookBoxAuthor"))
-                            }
-                        Column(
-                            modifier =
-                                Modifier.fillMaxWidth().testTag("mapDraggableMenuBookRight")) {
-                              Row(
-                                  modifier =
-                                      Modifier.fillMaxWidth()
-                                          .height(STAR_HEIGHT_DP.dp)
-                                          .testTag("mapDraggableMenuBookBoxRating")) {
-                                    // leave all stars empty if no rating
-                                    DisplayStarReview(book.rating ?: 0)
-                                  }
-                              // text for the tags of the book, will be added at a later date
-                              // It isn't decided how we will handle the tag for the books
-                              Text(
-                                  text = book.genres.joinToString(separator = ", ") { it.Genre },
-                                  modifier =
-                                      Modifier.fillMaxWidth().testTag("mapDraggableMenuBookBoxTag"),
-                                  fontSize = SECONDARY_TEXT_FONT_SP.sp,
-                                  color = ColorVariable.AccentSecondary)
-                            }
-                      }
+                          // Column for text content
+                          Column(
+                              modifier =
+                                  Modifier.padding(vertical = PADDING_VERTICAL_DP.dp)
+                                      .width(WIDTH_TITLE_BOX_DP.dp)
+                                      .testTag("mapDraggableMenuBookBoxMiddle")) {
+                                Text(
+                                    text = book.title,
+                                    color = ColorVariable.Accent,
+                                    fontSize = PRIMARY_TEXT_FONT_SP.sp,
+                                    modifier =
+                                        Modifier.padding(bottom = PADDING_VERTICAL_DP.dp)
+                                            .width(WIDTH_TITLE_BOX_DP.dp)
+                                            .testTag("mapDraggableMenuBookBoxTitle"))
+                                Text(
+                                    text = book.author ?: "",
+                                    color = ColorVariable.AccentSecondary,
+                                    fontSize = SECONDARY_TEXT_FONT_SP.sp,
+                                    modifier =
+                                        Modifier.width(WIDTH_TITLE_BOX_DP.dp)
+                                            .testTag("mapDraggableMenuBookBoxAuthor"))
+                              }
+                          Column(
+                              modifier =
+                                  Modifier.fillMaxWidth().testTag("mapDraggableMenuBookRight")) {
+                                Row(
+                                    modifier =
+                                        Modifier.fillMaxWidth()
+                                            .height(STAR_HEIGHT_DP.dp)
+                                            .testTag("mapDraggableMenuBookBoxRating")) {
+                                      // leave all stars empty if no rating
+                                      DisplayStarReview(book.rating ?: 0)
+                                    }
+                                // text for the tags of the book, will be added at a later date
+                                // It isn't decided how we will handle the tag for the books
+                                Text(
+                                    text = book.genres.joinToString(separator = ", ") { it.Genre },
+                                    modifier =
+                                        Modifier.fillMaxWidth()
+                                            .testTag("mapDraggableMenuBookBoxTag"),
+                                    fontSize = SECONDARY_TEXT_FONT_SP.sp,
+                                    color = ColorVariable.AccentSecondary)
+                              }
+                        }
 
-                  // Divider below each item
-                  HorizontalDivider(
-                      modifier = Modifier.fillMaxWidth().testTag("mapDraggableMenuBookBoxDivider"),
-                      thickness = DIVIDER_THICKNESS_DP.dp,
-                      color = ColorVariable.Accent)
+                    // Divider below each item
+                    HorizontalDivider(
+                        modifier =
+                            Modifier.fillMaxWidth().testTag("mapDraggableMenuBookBoxDivider"),
+                        thickness = DIVIDER_THICKNESS_DP.dp,
+                        color = ColorVariable.Accent)
+                  }
                 }
               }
             }

--- a/app/src/main/java/com/android/bookswap/ui/map/Map.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/Map.kt
@@ -137,6 +137,8 @@ fun MapScreen(
             onMapClick = { mutableStateSelectedUser = null },
             modifier = Modifier.fillMaxSize().padding(pd).testTag("mapGoogleMap"),
             cameraPositionState = cameraPositionState,
+            uiSettings = MapUiSettings(zoomControlsEnabled = false),
+
         ) {
           filteredUsers
               .filter { !it.longitude.isNaN() && !it.latitude.isNaN() && it.listBook.isNotEmpty() }
@@ -164,7 +166,7 @@ fun MapScreen(
                     Modifier.offset {
                       IntOffset(screenPos.x.roundToInt(), screenPos.y.roundToInt())
                     },
-                user = user)
+                userBooks = bookFilter.filterBooks(user.listBook))
           }
         }
         // Draggable Bottom List
@@ -195,7 +197,7 @@ const val SECONDARY_TEXT_FONT_SP = 16
  *   window.
  */
 @Composable
-private fun CustomInfoWindow(modifier: Modifier = Modifier, user: TempUser) {
+private fun CustomInfoWindow(modifier: Modifier = Modifier, userBooks: List<DataBook>) {
   Card(
       modifier =
           modifier
@@ -218,7 +220,7 @@ private fun CustomInfoWindow(modifier: Modifier = Modifier, user: TempUser) {
               0.dp, CARD_CORNER_RADIUS.dp, CARD_CORNER_RADIUS.dp, CARD_CORNER_RADIUS.dp)) {
         Spacer(modifier.height(CARD_CORNER_RADIUS.dp))
         LazyColumn(modifier = Modifier.fillMaxWidth().testTag("mapBoxMarkerList")) {
-          itemsIndexed(user.listBook) { index, book ->
+          itemsIndexed(userBooks) { index, book ->
             Column(
                 modifier =
                     Modifier.padding(horizontal = PADDING_HORIZONTAL_DP.dp)
@@ -235,7 +237,7 @@ private fun CustomInfoWindow(modifier: Modifier = Modifier, user: TempUser) {
                       fontSize = SECONDARY_TEXT_FONT_SP.sp,
                       modifier = Modifier.testTag("mapBoxMarkerListBoxAuthor"))
                 }
-            if (index < user.listBook.size - 1)
+            if (index < userBooks.size - 1)
                 HorizontalDivider(
                     modifier =
                         Modifier.fillMaxWidth()

--- a/app/src/main/java/com/android/bookswap/ui/map/Map.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/Map.kt
@@ -138,7 +138,6 @@ fun MapScreen(
             modifier = Modifier.fillMaxSize().padding(pd).testTag("mapGoogleMap"),
             cameraPositionState = cameraPositionState,
             uiSettings = MapUiSettings(zoomControlsEnabled = false),
-
         ) {
           filteredUsers
               .filter { !it.longitude.isNaN() && !it.latitude.isNaN() && it.listBook.isNotEmpty() }


### PR DESCRIPTION

This PR enhances the filter system on the map screen by applying filter settings to books displayed under user markers. A JUnit test has been added to verify the functionality of this feature. Additionally, the native Google Maps zoom controls have been removed to improve the UI.

### Changes Made

1.  Applied filters now affect both displayed books on the draggable menu and those associated with user markers on the map.

2.  Added tests to ensure the filter system works as expected.

3. Removed Google Maps' native zoom controls for a cleaner, more streamlined appearance.

Removing the native Google Maps UI wasn't part of the original task, but it was a quick change, and including it here avoids the need for a separate PR.