### PR TITLE
Expand Messaging Function to include deleting and editing

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
@@ -187,6 +187,22 @@ class ChatScreenTest {
       callback(sendMessageResult)
     }
 
+    override fun deleteMessage(message: DataMessage, callback: (Result<Unit>) -> Unit) {
+      TODO("Not yet implemented")
+    }
+
+    override fun deleteAllMessages(
+        user1Id: String,
+        user2Id: String,
+        callback: (Result<Unit>) -> Unit
+    ) {
+      TODO("Not yet implemented")
+    }
+
+    override fun updateMessage(message: DataMessage, callback: (Result<Unit>) -> Unit) {
+      TODO("Not yet implemented")
+    }
+
     override fun addMessagesListener(
         otherUserId: String,
         currentUserId: String,

--- a/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
@@ -1,14 +1,22 @@
 package com.android.bookswap.ui.chat
 
+import android.content.Context
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import com.android.bookswap.data.DataMessage
 import com.android.bookswap.data.repository.MessageRepository
+import com.android.bookswap.ui.navigation.NavigationActions
 import com.android.bookswap.ui.theme.ColorVariable
 import com.google.firebase.firestore.ListenerRegistration
 import io.mockk.mockk
@@ -26,9 +34,11 @@ class ChatScreenTest {
   private lateinit var mockMessageRepository: MessageRepository
   private val currentUserId = "current-user-id"
   private val otherUserId = "other-user-id"
+  private lateinit var mockNavigationActions: NavigationActions
 
   @Before
   fun setUp() {
+    mockNavigationActions = mockk()
     placeHolderData =
         List(6) {
           DataMessage(
@@ -36,7 +46,7 @@ class ChatScreenTest {
               senderId = "current-user-id",
               receiverId = "other-user-id",
               text = "Test message $it",
-              timestamp = System.currentTimeMillis())
+              timestamp = it.toLong())
         }
     mockMessageRepository =
         MockMessageFirestoreSource().apply { messages = placeHolderData.toMutableList() }
@@ -64,7 +74,8 @@ class ChatScreenTest {
       ChatScreen(
           messageRepository = mockMessageRepository,
           currentUserId = currentUserId,
-          otherUserId = otherUserId)
+          otherUserId = otherUserId,
+          mockNavigationActions)
     }
     composeTestRule.onNodeWithTag("message_input_field").assertIsDisplayed()
     composeTestRule.onNodeWithTag("send_button").assertIsDisplayed()
@@ -79,17 +90,32 @@ class ChatScreenTest {
       ChatScreen(
           messageRepository = mockMessageRepository,
           currentUserId = currentUserId,
-          otherUserId = otherUserId)
+          otherUserId = otherUserId,
+          mockNavigationActions)
     }
     composeTestRule.onNodeWithTag("message_input_field").assertIsDisplayed()
     composeTestRule.onNodeWithTag("send_button").assertIsDisplayed()
     placeHolderData.forEach { message ->
-      composeTestRule.onNodeWithTag("message_item ${message.id}").assertIsDisplayed()
-      composeTestRule.onNodeWithTag("message_text ${message.id}").assertIsDisplayed()
-      composeTestRule.onNodeWithTag("message_text ${message.id}").assertTextEquals(message.text)
-      composeTestRule.onNodeWithTag("message_timestamp ${message.id}").assertIsDisplayed()
+      composeTestRule.waitUntil {
+        composeTestRule
+            .onAllNodesWithTag("message_item ${message.id}", useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
+      }
       composeTestRule
-          .onNodeWithTag("message_timestamp ${message.id}")
+          .onNodeWithTag("message_item ${message.id}", useUnmergedTree = true)
+          .assertIsDisplayed()
+      composeTestRule
+          .onNodeWithTag("message_text ${message.id}", useUnmergedTree = true)
+          .assertIsDisplayed()
+      composeTestRule
+          .onNodeWithTag("message_text ${message.id}", useUnmergedTree = true)
+          .assertTextEquals(message.text)
+      composeTestRule
+          .onNodeWithTag("message_timestamp ${message.id}", useUnmergedTree = true)
+          .assertIsDisplayed()
+      composeTestRule
+          .onNodeWithTag("message_timestamp ${message.id}", useUnmergedTree = true)
           .assertTextEquals(formatTimestamp(message.timestamp))
     }
   }
@@ -100,7 +126,8 @@ class ChatScreenTest {
       ChatScreen(
           messageRepository = mockMessageRepository,
           currentUserId = currentUserId,
-          otherUserId = otherUserId)
+          otherUserId = otherUserId,
+          mockNavigationActions)
     }
     composeTestRule.onNodeWithTag("send_button").assertHasClickAction()
   }
@@ -111,7 +138,8 @@ class ChatScreenTest {
       ChatScreen(
           messageRepository = mockMessageRepository,
           currentUserId = currentUserId,
-          otherUserId = otherUserId)
+          otherUserId = otherUserId,
+          mockNavigationActions)
     }
     val testInput = "Hello, World!"
     composeTestRule.onNodeWithTag("message_input_field").performTextInput(testInput)
@@ -127,7 +155,8 @@ class ChatScreenTest {
       ChatScreen(
           messageRepository = mockMessageRepository,
           currentUserId = currentUserId,
-          otherUserId = otherUserId)
+          otherUserId = otherUserId,
+          mockNavigationActions)
     }
 
     val testInput = "Hello, World!"
@@ -144,12 +173,180 @@ class ChatScreenTest {
   }
 
   @Test
+  fun testTopAppBar() {
+    composeTestRule.setContent {
+      ChatScreen(
+          messageRepository = mockMessageRepository,
+          currentUserId = currentUserId,
+          otherUserId = otherUserId,
+          mockNavigationActions)
+    }
+
+    composeTestRule.onNodeWithTag("chatTopAppBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("chatName").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("chatName").assertTextEquals(otherUserId)
+    composeTestRule.onNodeWithTag("profileIcon", useUnmergedTree = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun testPopUpExists() {
+    composeTestRule.setContent {
+      ChatScreen(
+          messageRepository = mockMessageRepository,
+          currentUserId = currentUserId,
+          otherUserId = otherUserId,
+          navController = mockNavigationActions)
+    }
+
+    composeTestRule.waitForIdle()
+
+    val messageNode =
+        composeTestRule.onNodeWithTag(
+            "message_item ${placeHolderData.first().id}", useUnmergedTree = true)
+    messageNode.assertExists("Message item not found")
+
+    messageNode.performSemanticsAction(SemanticsActions.OnLongClick)
+
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule
+          .onAllNodesWithTag("editButton", useUnmergedTree = true)
+          .fetchSemanticsNodes()
+          .isNotEmpty() &&
+          composeTestRule
+              .onAllNodesWithTag("deleteButton", useUnmergedTree = true)
+              .fetchSemanticsNodes()
+              .isNotEmpty()
+    }
+
+    composeTestRule.onNodeWithTag("editButton", useUnmergedTree = true).assertIsDisplayed()
+    composeTestRule.onNodeWithTag("deleteButton", useUnmergedTree = true).assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag("editButton", useUnmergedTree = true).assertHasClickAction()
+    composeTestRule.onNodeWithTag("deleteButton", useUnmergedTree = true).assertHasClickAction()
+  }
+
+  @Test
+  fun testDelete() {
+    val mockMessageRepository =
+        MockMessageFirestoreSource().apply { messages = placeHolderData.toMutableList() }
+
+    composeTestRule.setContent {
+      ChatScreen(
+          messageRepository = mockMessageRepository,
+          currentUserId = currentUserId,
+          otherUserId = otherUserId,
+          mockNavigationActions)
+    }
+
+    val message = placeHolderData.first()
+    val messageNode =
+        composeTestRule.onNodeWithTag("message_item ${message.id}", useUnmergedTree = true)
+    messageNode.assertExists("Message item not found")
+
+    messageNode.performSemanticsAction(SemanticsActions.OnLongClick)
+
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule
+          .onAllNodesWithTag("deleteButton", useUnmergedTree = true)
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+    }
+
+    composeTestRule.onNodeWithTag("deleteButton", useUnmergedTree = true).performClick()
+
+    val deletedMessage = mockMessageRepository.messages.find { it.id == message.id }
+    assert(deletedMessage == null) { "Message was not deleted" }
+
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule
+          .onAllNodesWithTag("message_item ${message.id}", useUnmergedTree = true)
+          .fetchSemanticsNodes()
+          .isEmpty()
+    }
+
+    composeTestRule
+        .onNodeWithTag("message_item ${message.id}", useUnmergedTree = true)
+        .assertDoesNotExist()
+  }
+
+  @Test
+  fun testEdit() {
+    val mockMessageRepository =
+        MockMessageFirestoreSource().apply { messages = placeHolderData.toMutableList() }
+
+    composeTestRule.setContent {
+      ChatScreen(
+          messageRepository = mockMessageRepository,
+          currentUserId = currentUserId,
+          otherUserId = otherUserId,
+          navController = mockNavigationActions)
+    }
+
+    val message = placeHolderData.first()
+    val newText = "Updated message text"
+
+    val messageNode =
+        composeTestRule.onNodeWithTag("message_item ${message.id}", useUnmergedTree = true)
+    messageNode.assertExists("Message item not found")
+
+    messageNode.performSemanticsAction(SemanticsActions.OnLongClick)
+
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule
+          .onAllNodesWithTag("editButton", useUnmergedTree = true)
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+    }
+
+    composeTestRule.onNodeWithTag("editButton", useUnmergedTree = true).performClick()
+
+    composeTestRule
+        .onNodeWithTag("message_input_field", useUnmergedTree = true)
+        .assertTextEquals(message.text)
+
+    composeTestRule
+        .onNodeWithTag("message_input_field", useUnmergedTree = true)
+        .performTextClearance()
+    composeTestRule
+        .onNodeWithTag("message_input_field", useUnmergedTree = true)
+        .performTextInput(newText)
+    composeTestRule.onNodeWithTag("send_button", useUnmergedTree = true).performClick()
+
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      mockMessageRepository.messages.find { it.id == message.id }?.text == newText
+    }
+
+    val updatedMessage = mockMessageRepository.messages.find { it.id == message.id }
+    assert(updatedMessage != null && updatedMessage.text == newText) {
+      "Message was not updated correctly"
+    }
+
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule
+          .onNodeWithTag("message_text ${message.id}", useUnmergedTree = true)
+          .fetchSemanticsNode()
+          .config
+          .getOrNull(SemanticsProperties.Text)
+          ?.joinToString() == newText
+    }
+
+    composeTestRule
+        .onNodeWithTag("message_text ${message.id}", useUnmergedTree = true)
+        .assertTextEquals(newText)
+
+    composeTestRule
+        .onNodeWithTag("message_input_field", useUnmergedTree = true)
+        .assertTextEquals("")
+  }
+
+  @Test
   fun testAllColorsBelongToPalette() {
     composeTestRule.setContent {
       ChatScreen(
           messageRepository = mockMessageRepository,
           currentUserId = currentUserId,
-          otherUserId = otherUserId)
+          otherUserId = otherUserId,
+          mockNavigationActions)
     }
 
     val uiColors =
@@ -187,8 +384,13 @@ class ChatScreenTest {
       callback(sendMessageResult)
     }
 
-    override fun deleteMessage(message: DataMessage, callback: (Result<Unit>) -> Unit) {
-      TODO("Not yet implemented")
+    override fun deleteMessage(
+        messageId: String,
+        callback: (Result<Unit>) -> Unit,
+        context: Context
+    ) {
+      messages.removeIf { it.id == messageId }
+      callback(Result.success(Unit))
     }
 
     override fun deleteAllMessages(
@@ -196,11 +398,23 @@ class ChatScreenTest {
         user2Id: String,
         callback: (Result<Unit>) -> Unit
     ) {
-      TODO("Not yet implemented")
+      messages.removeIf { it.senderId == user1Id && it.receiverId == user2Id }
+      messages.removeIf { it.senderId == user2Id && it.receiverId == user1Id }
+      callback(Result.success(Unit))
     }
 
-    override fun updateMessage(message: DataMessage, callback: (Result<Unit>) -> Unit) {
-      TODO("Not yet implemented")
+    override fun updateMessage(
+        message: DataMessage,
+        callback: (Result<Unit>) -> Unit,
+        context: Context
+    ) {
+      val index = messages.indexOfFirst { it.id == message.id }
+      if (index != -1) {
+        messages[index] = message.copy(text = message.text) // Update the message text
+        callback(Result.success(Unit)) // Simulate success
+      } else {
+        callback(Result.failure(Exception("Message not found")))
+      }
     }
 
     override fun addMessagesListener(

--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -91,7 +91,9 @@ class MainActivity : ComponentActivity() {
       }
       navigation(startDestination = Screen.CHATLIST, route = Route.CHAT) {
         composable(Screen.CHATLIST) { ListChatScreen(placeHolder, navigationActions) }
-        composable(Screen.CHAT) { ChatScreen(messageRepository, userid1, userid2) }
+        composable(Screen.CHAT) {
+          ChatScreen(messageRepository, userid1, userid2, navigationActions)
+        }
       }
       navigation(startDestination = Screen.MAP, route = Route.MAP) {
         composable(Screen.MAP) {

--- a/app/src/main/java/com/android/bookswap/data/repository/MessageRepository.kt
+++ b/app/src/main/java/com/android/bookswap/data/repository/MessageRepository.kt
@@ -35,6 +35,34 @@ interface MessageRepository {
   fun sendMessage(message: DataMessage, callback: (Result<Unit>) -> Unit)
 
   /**
+   * Delete a message from the repository
+   *
+   * @param message message to be deleted
+   * @param callback callback function that receives Result.success() when operation succeed of
+   *   Result.failure(exception) if error
+   */
+  fun deleteMessage(messageId: String, callback: (Result<Unit>) -> Unit)
+
+  /**
+   * Delete all messages of this chat from the repository
+   *
+   * @param user1Id id of the first user
+   * @param user2Id id of the second user
+   * @param callback callback function that receives Result.success() when operation succeed of
+   *   Result.failure(exception) if error
+   */
+  fun deleteAllMessages(user1Id: String, user2Id: String, callback: (Result<Unit>) -> Unit)
+
+  /**
+   * Update a message in the repository
+   *
+   * @param message message to be updated
+   * @param callback callback function that receives Result.success() when operation succeed of
+   *   Result.failure(exception) if error
+   */
+  fun updateMessage(messageId: DataMessage, callback: (Result<Unit>) -> Unit)
+
+  /**
    * Add a listener to the repository to get messages in real-time
    *
    * @param otherUserId id of the other user

--- a/app/src/test/java/com/android/bookswap/model/chat/DataMessageFirestoreSourceTest.kt
+++ b/app/src/test/java/com/android/bookswap/model/chat/DataMessageFirestoreSourceTest.kt
@@ -1,7 +1,10 @@
 package com.android.bookswap.model.chat
 
+import android.content.Context
+import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import com.android.bookswap.data.DataMessage
+import com.android.bookswap.data.source.network.COLLECTION_PATH
 import com.android.bookswap.data.source.network.MessageFirestoreSource
 import com.android.bookswap.data.source.network.documentToMessage
 import com.google.android.gms.tasks.Tasks
@@ -11,19 +14,23 @@ import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
+import com.google.firebase.firestore.WriteBatch
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.anyMap
 import org.mockito.Mock
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 
 @RunWith(RobolectricTestRunner::class)
 class DataMessageFirestoreSourceTest {
@@ -82,6 +89,31 @@ class DataMessageFirestoreSourceTest {
   }
 
   @Test
+  fun `get messages returns empty list when no messages exist`() {
+    `when`(mockQuerySnapshot.documents).thenReturn(emptyList())
+
+    messageRepository.getMessages { result ->
+      assertTrue(result.isSuccess)
+      assertTrue(result.getOrNull()!!.isEmpty())
+    }
+
+    verify(mockCollectionReference).get()
+  }
+
+  @Test
+  fun `get messages handles firestore failure`() {
+    val exception = Exception("Firestore get error")
+    `when`(mockCollectionReference.get()).thenReturn(Tasks.forException(exception))
+
+    messageRepository.getMessages { result ->
+      assertTrue(result.isFailure)
+      assertEquals(exception, result.exceptionOrNull())
+    }
+
+    verify(mockCollectionReference).get()
+  }
+
+  @Test
   fun `get messages calls firestore get`() {
     // Arrange
     `when`(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot))
@@ -123,6 +155,41 @@ class DataMessageFirestoreSourceTest {
   }
 
   @Test
+  fun `send message handles firestore set failure`() {
+    val exception = Exception("Firestore set error")
+    val messageMap =
+        mapOf(
+            "id" to testMessage.id,
+            "text" to testMessage.text,
+            "senderId" to testMessage.senderId,
+            "receiverId" to testMessage.receiverId,
+            "timestamp" to testMessage.timestamp)
+
+    `when`(mockDocumentReference.set(messageMap)).thenReturn(Tasks.forException(exception))
+
+    messageRepository.sendMessage(testMessage) { result ->
+      assertTrue(result.isFailure)
+      assertEquals(exception, result.exceptionOrNull())
+    }
+
+    verify(mockDocumentReference).set(messageMap)
+  }
+
+  @Test
+  fun `documentToMessage fails when document is missing fields`() {
+    `when`(mockDocumentSnapshot.getString("id")).thenReturn(null) // Simulate missing "id" field
+    `when`(mockDocumentSnapshot.getString("text")).thenReturn(testMessage.text)
+    `when`(mockDocumentSnapshot.getString("senderId")).thenReturn(testMessage.senderId)
+    `when`(mockDocumentSnapshot.getString("receiverId")).thenReturn(testMessage.receiverId)
+    `when`(mockDocumentSnapshot.getLong("timestamp")).thenReturn(testMessage.timestamp)
+
+    val result = documentToMessage(mockDocumentSnapshot)
+
+    assertTrue(result.isFailure)
+    assertTrue(result.exceptionOrNull() is NullPointerException)
+  }
+
+  @Test
   fun `documentToMessage converts DocumentSnapshot to DataMessage`() {
     `when`(mockDocumentSnapshot.getString("id")).thenReturn(testMessage.id)
     `when`(mockDocumentSnapshot.getString("text")).thenReturn(testMessage.text)
@@ -134,5 +201,127 @@ class DataMessageFirestoreSourceTest {
 
     assertTrue(result.isSuccess)
     assertEquals(testMessage, result.getOrNull())
+  }
+
+  @Test
+  fun `delete message fails for messages older than 15 minutes`() {
+    val context = mock<Context>()
+    val oldMessage = testMessage.copy(timestamp = System.currentTimeMillis() - (16 * 60 * 1000))
+
+    `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
+    `when`(mockDocumentSnapshot.exists()).thenReturn(true)
+    `when`(mockDocumentSnapshot.getString("id")).thenReturn(oldMessage.id)
+    `when`(mockDocumentSnapshot.getLong("timestamp")).thenReturn(oldMessage.timestamp)
+
+    // Act
+    messageRepository.deleteMessage(
+        oldMessage.id,
+        { result ->
+          assertTrue(result.isFailure)
+          assertEquals(
+              "Message can only be deleted within 15 minutes of being sent",
+              result.exceptionOrNull()?.message)
+        },
+        context)
+
+    // Verify Firestore delete was not called
+    verify(mockDocumentReference, never()).delete()
+  }
+
+  @Test
+  fun `delete message fails when message does not exist`() {
+    val context = mock<Context>()
+    `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
+    `when`(mockDocumentSnapshot.exists()).thenReturn(false) // Simulate nonexistent document
+
+    messageRepository.deleteMessage(
+        testMessage.id,
+        { result ->
+          assertTrue(result.isFailure)
+          assertEquals("Message not found", result.exceptionOrNull()?.message)
+        },
+        context)
+
+    // Verify delete was not called
+    verify(mockDocumentReference, never()).delete()
+  }
+
+  @Test
+  fun `update message fails for messages older than 15 minutes`() {
+    val context = mock<Context>()
+    val oldMessage = testMessage.copy(timestamp = System.currentTimeMillis() - (16 * 60 * 1000))
+
+    `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
+    `when`(mockDocumentSnapshot.exists()).thenReturn(true)
+    `when`(mockDocumentSnapshot.getString("id")).thenReturn(oldMessage.id)
+    `when`(mockDocumentSnapshot.getLong("timestamp")).thenReturn(oldMessage.timestamp)
+
+    messageRepository.updateMessage(
+        oldMessage,
+        { result ->
+          assertTrue(result.isFailure)
+          assertEquals(
+              "Message can only be updated within 15 minutes of being sent",
+              result.exceptionOrNull()?.message)
+        },
+        context)
+
+    // Verify Firestore update was not called
+    verify(mockDocumentReference, never()).update(anyMap())
+  }
+
+  @Test
+  fun `update message fails when message does not exist`() {
+    val context = mock<Context>()
+    `when`(mockDocumentReference.get()).thenReturn(Tasks.forResult(mockDocumentSnapshot))
+    `when`(mockDocumentSnapshot.exists()).thenReturn(false) // Simulate nonexistent document
+
+    messageRepository.updateMessage(
+        testMessage,
+        { result ->
+          assertTrue(result.isFailure)
+          assertEquals("Message not found", result.exceptionOrNull()?.message)
+        },
+        context)
+
+    // Verify update was not called
+    verify(mockDocumentReference, never()).update(anyMap())
+  }
+
+  @Test
+  fun `delete all messages between two users deletes documents`() {
+    // Arrange
+    `when`(mockFirestore.collection(COLLECTION_PATH)).thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.whereIn("senderId", listOf("user1", "user2")))
+        .thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.whereIn("receiverId", listOf("user1", "user2")))
+        .thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.whereNotEqualTo("senderId", "receiverId"))
+        .thenReturn(mockCollectionReference)
+
+    // Mock retrieval of a query snapshot with one document to delete
+    `when`(mockCollectionReference.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
+    `when`(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot))
+    `when`(mockDocumentSnapshot.reference).thenReturn(mockDocumentReference)
+
+    // Mock the Firestore batch process
+    val mockBatch = mock<WriteBatch>()
+    `when`(mockFirestore.batch()).thenReturn(mockBatch)
+    `when`(mockBatch.delete(mockDocumentReference)).thenReturn(mockBatch)
+    `when`(mockBatch.commit()).thenReturn(Tasks.forResult(null)) // Simulate successful commit
+
+    // Act
+    messageRepository.deleteAllMessages("user1", "user2") { result ->
+      // Assert that the delete operation was successful
+      assertTrue(result.isSuccess)
+    }
+
+    // Ensure that any pending tasks are executed
+    shadowOf(Looper.getMainLooper()).idle()
+
+    // Verify interactions
+    verify(mockCollectionReference).get() // Verify retrieval call
+    verify(mockBatch).delete(mockDocumentReference) // Verify deletion call
+    verify(mockBatch).commit() // Verify batch commit call
   }
 }


### PR DESCRIPTION
Includes new UI parts for editing and deleting, a pop-up upon a long press of a message with two buttons delete and edit, which can be pressed to perform their functions. Delete simply deletes the text and update is more complex, redirects to the text field which is filled with old message, it can be modified, and send button changed to update button, when pressing it updates the text and timestamp. 
Also includes the firebase implementation of said functions, which also include the caveat that they can only be edited or deleted if less than 15 minutes have passed. Upon failing to meet this condition, nothing will happen and a toast will be shown.
It also added a top app bar to the chat and other small details.
Also includes tests for all of this, 3 new tests in the androidTest, including one to check that the pop up appears, one to check that deleting works, and one for editing (the most complex one). There are additionally numerous tests for multiple cases in the unitTests, including adding some for some cases for previous functions that were missing some tests.