### PR TITLE
Feature implements the api service for chatgpt

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,6 +86,7 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
             merges += "META-INF/LICENSE.md"
             merges += "META-INF/LICENSE-notice.md"
+            excludes += "META-INF/DEPENDENCIES"
         }
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,3 @@
-
 import java.io.FileInputStream
 import java.util.Properties
 
@@ -122,11 +121,20 @@ sonar {
         property("sonar.organization", "bookswapepfl")
         property("sonar.host.url", "https://sonarcloud.io")
         // Comma-separated paths to the various directories containing the *.xml JUnit report files. Each path may be absolute or relative to the project base directory.
-        property("sonar.junit.reportPaths", "${project.layout.buildDirectory.get()}/test-results/testDebugunitTest/")
+        property(
+            "sonar.junit.reportPaths",
+            "${project.layout.buildDirectory.get()}/test-results/testDebugunitTest/"
+        )
         // Paths to xml files with Android Lint issues. If the main flavor is changed, this file will have to be changed too.
-        property("sonar.androidLint.reportPaths", "${project.layout.buildDirectory.get()}/reports/lint-results-debug.xml")
+        property(
+            "sonar.androidLint.reportPaths",
+            "${project.layout.buildDirectory.get()}/reports/lint-results-debug.xml"
+        )
         // Paths to JaCoCo XML coverage report files.
-        property("sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory.get()}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
+        property(
+            "sonar.coverage.jacoco.xmlReportPaths",
+            "${project.layout.buildDirectory.get()}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
+        )
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,7 +40,7 @@ android {
         }
         manifestPlaceholders["MAPS_API_KEY"] = mapsApiKey
         manifestPlaceholders["OPENAI_API_KEY"] = openAiApiKey
-        buildConfigField("String", "OPENAI_API_KEY", localProperties.getProperty("OPENAI_API_KEY"))
+        buildConfigField("String", "OPENAI_API_KEY", openAiApiKey)
     }
 
     buildTypes {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -209,8 +209,6 @@ dependencies {
     globalTestImplementation(libs.kaspresso)
     globalTestImplementation(libs.kaspresso.compose)
 
-
-
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.inline)
     testImplementation(libs.mockito.kotlin)
@@ -224,6 +222,8 @@ dependencies {
     implementation(libs.volley) //HTTP request
     implementation(libs.okhttp)
 
+    implementation("org.apache.httpcomponents:httpclient:4.5.14")
+    implementation("org.apache.httpcomponents:httpcore:4.4.13")
     implementation(libs.json) //JSON parser
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("androidx.vectordrawable:vectordrawable:1.1.0")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
     }
 
     val mapsApiKey: String = localProperties.getProperty("MAPS_API_KEY") ?: ""
-    val openAiApiKey: String = localProperties.getProperty("OPENAI_API_KEY") ?: ""
+
 
     defaultConfig {
         applicationId = "com.android.bookswap"
@@ -38,9 +38,10 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+        val openAiApiKey: String = localProperties.getProperty("OPENAI_API_KEY") ?: "\" placeHolder \" "
         manifestPlaceholders["MAPS_API_KEY"] = mapsApiKey
         manifestPlaceholders["OPENAI_API_KEY"] = openAiApiKey
-        buildConfigField("String", "OPENAI_API_KEY", openAiApiKey)
+        buildConfigField("String", "OPENAI_API_KEY",  openAiApiKey)
     }
 
     buildTypes {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,6 +15,9 @@ android {
     namespace = "com.android.bookswap"
     compileSdk = 34
 
+    buildFeatures {
+        buildConfig = true
+    }
     // Load the API key from local.properties
     val localProperties = Properties()
     val localPropertiesFile = rootProject.file("local.properties")
@@ -23,6 +26,7 @@ android {
     }
 
     val mapsApiKey: String = localProperties.getProperty("MAPS_API_KEY") ?: ""
+    val openAiApiKey: String = localProperties.getProperty("OPENAI_API_KEY") ?: ""
 
     defaultConfig {
         applicationId = "com.android.bookswap"
@@ -36,6 +40,8 @@ android {
             useSupportLibrary = true
         }
         manifestPlaceholders["MAPS_API_KEY"] = mapsApiKey
+        manifestPlaceholders["OPENAI_API_KEY"] = openAiApiKey
+        buildConfigField("String", "OPENAI_API_KEY", localProperties.getProperty("OPENAI_API_KEY"))
     }
 
     buildTypes {
@@ -207,6 +213,8 @@ dependencies {
     testImplementation(libs.robolectric)
 
     implementation(libs.volley) //HTTP request
+    implementation(libs.okhttp)
+
     implementation(libs.json) //JSON parser
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("androidx.vectordrawable:vectordrawable:1.1.0")

--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -83,7 +83,6 @@ class MainActivity : ComponentActivity() {
     val navController = rememberNavController()
     val navigationActions = NavigationActions(navController)
     val bookFilter = BookFilter()
-
     val placeHolder =
         listOf(
             MessageBox(

--- a/app/src/main/java/com/android/bookswap/data/source/api/ChatGPTApiService.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/api/ChatGPTApiService.kt
@@ -23,13 +23,13 @@ data class ChatGPTRequest(val model: String, val messages: List<ChatGPTMessage>)
  * @param context the context from where the request is made
  * @param mode true for production mode, false for testing mode
  */
-class ChatGPTApiService(context: Context, mode: Boolean = true) {
+class ChatGPTApiService(context: Context, mode: Boolean = true) : ApiService {
   private val requestQueue: RequestQueue = Volley.newRequestQueue(context)
   private val apiKey = if (mode) BuildConfig.OPENAI_API_KEY else ""
   private val apiUrl = "https://api.openai.com/v1/chat/completions"
 
   // Send a chat request to the OpenAI API
-  fun sendChatRequest(
+  override fun sendChatRequest(
       userMessages: List<String>,
       onSuccess: (String) -> Unit,
       onError: (String) -> Unit

--- a/app/src/main/java/com/android/bookswap/data/source/api/ChatGPTApiService.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/api/ChatGPTApiService.kt
@@ -1,6 +1,7 @@
 package com.android.bookswap.data.source.api
 
 import android.content.Context
+import android.util.Log
 import com.android.bookswap.BuildConfig
 import com.android.volley.Request
 import com.android.volley.RequestQueue
@@ -69,10 +70,12 @@ class ChatGPTApiService(context: Context, mode: Boolean = true) : ApiService {
 
                     onSuccess(messageContent)
                   } catch (e: Exception) {
+                    Log.e("ChatGPTApiService", "Error: ${e.localizedMessage}")
                     onError("Parsing error: ${e.localizedMessage}")
                   }
                 },
                 Response.ErrorListener { error ->
+                  Log.e("ChatGPTApiService", "Error: ${error.localizedMessage}")
                   onError("Request error: ${error.localizedMessage}")
                 }) {
           // Add the API key and content type to the request headers

--- a/app/src/main/java/com/android/bookswap/data/source/api/ChatGPTApiService.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/api/ChatGPTApiService.kt
@@ -1,0 +1,90 @@
+package com.android.bookswap.data.source.api
+
+import android.content.Context
+import com.android.bookswap.BuildConfig
+import com.android.volley.Request
+import com.android.volley.RequestQueue
+import com.android.volley.Response
+import com.android.volley.toolbox.JsonObjectRequest
+import com.android.volley.toolbox.Volley
+import org.json.JSONArray
+import org.json.JSONObject
+
+data class ChatGPTMessage(
+    val role: String, // "user" or "assistant"
+    val content: String
+)
+
+data class ChatGPTRequest(val model: String, val messages: List<ChatGPTMessage>)
+
+data class ChatGPTChoice(val message: ChatGPTMessage)
+
+data class ChatGPTResponse(val choices: List<ChatGPTChoice>)
+
+/**
+ * Service to interact with the OpenAI ChatGPT API.
+ *
+ * @param context the context from where the request is made
+ * @param mode true for production mode, false for testing mode
+ */
+class ChatGPTApiService(context: Context, mode: Boolean = true) {
+  private val requestQueue: RequestQueue = Volley.newRequestQueue(context)
+  private val apiKey = if (mode) BuildConfig.OPENAI_API_KEY else ""
+  private val apiUrl = "https://api.openai.com/v1/chat/completions"
+
+  // Send a chat request to the OpenAI API
+  fun sendChatRequest(
+      userMessages: List<String>,
+      onSuccess: (String) -> Unit,
+      onError: (String) -> Unit
+  ) {
+    val messageList = userMessages.map { m -> ChatGPTMessage(role = "user", content = m) }
+    val chatGPTRequest = ChatGPTRequest(model = "gpt-4o-mini", messages = messageList)
+
+    // Create the JSON body for the request
+    val jsonBody =
+        JSONObject().apply {
+          put("model", chatGPTRequest.model)
+          put(
+              "messages",
+              JSONArray().apply {
+                chatGPTRequest.messages.forEach { message ->
+                  put(
+                      JSONObject().apply {
+                        put("role", message.role)
+                        put("content", message.content)
+                      })
+                }
+              })
+        }
+
+    // Create the request and listen for the response
+    val jsonObjectRequest =
+        object :
+            JsonObjectRequest(
+                Request.Method.POST,
+                apiUrl,
+                jsonBody,
+                Response.Listener { response ->
+                  try {
+                    val choicesArray = response.getJSONArray("choices")
+                    val messageContent =
+                        choicesArray.getJSONObject(0).getJSONObject("message").getString("content")
+
+                    onSuccess(messageContent)
+                  } catch (e: Exception) {
+                    onError("Parsing error: ${e.localizedMessage}")
+                  }
+                },
+                Response.ErrorListener { error ->
+                  onError("Request error: ${error.localizedMessage}")
+                }) {
+          // Add the API key and content type to the request headers
+          override fun getHeaders(): MutableMap<String, String> {
+            return hashMapOf(
+                "Authorization" to "Bearer $apiKey", "Content-Type" to "application/json")
+          }
+        }
+    requestQueue.add(jsonObjectRequest)
+  }
+}

--- a/app/src/main/java/com/android/bookswap/data/source/api/ChatGPTApiService.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/api/ChatGPTApiService.kt
@@ -17,10 +17,6 @@ data class ChatGPTMessage(
 
 data class ChatGPTRequest(val model: String, val messages: List<ChatGPTMessage>)
 
-data class ChatGPTChoice(val message: ChatGPTMessage)
-
-data class ChatGPTResponse(val choices: List<ChatGPTChoice>)
-
 /**
  * Service to interact with the OpenAI ChatGPT API.
  *

--- a/app/src/test/java/com/android/bookswap/data/source/api/ChatGptApiCallTest.kt
+++ b/app/src/test/java/com/android/bookswap/data/source/api/ChatGptApiCallTest.kt
@@ -1,3 +1,51 @@
 package com.android.bookswap.data.source.api
 
-class ChatGptApiCallTest {}
+import android.content.Context
+import com.android.volley.Request
+import com.android.volley.RequestQueue
+import com.android.volley.toolbox.Volley
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import junit.framework.TestCase.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class ChatGptApiCallTest {
+  private lateinit var mockContext: Context
+  private lateinit var mockRequestQueue: RequestQueue
+  private lateinit var chatGPTApiService: ChatGPTApiService
+  private lateinit var request: Request<*>
+
+  @Before
+  fun setUp() {
+
+    mockContext = mockk()
+
+    mockRequestQueue = mockk()
+    request = mockk()
+
+    mockkStatic(Volley::class)
+    every { Volley.newRequestQueue(any()) } returns mockRequestQueue
+
+    chatGPTApiService = ChatGPTApiService(mockContext, mode = false)
+  }
+
+  @Test
+  fun `test sendChatRequest adds request to requestQueue`() {
+
+    val userMessages = listOf("Hello")
+    val onSuccess: (String) -> Unit = mockk(relaxed = true)
+    val onError: (String) -> Unit = mockk(relaxed = true)
+    var check = 0
+    every { mockRequestQueue.add(any<Request<*>>()) } answers
+        {
+          check++
+          return@answers request
+        }
+
+    chatGPTApiService.sendChatRequest(userMessages, onSuccess, onError)
+
+    assertEquals(1, check)
+  }
+}

--- a/app/src/test/java/com/android/bookswap/data/source/api/ChatGptApiCallTest.kt
+++ b/app/src/test/java/com/android/bookswap/data/source/api/ChatGptApiCallTest.kt
@@ -1,0 +1,3 @@
+package com.android.bookswap.data.source.api
+
+class ChatGptApiCallTest {}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ mockitoInline = "5.2.0"
 mockitoKotlin = "5.4.0"
 mockk = "1.13.13"
 mockk-android = "1.13.13"
+okhttp = "4.9.1"
 robolectric = "4.11.1"
 sonar = "4.4.1.3373"
 firebaseFirestoreKtx = "25.1.0"
@@ -92,6 +93,7 @@ compose-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifes
 kaspresso = { group = "com.kaspersky.android-components", name = "kaspresso", version.ref = "kaspresso" }
 kaspresso-compose = { group = "com.kaspersky.android-components", name = "kaspresso-compose-support", version.ref = "kaspresso" }
 
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 play-services-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "playServicesAuth" }
 play-services-maps = { module = "com.google.android.gms:play-services-maps", version.ref = "playServicesMaps" }
 


### PR DESCRIPTION
Add ChatGPT API Service to Enable OpenAI API Calls for Book Profile Creation

### Description
This PR introduces a `ChatGPTApiService` class that facilitates basic calls to the OpenAI API, specifically designed to assist with the upcoming tasks related to book profile creation. This service provides a foundational layer to connect with OpenAI’s ChatGPT API, which will be further extended in a separate task to include prompt generation and response parsing.

The current implementation has been manually tested, and API calls are confirmed to work as expected. However, I am encountering challenges in implementing automated tests for this feature and would appreciate feedback or suggestions on how to approach these tests effectively.

- **Added `ChatGPTApiService`**: This service manages requests to OpenAI’s ChatGPT API using Volley.
- **Data Classes**:
  - `ChatGPTMessage`: Represents individual messages with roles (e.g., "user" or "assistant") and content.
  - `ChatGPTRequest`: Structures the model and message list for the API request.
  - `ChatGPTChoice` and `ChatGPTResponse`: Parse response data from the OpenAI API.
- **`sendChatRequest` Function**: Sends user messages as a list, creating a structured API request. Upon receiving the response, it parses the message content, providing success and error handlers.

### Implementation Details
- **Request Queue**: Uses Android’s Volley library to handle network requests.
- **API Key Handling**: Retrieves the API key from `BuildConfig`, depending on the `mode` parameter (production or testing).
- **Error Handling**: Captures and returns both parsing and request errors to provide detailed feedback.
- **Response Parsing**: Extracts the content of the first message choice, ensuring robust parsing even if the response structure varies.

You can review my code already, but I would prefer if you could provide some suggestions for testing this feature first.