### PR TITLE
Feature implement the prompt and the parser for the openAI API

### DIFF
--- a/app/src/main/java/com/android/bookswap/data/source/api/ApiService.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/api/ApiService.kt
@@ -3,6 +3,13 @@ package com.android.bookswap.data.source.api
   This interface is used to send a chat request to the API
 */
 interface ApiService {
+  /**
+   * Send a chat request to the API
+   *
+   * @param userMessages List of user messages to send
+   * @param onSuccess Callback for a successful response
+   * @param onError Callback for handling errors
+   */
   fun sendChatRequest(
       userMessages: List<String>,
       onSuccess: (String) -> Unit,

--- a/app/src/main/java/com/android/bookswap/data/source/api/ApiService.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/api/ApiService.kt
@@ -1,0 +1,11 @@
+package com.android.bookswap.data.source.api
+/*
+   This interface is used to send a chat request to the API
+ */
+interface ApiService {
+    fun sendChatRequest(
+        userMessages: List<String>,
+        onSuccess: (String) -> Unit,
+        onError: (String) -> Unit
+    )
+}

--- a/app/src/main/java/com/android/bookswap/data/source/api/ApiService.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/api/ApiService.kt
@@ -1,11 +1,11 @@
 package com.android.bookswap.data.source.api
 /*
-   This interface is used to send a chat request to the API
- */
+  This interface is used to send a chat request to the API
+*/
 interface ApiService {
-    fun sendChatRequest(
-        userMessages: List<String>,
-        onSuccess: (String) -> Unit,
-        onError: (String) -> Unit
-    )
+  fun sendChatRequest(
+      userMessages: List<String>,
+      onSuccess: (String) -> Unit,
+      onError: (String) -> Unit
+  )
 }

--- a/app/src/main/java/com/android/bookswap/data/source/network/ImageToDataSource.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/network/ImageToDataSource.kt
@@ -1,39 +1,12 @@
 package com.android.bookswap.data.source.network
 
+import com.android.bookswap.R
 import com.android.bookswap.data.source.api.ApiService
 import org.json.JSONObject
 
 class ImageToDataSource(private val apiService: ApiService) {
   // The specific prompt for the image analysis
-  private val PROMPT =
-      """
-        You are an AI designed to analyze images of book covers. Given an image of a book's back cover in URL format, extract the following information in a structured format (JSON) with the specified fields: title, author, description, language, and ISBN. Please ensure that:
-
-        1. If any of the fields are not present or cannot be confidently identified, indicate them with "N/A".
-        2. If the image does not appear to be a book cover, return an error message stating "The image does not appear to be a valid book cover."
-        3. If the title, author, description, or other fields are in a different language, keep the original text for reference, and provide the appropriate language code using the following classification:
-           - FRENCH ("FR")
-           - GERMAN ("DE")
-           - ENGLISH ("EN")
-           - SPANISH ("ES")
-           - ITALIAN ("IT")
-           - ROMANSH ("RM")
-           - OTHER ("OTHER") // All languages that are not yet implemented
-        4. The description should be the one written on the books.
-        5. The ISBN is often over a barcode, in the bottom left or right corner.
-
-        Example output format:
-        {
-          "title": "Example Title",
-          "author": "Example Author",
-          "description": "An example description of the book.",
-          "language": "EN",
-          "isbn": "1234567890"
-        }
-        
-        The image URL:
-    """
-          .trimIndent()
+  private val PROMPT = R.string.prompt
 
   /**
    * Function to send an image URL to ChatGPT API and parse the response for book information.

--- a/app/src/main/java/com/android/bookswap/data/source/network/ImageToDataSource.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/network/ImageToDataSource.kt
@@ -4,6 +4,11 @@ import com.android.bookswap.R
 import com.android.bookswap.data.source.api.ApiService
 import org.json.JSONObject
 
+/**
+ * Class to send an image URL to ChatGPT API and parse the response for book information.
+ *
+ * @param apiService The API service to send the request
+ */
 class ImageToDataSource(private val apiService: ApiService) {
   // The specific prompt for the image analysis
   private val PROMPT = R.string.prompt

--- a/app/src/main/java/com/android/bookswap/data/source/network/ImageToDataSource.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/network/ImageToDataSource.kt
@@ -1,13 +1,12 @@
 package com.android.bookswap.data.source.network
 
-import android.content.Context
-import android.widget.Toast
 import com.android.bookswap.data.source.api.ApiService
 import org.json.JSONObject
 
 class ImageToDataSource(private val apiService: ApiService) {
-    // The specific prompt for the image analysis
-    private val PROMPT = """
+  // The specific prompt for the image analysis
+  private val PROMPT =
+      """
         You are an AI designed to analyze images of book covers. Given an image of a book's back cover in URL format, extract the following information in a structured format (JSON) with the specified fields: title, author, description, language, and ISBN. Please ensure that:
 
         1. If any of the fields are not present or cannot be confidently identified, indicate them with "N/A".
@@ -33,63 +32,60 @@ class ImageToDataSource(private val apiService: ApiService) {
         }
         
         The image URL:
-    """.trimIndent()
+    """
+          .trimIndent()
 
-    /**
-     * Function to send an image URL to ChatGPT API and parse the response for book information.
-     *
-     * @param imageUrl URL of the image to analyze
-     * @param onSuccess Callback for a successful response, returns structured book data
-     * @param onError Callback for handling errors
-     */
-    fun analyzeImage(
-        imageUrl: String,
-        onSuccess: (Map<String, String>) -> Unit,
-        onError: (String) -> Unit
-    ) {
-        // Complete the prompt by appending the image URL
-        val fullPrompt = "$PROMPT $imageUrl"
+  /**
+   * Function to send an image URL to ChatGPT API and parse the response for book information.
+   *
+   * @param imageUrl URL of the image to analyze
+   * @param onSuccess Callback for a successful response, returns structured book data
+   * @param onError Callback for handling errors
+   */
+  fun analyzeImage(
+      imageUrl: String,
+      onSuccess: (Map<String, String>) -> Unit,
+      onError: (String) -> Unit
+  ) {
+    // Complete the prompt by appending the image URL
+    val fullPrompt = "$PROMPT $imageUrl"
 
-        // Send the request to ChatGPTApiService
-        apiService.sendChatRequest(
-            userMessages = listOf(fullPrompt),
-            onSuccess = { responseContent ->
-                try {
-                    // Parse the JSON response into a Map
-                    val parsedData = parseResponse(responseContent)
-                    onSuccess(parsedData)
-                } catch (e: Exception) {
-                    onError("Parsing error: ${e.localizedMessage}")
-                }
-            },
-            onError = { error ->
-                onError("API Request Error: $error")
-            }
-        )
-    }
+    // Send the request to ChatGPTApiService
+    apiService.sendChatRequest(
+        userMessages = listOf(fullPrompt),
+        onSuccess = { responseContent ->
+          try {
+            // Parse the JSON response into a Map
+            val parsedData = parseResponse(responseContent)
+            onSuccess(parsedData)
+          } catch (e: Exception) {
+            onError("Parsing error: ${e.localizedMessage}")
+          }
+        },
+        onError = { error -> onError("API Request Error: $error") })
+  }
 
-    /**
-     * Parses the ChatGPT response JSON string into a map of book information.
-     *
-     * @param response JSON string returned by the ChatGPT API
-     * @return A map with keys: "title", "author", "description", "language", and "isbn"
-     */
-    private fun parseResponse(response: String): Map<String, String> {
-        val jsonObject = JSONObject(response)
+  /**
+   * Parses the ChatGPT response JSON string into a map of book information.
+   *
+   * @param response JSON string returned by the ChatGPT API
+   * @return A map with keys: "title", "author", "description", "language", and "isbn"
+   */
+  private fun parseResponse(response: String): Map<String, String> {
+    val jsonObject = JSONObject(response)
 
-        // Extract the fields as specified
-        val title = jsonObject.optString("title", "N/A")
-        val author = jsonObject.optString("author", "N/A")
-        val description = jsonObject.optString("description", "N/A")
-        val language = jsonObject.optString("language", "N/A")
-        val isbn = jsonObject.optString("isbn", "N/A")
+    // Extract the fields as specified
+    val title = jsonObject.optString("title", "N/A")
+    val author = jsonObject.optString("author", "N/A")
+    val description = jsonObject.optString("description", "N/A")
+    val language = jsonObject.optString("language", "N/A")
+    val isbn = jsonObject.optString("isbn", "N/A")
 
-        return mapOf(
-            "title" to title,
-            "author" to author,
-            "description" to description,
-            "language" to language,
-            "isbn" to isbn
-        )
-    }
+    return mapOf(
+        "title" to title,
+        "author" to author,
+        "description" to description,
+        "language" to language,
+        "isbn" to isbn)
+  }
 }

--- a/app/src/main/java/com/android/bookswap/data/source/network/ImageToDataSource.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/network/ImageToDataSource.kt
@@ -1,0 +1,95 @@
+package com.android.bookswap.data.source.network
+
+import android.content.Context
+import android.widget.Toast
+import com.android.bookswap.data.source.api.ApiService
+import org.json.JSONObject
+
+class ImageToDataSource(private val apiService: ApiService) {
+    // The specific prompt for the image analysis
+    private val PROMPT = """
+        You are an AI designed to analyze images of book covers. Given an image of a book's back cover in URL format, extract the following information in a structured format (JSON) with the specified fields: title, author, description, language, and ISBN. Please ensure that:
+
+        1. If any of the fields are not present or cannot be confidently identified, indicate them with "N/A".
+        2. If the image does not appear to be a book cover, return an error message stating "The image does not appear to be a valid book cover."
+        3. If the title, author, description, or other fields are in a different language, keep the original text for reference, and provide the appropriate language code using the following classification:
+           - FRENCH ("FR")
+           - GERMAN ("DE")
+           - ENGLISH ("EN")
+           - SPANISH ("ES")
+           - ITALIAN ("IT")
+           - ROMANSH ("RM")
+           - OTHER ("OTHER") // All languages that are not yet implemented
+        4. The description should be the one written on the books.
+        5. The ISBN is often over a barcode, in the bottom left or right corner.
+
+        Example output format:
+        {
+          "title": "Example Title",
+          "author": "Example Author",
+          "description": "An example description of the book.",
+          "language": "EN",
+          "isbn": "1234567890"
+        }
+        
+        The image URL:
+    """.trimIndent()
+
+    /**
+     * Function to send an image URL to ChatGPT API and parse the response for book information.
+     *
+     * @param imageUrl URL of the image to analyze
+     * @param onSuccess Callback for a successful response, returns structured book data
+     * @param onError Callback for handling errors
+     */
+    fun analyzeImage(
+        imageUrl: String,
+        onSuccess: (Map<String, String>) -> Unit,
+        onError: (String) -> Unit
+    ) {
+        // Complete the prompt by appending the image URL
+        val fullPrompt = "$PROMPT $imageUrl"
+
+        // Send the request to ChatGPTApiService
+        apiService.sendChatRequest(
+            userMessages = listOf(fullPrompt),
+            onSuccess = { responseContent ->
+                try {
+                    // Parse the JSON response into a Map
+                    val parsedData = parseResponse(responseContent)
+                    onSuccess(parsedData)
+                } catch (e: Exception) {
+                    onError("Parsing error: ${e.localizedMessage}")
+                }
+            },
+            onError = { error ->
+                onError("API Request Error: $error")
+            }
+        )
+    }
+
+    /**
+     * Parses the ChatGPT response JSON string into a map of book information.
+     *
+     * @param response JSON string returned by the ChatGPT API
+     * @return A map with keys: "title", "author", "description", "language", and "isbn"
+     */
+    private fun parseResponse(response: String): Map<String, String> {
+        val jsonObject = JSONObject(response)
+
+        // Extract the fields as specified
+        val title = jsonObject.optString("title", "N/A")
+        val author = jsonObject.optString("author", "N/A")
+        val description = jsonObject.optString("description", "N/A")
+        val language = jsonObject.optString("language", "N/A")
+        val isbn = jsonObject.optString("isbn", "N/A")
+
+        return mapOf(
+            "title" to title,
+            "author" to author,
+            "description" to description,
+            "language" to language,
+            "isbn" to isbn
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,7 @@
     <string name="app_name">BookSwapApp</string>
     <string name="title_activity_main">MainActivity</string>
     <string name="default_web_client_id">53350524991-rim3tpfdgv2ghibl586ku7fvq6ngcddn.apps.googleusercontent.com</string>
+    <string name="prompt">You are an AI designed to analyze images of book covers. Given an image of a book\'s back cover in URL format, extract the following information in a structured format (JSON) with the specified fields: title, author, description, language, and ISBN. Please ensure that: 1. If any of the fields are not present or cannot be confidently identified, indicate them with \"N/A\". 2. If the image does not appear to be a book cover, return an error message stating \"The image does not appear to be a valid book cover.\" 3. If the title, author, description, or other fields are in a different language, keep the original text for reference, and provide the appropriate language code using the following classification: - FRENCH (\"FR\") - GERMAN (\"DE\") - ENGLISH (\"EN\") - SPANISH (\"ES\") - ITALIAN (\"IT\") - ROMANSH (\"RM\") - OTHER (\"OTHER\") 4. The description should be the one written on the book\'s. 5. The ISBN is often over a barcode, in the bottom left or right corner. Example output format: { \"title\": \"Example Title\", \"author\": \"Example Author\", \"description\": \"An example description of the book.\", \"language\": \"EN\", \"isbn\": \"1234567890\" } The image URL:
+</string>
+
 </resources>

--- a/app/src/test/java/com/android/bookswap/data/source/network/ImageToDataSourceTest.kt
+++ b/app/src/test/java/com/android/bookswap/data/source/network/ImageToDataSourceTest.kt
@@ -1,5 +1,6 @@
 package com.android.bookswap.data.source.network
 
+import com.android.bookswap.R
 import com.android.bookswap.data.source.api.ApiService
 import io.mockk.every
 import io.mockk.invoke
@@ -16,35 +17,7 @@ class ImageToDataSourceTest {
   private lateinit var apiService: ApiService
   private lateinit var imageToDataSource: ImageToDataSource
   private val imageUrl = "https://example.com/book-cover.jpg"
-  private val expectedPrompt =
-      """
-        You are an AI designed to analyze images of book covers. Given an image of a book's back cover in URL format, extract the following information in a structured format (JSON) with the specified fields: title, author, description, language, and ISBN. Please ensure that:
-
-        1. If any of the fields are not present or cannot be confidently identified, indicate them with "N/A".
-        2. If the image does not appear to be a book cover, return an error message stating "The image does not appear to be a valid book cover."
-        3. If the title, author, description, or other fields are in a different language, keep the original text for reference, and provide the appropriate language code using the following classification:
-           - FRENCH ("FR")
-           - GERMAN ("DE")
-           - ENGLISH ("EN")
-           - SPANISH ("ES")
-           - ITALIAN ("IT")
-           - ROMANSH ("RM")
-           - OTHER ("OTHER") // All languages that are not yet implemented
-        4. The description should be the one written on the books.
-        5. The ISBN is often over a barcode, in the bottom left or right corner.
-
-        Example output format:
-        {
-          "title": "Example Title",
-          "author": "Example Author",
-          "description": "An example description of the book.",
-          "language": "EN",
-          "isbn": "1234567890"
-        }
-
-        The image URL: $imageUrl
-    """
-          .trimIndent()
+  private val expectedPrompt = "${R.string.prompt} $imageUrl"
 
   @Before
   fun setup() {

--- a/app/src/test/java/com/android/bookswap/data/source/network/ImageToDataSourceTest.kt
+++ b/app/src/test/java/com/android/bookswap/data/source/network/ImageToDataSourceTest.kt
@@ -1,0 +1,172 @@
+package com.android.bookswap.data.source.network
+
+import com.android.bookswap.data.source.api.ApiService
+import io.mockk.every
+import io.mockk.invoke
+import io.mockk.mockk
+import io.mockk.verify
+import junit.framework.Assert.assertTrue
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.fail
+import net.bytebuddy.implementation.InvokeDynamic.lambda
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.startsWith
+
+class ImageToDataSourceTest {
+    private lateinit var apiService: ApiService
+    private lateinit var imageToDataSource: ImageToDataSource
+    private val imageUrl = "https://example.com/book-cover.jpg"
+    private val expectedPrompt = """
+        You are an AI designed to analyze images of book covers. Given an image of a book's back cover in URL format, extract the following information in a structured format (JSON) with the specified fields: title, author, description, language, and ISBN. Please ensure that:
+
+        1. If any of the fields are not present or cannot be confidently identified, indicate them with "N/A".
+        2. If the image does not appear to be a book cover, return an error message stating "The image does not appear to be a valid book cover."
+        3. If the title, author, description, or other fields are in a different language, keep the original text for reference, and provide the appropriate language code using the following classification:
+           - FRENCH ("FR")
+           - GERMAN ("DE")
+           - ENGLISH ("EN")
+           - SPANISH ("ES")
+           - ITALIAN ("IT")
+           - ROMANSH ("RM")
+           - OTHER ("OTHER") // All languages that are not yet implemented
+        4. The description should be the one written on the books.
+        5. The ISBN is often over a barcode, in the bottom left or right corner.
+
+        Example output format:
+        {
+          "title": "Example Title",
+          "author": "Example Author",
+          "description": "An example description of the book.",
+          "language": "EN",
+          "isbn": "1234567890"
+        }
+
+        The image URL: $imageUrl
+    """.trimIndent()
+
+
+
+    @Before
+    fun setup() {
+        apiService = mockk()
+        imageToDataSource = ImageToDataSource(apiService)
+    }
+    @Test
+    fun `analyzeImage should return parsed data on success`() {
+
+
+        // Mock API response
+        val mockResponse = """
+        {
+          "title": "Example Title",
+          "author": "Example Author",
+          "description": "An example description of the book.",
+          "language": "EN",
+          "isbn": "1234567890"
+        }
+    """.trimIndent()
+
+        // Mock successful response
+        every {
+            apiService.sendChatRequest(
+                listOf(expectedPrompt), // This should now match the exact prompt
+                captureLambda(),
+                any()
+            )
+        } answers {
+            lambda<(String) -> Unit>().invoke(mockResponse)
+        }
+
+        // Test analyzeImage
+        imageToDataSource.analyzeImage(imageUrl,
+            onSuccess = { result ->
+                assertEquals("Example Title", result["title"])
+                assertEquals("Example Author", result["author"])
+                assertEquals("An example description of the book.", result["description"])
+                assertEquals("EN", result["language"])
+                assertEquals("1234567890", result["isbn"])
+            },
+            onError = {
+                fail("Expected success callback but got error: $it")
+            }
+        )
+
+        // Verify that sendChatRequest was called with the exact prompt
+        verify { apiService.sendChatRequest(listOf(expectedPrompt), any(), any()) }
+    }
+
+    @Test
+    fun `analyzeImage should call onError when API fails`() {
+        val errorMessage = "Network error"
+        every {
+            apiService.sendChatRequest(any(), any(), captureLambda())
+        } answers {
+            lambda<(String) -> Unit>().invoke(errorMessage)
+        }
+
+        val imageUrl = "https://example.com/book-cover.jpg"
+
+        // Test analyzeImage
+        imageToDataSource.analyzeImage(imageUrl,
+            onSuccess = {
+                fail("Expected error callback but got success")
+            },
+            onError = { error ->
+                assertEquals("API Request Error: $errorMessage", error)
+            }
+        )
+
+        // Verify that sendChatRequest was called
+        verify { apiService.sendChatRequest(any(), any(), any()) }
+    }
+
+    @Test
+    fun `analyzeImage should handle partial data in response`() {
+        val mockPartialResponse = """
+        {
+          "title": "Partial Title",
+          "author": "Partial Author",
+          "language": "EN"
+        }
+    """.trimIndent()
+
+        every {
+            apiService.sendChatRequest(listOf(expectedPrompt), captureLambda(), any())
+        } answers {
+            lambda<(String) -> Unit>().invoke(mockPartialResponse)
+        }
+
+        imageToDataSource.analyzeImage(imageUrl,
+            onSuccess = { result ->
+                assertEquals("Partial Title", result["title"])
+                assertEquals("Partial Author", result["author"])
+                assertEquals("N/A", result["description"]) // Missing field should default to "N/A"
+                assertEquals("EN", result["language"])
+                assertEquals("N/A", result["isbn"]) // Missing field should default to "N/A"
+            },
+            onError = {
+                fail("Expected success callback but got error: $it")
+            }
+        )
+    }
+    @Test
+    fun `analyzeImage should handle non-JSON response from API`() {
+        val mockNonJsonResponse = "This is not JSON"
+
+        every {
+            apiService.sendChatRequest(listOf(expectedPrompt), captureLambda(), any())
+        } answers {
+            lambda<(String) -> Unit>().invoke(mockNonJsonResponse)
+        }
+
+        imageToDataSource.analyzeImage(imageUrl,
+            onSuccess = {
+                fail("Expected error callback but got success with data: $it")
+            },
+            onError = { error ->
+                assertTrue(error.contains("Parsing error"))
+            }
+        )
+    }
+}


### PR DESCRIPTION
This pull request introduces the `ImageToDataSource` class, a new data source responsible for analyzing book cover images by leveraging the `ApiService`. The class is designed to send image URLs to ChatGPT, extract relevant book details, and parse these details into a structured JSON format. This enables the app to obtain key information like title, author, description, language, and ISBN directly from a book cover image.

- **Prompt for Image Analysis**: A prompt is defined to guide the ChatGPT API in recognizing and extracting the required book information. Specific instructions are provided to ensure accurate data extraction, including handling missing or unidentifiable fields, classifying languages, and verifying image content.
- **Error Handling and Response Parsing**: The `analyzeImage` method sends the structured prompt to the API and handles the response by parsing JSON data into a map of book details, or returning error messages for unidentifiable content.

### Implementation Overview

1. **Analyze Image Method**: The `analyzeImage` function builds the full prompt by appending the image URL and sends it to the `ApiService`. The response is parsed into a structured map of book details for further processing.
2. **Structured Data Parsing**: The `parseResponse` helper method processes the JSON response to ensure fields (title, author, description, language, and ISBN) are correctly extracted or marked as "N/A" if absent.
3. **ApiService**. The abstract interface used for the OpenAI api in the PR #156 

### Example Output Format
```json
{
  "title": "Example Title",
  "author": "Example Author",
  "description": "An example description of the book.",
  "language": "EN",
  "isbn": "1234567890"
}
```
All suggestions for improving the code or refining the prompt are welcome and greatly appreciated.

