### PR TITLE
Sort the users by the distance from the user and moved logic from the mapScreen

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/map/MapScreenTest.kt
@@ -17,90 +17,77 @@ import com.android.bookswap.data.BookGenres
 import com.android.bookswap.data.BookLanguages
 import com.android.bookswap.data.DataBook
 import com.android.bookswap.data.DataUser
-import com.android.bookswap.data.source.network.BooksFirestoreRepository
-import com.android.bookswap.model.map.BookFilter
 import com.android.bookswap.model.map.BookManager
 import com.android.bookswap.model.map.DefaultGeolocation
 import com.android.bookswap.ui.navigation.NavigationActions
 import com.google.maps.android.compose.CameraPositionState
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkConstructor
-import io.mockk.runs
 import java.util.UUID
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
 class MapScreenTest {
   private val longListBook =
-    List(20) {
-      DataBook(
-        uuid = UUID(2000, 2000),
-        title = "Book 1",
-        author = "Author 1",
-        description = "Description of Book 1",
-        rating = 5,
-        photo = "url_to_photo_1",
-        language = BookLanguages.ENGLISH,
-        isbn = "123-456-789",
-        genres = listOf(BookGenres.FICTION, BookGenres.NONFICTION))
-    }
+      List(20) {
+        DataBook(
+            uuid = UUID(2000, 2000),
+            title = "Book 1",
+            author = "Author 1",
+            description = "Description of Book 1",
+            rating = 5,
+            photo = "url_to_photo_1",
+            language = BookLanguages.ENGLISH,
+            isbn = "123-456-789",
+            genres = listOf(BookGenres.FICTION, BookGenres.NONFICTION))
+      }
 
   private val books =
-    listOf(
-      DataBook(
-        uuid = UUID(1000, 1000),
-        title = "Book 1",
-        author = "Author 1",
-        description = "Description of Book 1",
-        rating = 5,
-        photo = "url_to_photo_1",
-        language = BookLanguages.ENGLISH,
-        isbn = "123-456-789",
-        genres = listOf(BookGenres.FICTION, BookGenres.HORROR)),
-      DataBook(
-        uuid = UUID(2000, 1000),
-        title = "Book 2",
-        author = "Author 2",
-        description = "Description of Book 2",
-        rating = 4,
-        photo = "url_to_photo_2",
-        language = BookLanguages.FRENCH,
-        isbn = "234-567-890",
-        genres = listOf(BookGenres.FICTION)))
+      listOf(
+          DataBook(
+              uuid = UUID(1000, 1000),
+              title = "Book 1",
+              author = "Author 1",
+              description = "Description of Book 1",
+              rating = 5,
+              photo = "url_to_photo_1",
+              language = BookLanguages.ENGLISH,
+              isbn = "123-456-789",
+              genres = listOf(BookGenres.FICTION, BookGenres.HORROR)),
+          DataBook(
+              uuid = UUID(2000, 1000),
+              title = "Book 2",
+              author = "Author 2",
+              description = "Description of Book 2",
+              rating = 4,
+              photo = "url_to_photo_2",
+              language = BookLanguages.FRENCH,
+              isbn = "234-567-890",
+              genres = listOf(BookGenres.FICTION)))
   private val user = listOf(DataUser(bookList = listOf(UUID(1000, 1000), UUID(2000, 1000))))
   private val userLongList = listOf(DataUser(bookList = listOf(UUID(2000, 2000))))
 
-  private val userBooksWithLocationList = listOf(UserBooksWithLocation(user[0].longitude, user[0].latitude, books))
-  private val userBooksWithLocationLongList = listOf(UserBooksWithLocation(userLongList[0].longitude, userLongList[0].latitude, longListBook))
+  private val userBooksWithLocationList =
+      listOf(UserBooksWithLocation(user[0].longitude, user[0].latitude, books))
+  private val userBooksWithLocationLongList =
+      listOf(
+          UserBooksWithLocation(userLongList[0].longitude, userLongList[0].latitude, longListBook))
 
-  private val userWithoutBooks = listOf(UserBooksWithLocation(0.0,0.0,emptyList()))
+  private val userWithoutBooks = listOf(UserBooksWithLocation(0.0, 0.0, emptyList()))
   @get:Rule val composeTestRule = createComposeRule()
 
-  private lateinit var mockBookRepository: BooksFirestoreRepository
   private lateinit var mockBookManager: BookManager
 
   @Before
   fun setup() {
-    mockBookRepository = mockk()
-    every { mockBookRepository.getBook(any(), any()) } just runs
-
     mockBookManager = mockk()
 
-    // Mock the behavior of filteredBooks and filteredUsers for the mocked instance
-    every {
-      mockBookManager.filteredBooks
-    } returns MutableStateFlow(books)
+    every { mockBookManager.filteredBooks } returns MutableStateFlow(books)
 
-    every {
-      mockBookManager.filteredUsers
-    } returns MutableStateFlow(userBooksWithLocationList)
-
+    every { mockBookManager.filteredUsers } returns MutableStateFlow(userBooksWithLocationList)
   }
 
   @Test
@@ -181,9 +168,9 @@ class MapScreenTest {
     composeTestRule.onNodeWithTag("mapDraggableMenu").assertIsDisplayed()
     composeTestRule.onNodeWithTag("mapDraggableMenuBookBox0").assertIsNotDisplayed()
     composeTestRule
-      .onNodeWithTag("mapDraggableMenuNoBook")
-      .assertIsDisplayed()
-      .assertTextContains("No books found")
+        .onNodeWithTag("mapDraggableMenuNoBook")
+        .assertIsDisplayed()
+        .assertTextContains("No books found")
   }
 
   @Test
@@ -226,12 +213,14 @@ class MapScreenTest {
     composeTestRule.onNodeWithTag("mapDraggableMenu").assertIsDisplayed()
   }
 
-
   @Test
   fun draggableMenuListIsScrollable() {
 
     every { mockBookManager.filteredBooks } answers { MutableStateFlow(longListBook) }
-    every { mockBookManager.filteredUsers } answers { MutableStateFlow(userBooksWithLocationLongList) }
+    every { mockBookManager.filteredUsers } answers
+        {
+          MutableStateFlow(userBooksWithLocationLongList)
+        }
     composeTestRule.setContent {
       val navController = rememberNavController()
       val navigationActions = NavigationActions(navController)

--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -81,7 +81,7 @@ class MainActivity : ComponentActivity() {
     val navController = rememberNavController()
     val navigationActions = NavigationActions(navController)
     val bookFilter = BookFilter()
-      val bookManager = BookManager(geolocation, bookRepository, user, bookFilter)
+    val bookManager = BookManager(geolocation, bookRepository, user, bookFilter)
 
     val placeHolder =
         listOf(
@@ -110,10 +110,7 @@ class MainActivity : ComponentActivity() {
       }
       navigation(startDestination = Screen.MAP, route = Route.MAP) {
         composable(Screen.MAP) {
-          MapScreen(
-              bookManager,
-              navigationActions = navigationActions,
-              geolocation = geolocation)
+          MapScreen(bookManager, navigationActions = navigationActions, geolocation = geolocation)
         }
         composable(Screen.FILTER) { FilterMapScreen(navigationActions, bookFilter) }
       }
@@ -132,21 +129,9 @@ class MainActivity : ComponentActivity() {
 // Need to be removed in the future.
 val user =
     listOf(
-        DataUser(
-            longitude = 0.04,
-            latitude = 0.04,
-            bookList =
-                listOf(
-                    UUID(12345678L, 87654321L))),
-        DataUser(
-            longitude = -0.08,
-            latitude = -0.08,
-            bookList =
-            listOf(
-                UUID(-848484, 848484))),
+        DataUser(longitude = 0.04, latitude = 0.04, bookList = listOf(UUID(12345678L, 87654321L))),
+        DataUser(longitude = -0.08, latitude = -0.08, bookList = listOf(UUID(-848484, 848484))),
         DataUser(
             longitude = 0.0,
             latitude = 0.0,
-            bookList =
-            listOf(
-                UUID(763879565731911, 5074118859109511))))
+            bookList = listOf(UUID(763879565731911, 5074118859109511))))

--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -20,6 +20,7 @@ import com.android.bookswap.data.source.network.MessageFirestoreSource
 import com.android.bookswap.model.chat.MessageBox
 import com.android.bookswap.model.chat.PermissionHandler
 import com.android.bookswap.model.map.BookFilter
+import com.android.bookswap.model.map.BookManager
 import com.android.bookswap.model.map.DefaultGeolocation
 import com.android.bookswap.model.map.Geolocation
 import com.android.bookswap.model.map.IGeolocation
@@ -80,6 +81,7 @@ class MainActivity : ComponentActivity() {
     val navController = rememberNavController()
     val navigationActions = NavigationActions(navController)
     val bookFilter = BookFilter()
+      val bookManager = BookManager(geolocation, bookRepository, user, bookFilter)
 
     val placeHolder =
         listOf(
@@ -109,10 +111,8 @@ class MainActivity : ComponentActivity() {
       navigation(startDestination = Screen.MAP, route = Route.MAP) {
         composable(Screen.MAP) {
           MapScreen(
-              user,
+              bookManager,
               navigationActions = navigationActions,
-              bookFilter = bookFilter,
-              bookRepository,
               geolocation = geolocation)
         }
         composable(Screen.FILTER) { FilterMapScreen(navigationActions, bookFilter) }

--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -133,8 +133,20 @@ class MainActivity : ComponentActivity() {
 val user =
     listOf(
         DataUser(
+            longitude = 0.04,
+            latitude = 0.04,
             bookList =
                 listOf(
-                    UUID(12345678L, 87654321L),
-                    UUID(-848484, 848484),
-                    UUID(763879565731911, 5074118859109511))))
+                    UUID(12345678L, 87654321L))),
+        DataUser(
+            longitude = -0.08,
+            latitude = -0.08,
+            bookList =
+            listOf(
+                UUID(-848484, 848484))),
+        DataUser(
+            longitude = 0.0,
+            latitude = 0.0,
+            bookList =
+            listOf(
+                UUID(763879565731911, 5074118859109511))))

--- a/app/src/main/java/com/android/bookswap/model/map/BookManager.kt
+++ b/app/src/main/java/com/android/bookswap/model/map/BookManager.kt
@@ -6,87 +6,87 @@ import com.android.bookswap.data.DataBook
 import com.android.bookswap.data.DataUser
 import com.android.bookswap.data.repository.BooksRepository
 import com.android.bookswap.ui.map.UserBooksWithLocation
-import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.*
 import java.util.Timer
 import kotlin.concurrent.schedule
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
 
 const val REFRESH_TIME_PERIOD = 5000L
 
 class BookManager(
     private val geolocation: IGeolocation,
     private val booksRepository: BooksRepository,
-    //TODO replace the listUser by a User repository to retrieve the users from the database
+    // TODO replace the listUser by a User repository to retrieve the users from the database
     listUser: List<DataUser>,
     private val bookFilter: BookFilter
-){
-    // Internal MutableStateFlows to manage dynamic data
-    private val _allBooks = MutableStateFlow<List<DataBook>>(emptyList())
-    private val _allUsers = MutableStateFlow(listUser)
-    private val _allUserDistance = MutableStateFlow<List<Pair<DataUser, Double>>>(emptyList())
-    private val _filteredBooks = MutableStateFlow<List<DataBook>>(emptyList())
-    private val _filteredUsers = MutableStateFlow<List<UserBooksWithLocation>>(emptyList())
+) {
+  // Internal MutableStateFlows to manage dynamic data
+  private val _allBooks = MutableStateFlow<List<DataBook>>(emptyList())
+  private val _allUsers = MutableStateFlow(listUser)
+  private val _allUserDistance = MutableStateFlow<List<Pair<DataUser, Double>>>(emptyList())
+  private val _filteredBooks = MutableStateFlow<List<DataBook>>(emptyList())
+  private val _filteredUsers = MutableStateFlow<List<UserBooksWithLocation>>(emptyList())
 
-    // Public StateFlows for UI to observe
-    val filteredBooks: StateFlow<List<DataBook>> = _filteredBooks.asStateFlow()
-    val filteredUsers: StateFlow<List<UserBooksWithLocation>> = _filteredUsers.asStateFlow()
+  // Public StateFlows for UI to observe
+  val filteredBooks: StateFlow<List<DataBook>> = _filteredBooks.asStateFlow()
+  val filteredUsers: StateFlow<List<UserBooksWithLocation>> = _filteredUsers.asStateFlow()
 
-    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private val timer = Timer()
+  private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+  private val timer = Timer()
 
-    init {
-        timer.schedule(0,REFRESH_TIME_PERIOD) { fetchBooksFromRepository()}
-        computeDistanceOfUsers()
-        combineFlowsAndFilterBooks()
-    }
+  init {
+    timer.schedule(0, REFRESH_TIME_PERIOD) { fetchBooksFromRepository() }
+    computeDistanceOfUsers()
+    combineFlowsAndFilterBooks()
+  }
 
-    // Fetch books from the repository and update `_allBooks`
-    private fun fetchBooksFromRepository() {
-        booksRepository.getBook(
-            OnSucess = { books ->
-                _allBooks.value = books
-            },
-            onFailure = { error ->
-                Log.e("BookManager", "Failed to fetch books: ${error.message}")
-            }
-        )
-    }
+  // Fetch books from the repository and update `_allBooks`
+  private fun fetchBooksFromRepository() {
+    booksRepository.getBook(
+        OnSucess = { books -> _allBooks.value = books },
+        onFailure = { error -> Log.e("BookManager", "Failed to fetch books: ${error.message}") })
+  }
 
-    // Combine books and filter flows and apply filtering logic
-    private fun combineFlowsAndFilterBooks() {
-        scope.launch {
-            combine(_allBooks,_allUserDistance, bookFilter.genresFilter, bookFilter.languagesFilter){
-                    books, userDistance, _, _ ->
-                val userBooksWithLocation = userDistance.map { user ->
-                    UserBooksWithLocation(
-                        longitude = user.first.longitude,
-                        latitude = user.first.latitude,
-                        books = bookFilter.filterBooks(books).filter { book -> book.uuid in user.first.bookList }
-                    )
+  // Combine books and filter flows and apply filtering logic
+  private fun combineFlowsAndFilterBooks() {
+    scope.launch {
+      combine(_allBooks, _allUserDistance, bookFilter.genresFilter, bookFilter.languagesFilter) {
+              books,
+              userDistance,
+              _,
+              _ ->
+            val userBooksWithLocation =
+                userDistance.map { user ->
+                  UserBooksWithLocation(
+                      longitude = user.first.longitude,
+                      latitude = user.first.latitude,
+                      books =
+                          bookFilter.filterBooks(books).filter { book ->
+                            book.uuid in user.first.bookList
+                          })
                 }
 
-                _filteredBooks.value = userBooksWithLocation.flatMap { it.books }
-                _filteredUsers.value = userBooksWithLocation
-            }.collect()
-        }
+            _filteredBooks.value = userBooksWithLocation.flatMap { it.books }
+            _filteredUsers.value = userBooksWithLocation
+          }
+          .collect()
     }
+  }
 
-    private fun computeDistanceOfUsers(){
-        scope.launch {
-            combine(_allUsers,geolocation.latitude, geolocation.longitude){
-                users,latitude, longitude ->
-                val userDistance = users.map { user ->
-                    val result = FloatArray(1)
-                    Location.distanceBetween(latitude,longitude, user.latitude, user.longitude, result)
-                    user to result[0].toDouble()
+  private fun computeDistanceOfUsers() {
+    scope.launch {
+      combine(_allUsers, geolocation.latitude, geolocation.longitude) { users, latitude, longitude
+            ->
+            val userDistance =
+                users.map { user ->
+                  val result = FloatArray(1)
+                  Location.distanceBetween(
+                      latitude, longitude, user.latitude, user.longitude, result)
+                  user to result[0].toDouble()
                 }
-                    userDistance.sortedBy { it.second }
-            }.collect{
-                    sortedUserDistance ->
-                _allUserDistance.value = sortedUserDistance
-            }
-
-        }
+            userDistance.sortedBy { it.second }
+          }
+          .collect { sortedUserDistance -> _allUserDistance.value = sortedUserDistance }
     }
-
+  }
 }

--- a/app/src/main/java/com/android/bookswap/model/map/BookManager.kt
+++ b/app/src/main/java/com/android/bookswap/model/map/BookManager.kt
@@ -1,0 +1,92 @@
+package com.android.bookswap.model.map
+
+import android.location.Location
+import android.util.Log
+import com.android.bookswap.data.DataBook
+import com.android.bookswap.data.DataUser
+import com.android.bookswap.data.repository.BooksRepository
+import com.android.bookswap.ui.map.UserBooksWithLocation
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+import java.util.Timer
+import kotlin.concurrent.schedule
+
+const val REFRESH_TIME_PERIOD = 5000L
+
+class BookManager(
+    private val geolocation: IGeolocation,
+    private val booksRepository: BooksRepository,
+    //TODO replace the listUser by a User repository to retrieve the users from the database
+    listUser: List<DataUser>,
+    private val bookFilter: BookFilter
+){
+    // Internal MutableStateFlows to manage dynamic data
+    private val _allBooks = MutableStateFlow<List<DataBook>>(emptyList())
+    private val _allUsers = MutableStateFlow(listUser)
+    private val _allUserDistance = MutableStateFlow<List<Pair<DataUser, Double>>>(emptyList())
+    private val _filteredBooks = MutableStateFlow<List<DataBook>>(emptyList())
+    private val _filteredUsers = MutableStateFlow<List<UserBooksWithLocation>>(emptyList())
+
+    // Public StateFlows for UI to observe
+    val filteredBooks: StateFlow<List<DataBook>> = _filteredBooks.asStateFlow()
+    val filteredUsers: StateFlow<List<UserBooksWithLocation>> = _filteredUsers.asStateFlow()
+
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val timer = Timer()
+
+    init {
+        timer.schedule(0,REFRESH_TIME_PERIOD) { fetchBooksFromRepository()}
+        computeDistanceOfUsers()
+        combineFlowsAndFilterBooks()
+    }
+
+    // Fetch books from the repository and update `_allBooks`
+    private fun fetchBooksFromRepository() {
+        booksRepository.getBook(
+            OnSucess = { books ->
+                _allBooks.value = books
+            },
+            onFailure = { error ->
+                Log.e("BookManager", "Failed to fetch books: ${error.message}")
+            }
+        )
+    }
+
+    // Combine books and filter flows and apply filtering logic
+    private fun combineFlowsAndFilterBooks() {
+        scope.launch {
+            combine(_allBooks,_allUserDistance, bookFilter.genresFilter, bookFilter.languagesFilter){
+                    books, userDistance, _, _ ->
+                val userBooksWithLocation = userDistance.map { user ->
+                    UserBooksWithLocation(
+                        longitude = user.first.longitude,
+                        latitude = user.first.latitude,
+                        books = bookFilter.filterBooks(books).filter { book -> book.uuid in user.first.bookList }
+                    )
+                }
+
+                _filteredBooks.value = userBooksWithLocation.flatMap { it.books }
+                _filteredUsers.value = userBooksWithLocation
+            }.collect()
+        }
+    }
+
+    private fun computeDistanceOfUsers(){
+        scope.launch {
+            combine(_allUsers,geolocation.latitude, geolocation.longitude){
+                users,latitude, longitude ->
+                val userDistance = users.map { user ->
+                    val result = FloatArray(1)
+                    Location.distanceBetween(latitude,longitude, user.latitude, user.longitude, result)
+                    user to result[0].toDouble()
+                }
+                    userDistance.sortedBy { it.second }
+            }.collect{
+                    sortedUserDistance ->
+                _allUserDistance.value = sortedUserDistance
+            }
+
+        }
+    }
+
+}

--- a/app/src/main/java/com/android/bookswap/model/map/DefaultGeolocation.kt
+++ b/app/src/main/java/com/android/bookswap/model/map/DefaultGeolocation.kt
@@ -2,6 +2,7 @@ package com.android.bookswap.model.map
 
 import android.util.Log
 import androidx.compose.runtime.mutableStateOf
+import kotlinx.coroutines.flow.MutableStateFlow
 
 /**
  * Mock implementation of [IGeolocation] for testing purposes.
@@ -16,8 +17,8 @@ import androidx.compose.runtime.mutableStateOf
  *   environment.
  */
 class DefaultGeolocation : IGeolocation {
-  override val latitude = mutableStateOf(0.0)
-  override val longitude = mutableStateOf(0.0)
+  override val latitude = MutableStateFlow(0.0)
+  override val longitude = MutableStateFlow(0.0)
   private val isRunning = mutableStateOf(false)
 
   override fun startLocationUpdates() {

--- a/app/src/main/java/com/android/bookswap/model/map/Geolocation.kt
+++ b/app/src/main/java/com/android/bookswap/model/map/Geolocation.kt
@@ -7,7 +7,6 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Looper
 import androidx.annotation.RequiresApi
-import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.core.app.ActivityCompat
 import com.google.android.gms.location.FusedLocationProviderClient

--- a/app/src/main/java/com/android/bookswap/model/map/Geolocation.kt
+++ b/app/src/main/java/com/android/bookswap/model/map/Geolocation.kt
@@ -15,6 +15,7 @@ import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationResult
 import com.google.android.gms.location.LocationServices
+import kotlinx.coroutines.flow.MutableStateFlow
 
 const val REQUEST_LOCATION_PERMISSION = 1
 const val BACKGROUND_LOCATION_PERMISSION_REQUEST_CODE = 2
@@ -34,8 +35,8 @@ class Geolocation(private val activity: Activity) : IGeolocation {
   private val fusedLocationClient: FusedLocationProviderClient =
       LocationServices.getFusedLocationProviderClient(activity)
   val isRunning = mutableStateOf(false)
-  override val latitude = mutableDoubleStateOf(Double.NaN)
-  override val longitude = mutableDoubleStateOf(Double.NaN)
+  override val latitude = MutableStateFlow(Double.NaN)
+  override val longitude = MutableStateFlow(Double.NaN)
 
   /** Location request settings */
   private val locationRequest: LocationRequest =
@@ -50,8 +51,8 @@ class Geolocation(private val activity: Activity) : IGeolocation {
         override fun onLocationResult(p0: LocationResult) {
           p0.lastLocation.let { location ->
             // Handle the updated location here
-            latitude.doubleValue = location.latitude
-            longitude.doubleValue = location.longitude
+            latitude.value = location.latitude
+            longitude.value = location.longitude
             // You can save this location or notify other parts of your app
           }
         }

--- a/app/src/main/java/com/android/bookswap/model/map/IGeolocation.kt
+++ b/app/src/main/java/com/android/bookswap/model/map/IGeolocation.kt
@@ -1,6 +1,6 @@
 package com.android.bookswap.model.map
 
-import androidx.compose.runtime.MutableState
+import kotlinx.coroutines.flow.MutableStateFlow
 
 /**
  * Interface for providing geolocation data, with basic location management functionality.
@@ -12,8 +12,8 @@ import androidx.compose.runtime.MutableState
  * the use of mock or fake data sources.
  */
 interface IGeolocation {
-  val latitude: MutableState<Double>
-  val longitude: MutableState<Double>
+  val latitude: MutableStateFlow<Double>
+  val longitude: MutableStateFlow<Double>
 
   fun startLocationUpdates()
 

--- a/app/src/main/java/com/android/bookswap/ui/map/Map.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/Map.kt
@@ -1,6 +1,5 @@
 package com.android.bookswap.ui.map
 
-import android.annotation.SuppressLint
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -109,10 +108,9 @@ fun MapScreen(
   var mutableStateSelectedUser by remember { mutableStateOf(selectedUser) }
   var markerScreenPosition by remember { mutableStateOf<Offset?>(null) }
 
-    val filteredBooks = bookManager.filteredBooks.collectAsState()
+  val filteredBooks = bookManager.filteredBooks.collectAsState()
 
-    val filteredUsers = bookManager.filteredUsers.collectAsState()
-
+  val filteredUsers = bookManager.filteredUsers.collectAsState()
 
   // compute the position of the marker on the screen given the camera position and the marker's
   // position on the map

--- a/app/src/main/java/com/android/bookswap/ui/map/Map.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/Map.kt
@@ -88,10 +88,8 @@ var SemanticsPropertyReceiver.cameraPosition by CameraPositionKey
  */
 @Composable
 fun MapScreen(
-    listUser: List<DataUser>,
+    bookManager: BookManager,
     navigationActions: NavigationActions,
-    bookFilter: BookFilter,
-    booksRepository: BooksRepository,
     selectedUser: Int = NO_USER_SELECTED,
     geolocation: IGeolocation = DefaultGeolocation()
 ) {
@@ -110,10 +108,6 @@ fun MapScreen(
 
   var mutableStateSelectedUser by remember { mutableStateOf(selectedUser) }
   var markerScreenPosition by remember { mutableStateOf<Offset?>(null) }
-
-    val bookManager = remember {
-        BookManager(geolocation, booksRepository, listUser, bookFilter)
-    }
 
     val filteredBooks = bookManager.filteredBooks.collectAsState()
 

--- a/app/src/test/java/com/android/bookswap/model/map/BookManagerTest.kt
+++ b/app/src/test/java/com/android/bookswap/model/map/BookManagerTest.kt
@@ -1,0 +1,104 @@
+package com.android.bookswap.model.map
+
+import com.android.bookswap.data.BookGenres
+import com.android.bookswap.data.BookLanguages
+import com.android.bookswap.data.DataBook
+import com.android.bookswap.data.DataUser
+import com.android.bookswap.data.source.network.BooksFirestoreRepository
+import io.mockk.every
+import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import java.util.UUID
+
+class BookManagerTest {
+  private val users = listOf(
+    DataUser(bookList = listOf(
+      UUID(1,2),
+      UUID(2,1)
+    ),
+      longitude = -5.0,
+      latitude = 0.0),
+    DataUser(bookList = listOf(
+      UUID(1,1)
+    ),
+      longitude = 1.0,
+      latitude = 2.0)
+    )
+
+  private val books = listOf(
+    DataBook(
+      uuid = UUID(1, 2),
+      title = "Book 1",
+      author = "Author 1",
+      description = "Description of Book 1",
+      rating = 5,
+      photo = "url_to_photo_1",
+      language = BookLanguages.ENGLISH,
+      isbn = "123-456-789",
+      genres = listOf(BookGenres.FICTION, BookGenres.HORROR)),
+    DataBook(
+      uuid = UUID(2, 1),
+      title = "Book 2",
+      author = "Author 2",
+      description = "Description of Book 2",
+      rating = 4,
+      photo = "url_to_photo_2",
+      language = BookLanguages.FRENCH,
+      isbn = "234-567-890",
+      genres = listOf(BookGenres.FICTION)),
+    DataBook(
+      uuid = UUID(1, 1),
+      title = "Book 3",
+      author = "Author 3",
+      description = "Description of Book 3",
+      rating = 4,
+      photo = "url_to_photo_3",
+      language = BookLanguages.GERMAN,
+      isbn = "234-567-890",
+      genres = listOf(BookGenres.NONFICTION, BookGenres.HORROR))
+  )
+
+  private val geolocation1 = listOf(3.5,8.0)
+  private val geolocation2 = listOf(-10.0,-10.0)
+
+  private lateinit var mockBookRepository: BooksFirestoreRepository
+  private lateinit var mockGeolocation1: IGeolocation
+  private lateinit var mockGeolocation2: IGeolocation
+  private lateinit var mockBookFilter: BookFilter
+  private lateinit var mockBookFilterEmpty: BookFilter
+  private lateinit var bookManager: BookManager
+
+  @Before
+  fun setup() {
+    mockBookRepository = mockk()
+    every { mockBookRepository.getBook(any(), any()) } answers {
+      firstArg<(List<DataBook>) -> Unit>().invoke(books)
+    }
+
+    mockGeolocation1 = mockk()
+    every { mockGeolocation1.longitude } answers {MutableStateFlow(geolocation1[0])}
+    every { mockGeolocation1.latitude } answers {MutableStateFlow(geolocation1[1])}
+
+    mockGeolocation2 = mockk()
+    every { mockGeolocation2.longitude } answers {MutableStateFlow(geolocation2[0])}
+    every { mockGeolocation2.latitude } answers {MutableStateFlow(geolocation2[1])}
+
+    mockBookFilter = mockk()
+    every { mockBookFilter.genresFilter } answers { MutableStateFlow(listOf(BookGenres.HORROR))}
+    every { mockBookFilter.languagesFilter } answers { MutableStateFlow(listOf(BookLanguages.FRENCH))}
+
+    mockBookFilterEmpty = mockk()
+    every { mockBookFilterEmpty.genresFilter } answers { MutableStateFlow(emptyList())}
+    every { mockBookFilterEmpty.languagesFilter } answers { MutableStateFlow(emptyList())}
+  }
+
+  @Test
+  fun listMarkerBookChangedWhenFilterApplied() = runTest {
+    bookManager = BookManager(mockGeolocation1, mockBookRepository, users, mockBookFilterEmpty)
+    assertEquals(books, bookManager.filteredBooks.value)
+  }
+}

--- a/app/src/test/java/com/android/bookswap/model/map/BookManagerTest.kt
+++ b/app/src/test/java/com/android/bookswap/model/map/BookManagerTest.kt
@@ -7,63 +7,51 @@ import com.android.bookswap.data.DataUser
 import com.android.bookswap.data.source.network.BooksFirestoreRepository
 import io.mockk.every
 import io.mockk.mockk
-import junit.framework.TestCase.assertEquals
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.runTest
-import org.junit.Before
-import org.junit.Test
 import java.util.UUID
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Before
 
 class BookManagerTest {
-  private val users = listOf(
-    DataUser(bookList = listOf(
-      UUID(1,2),
-      UUID(2,1)
-    ),
-      longitude = -5.0,
-      latitude = 0.0),
-    DataUser(bookList = listOf(
-      UUID(1,1)
-    ),
-      longitude = 1.0,
-      latitude = 2.0)
-    )
+  private val users =
+      listOf(
+          DataUser(bookList = listOf(UUID(1, 2), UUID(2, 1)), longitude = -5.0, latitude = 0.0),
+          DataUser(bookList = listOf(UUID(1, 1)), longitude = 1.0, latitude = 2.0))
 
-  private val books = listOf(
-    DataBook(
-      uuid = UUID(1, 2),
-      title = "Book 1",
-      author = "Author 1",
-      description = "Description of Book 1",
-      rating = 5,
-      photo = "url_to_photo_1",
-      language = BookLanguages.ENGLISH,
-      isbn = "123-456-789",
-      genres = listOf(BookGenres.FICTION, BookGenres.HORROR)),
-    DataBook(
-      uuid = UUID(2, 1),
-      title = "Book 2",
-      author = "Author 2",
-      description = "Description of Book 2",
-      rating = 4,
-      photo = "url_to_photo_2",
-      language = BookLanguages.FRENCH,
-      isbn = "234-567-890",
-      genres = listOf(BookGenres.FICTION)),
-    DataBook(
-      uuid = UUID(1, 1),
-      title = "Book 3",
-      author = "Author 3",
-      description = "Description of Book 3",
-      rating = 4,
-      photo = "url_to_photo_3",
-      language = BookLanguages.GERMAN,
-      isbn = "234-567-890",
-      genres = listOf(BookGenres.NONFICTION, BookGenres.HORROR))
-  )
+  private val books =
+      listOf(
+          DataBook(
+              uuid = UUID(1, 2),
+              title = "Book 1",
+              author = "Author 1",
+              description = "Description of Book 1",
+              rating = 5,
+              photo = "url_to_photo_1",
+              language = BookLanguages.ENGLISH,
+              isbn = "123-456-789",
+              genres = listOf(BookGenres.FICTION, BookGenres.HORROR)),
+          DataBook(
+              uuid = UUID(2, 1),
+              title = "Book 2",
+              author = "Author 2",
+              description = "Description of Book 2",
+              rating = 4,
+              photo = "url_to_photo_2",
+              language = BookLanguages.FRENCH,
+              isbn = "234-567-890",
+              genres = listOf(BookGenres.FICTION)),
+          DataBook(
+              uuid = UUID(1, 1),
+              title = "Book 3",
+              author = "Author 3",
+              description = "Description of Book 3",
+              rating = 4,
+              photo = "url_to_photo_3",
+              language = BookLanguages.GERMAN,
+              isbn = "234-567-890",
+              genres = listOf(BookGenres.NONFICTION, BookGenres.HORROR)))
 
-  private val geolocation1 = listOf(3.5,8.0)
-  private val geolocation2 = listOf(-10.0,-10.0)
+  private val geolocation1 = listOf(3.5, 8.0)
+  private val geolocation2 = listOf(-10.0, -10.0)
 
   private lateinit var mockBookRepository: BooksFirestoreRepository
   private lateinit var mockGeolocation1: IGeolocation
@@ -75,30 +63,37 @@ class BookManagerTest {
   @Before
   fun setup() {
     mockBookRepository = mockk()
-    every { mockBookRepository.getBook(any(), any()) } answers {
-      firstArg<(List<DataBook>) -> Unit>().invoke(books)
-    }
+    every { mockBookRepository.getBook(any(), any()) } answers
+        {
+          firstArg<(List<DataBook>) -> Unit>().invoke(books)
+        }
 
     mockGeolocation1 = mockk()
-    every { mockGeolocation1.longitude } answers {MutableStateFlow(geolocation1[0])}
-    every { mockGeolocation1.latitude } answers {MutableStateFlow(geolocation1[1])}
+    every { mockGeolocation1.longitude } answers { MutableStateFlow(geolocation1[0]) }
+    every { mockGeolocation1.latitude } answers { MutableStateFlow(geolocation1[1]) }
 
     mockGeolocation2 = mockk()
-    every { mockGeolocation2.longitude } answers {MutableStateFlow(geolocation2[0])}
-    every { mockGeolocation2.latitude } answers {MutableStateFlow(geolocation2[1])}
+    every { mockGeolocation2.longitude } answers { MutableStateFlow(geolocation2[0]) }
+    every { mockGeolocation2.latitude } answers { MutableStateFlow(geolocation2[1]) }
 
     mockBookFilter = mockk()
-    every { mockBookFilter.genresFilter } answers { MutableStateFlow(listOf(BookGenres.HORROR))}
-    every { mockBookFilter.languagesFilter } answers { MutableStateFlow(listOf(BookLanguages.FRENCH))}
+    every { mockBookFilter.genresFilter } answers { MutableStateFlow(listOf(BookGenres.HORROR)) }
+    every { mockBookFilter.languagesFilter } answers
+        {
+          MutableStateFlow(listOf(BookLanguages.FRENCH))
+        }
 
     mockBookFilterEmpty = mockk()
-    every { mockBookFilterEmpty.genresFilter } answers { MutableStateFlow(emptyList())}
-    every { mockBookFilterEmpty.languagesFilter } answers { MutableStateFlow(emptyList())}
+    every { mockBookFilterEmpty.genresFilter } answers { MutableStateFlow(emptyList()) }
+    every { mockBookFilterEmpty.languagesFilter } answers { MutableStateFlow(emptyList()) }
   }
 
+  /*
+  @OptIn(ExperimentalCoroutinesApi::class)
   @Test
-  fun listMarkerBookChangedWhenFilterApplied() = runTest {
+  fun listMarkerBookChangedWhenFilterApplied() = runTest{
     bookManager = BookManager(mockGeolocation1, mockBookRepository, users, mockBookFilterEmpty)
+    advanceUntilIdle()
     assertEquals(books, bookManager.filteredBooks.value)
-  }
+  }*/
 }


### PR DESCRIPTION
This PR moved the logic for retrieving the books and filtering them, from the map screen to a new model file named BookManager. As a few of the argument for the map screen is only used by the BookManager, these arguments were replaced by the book manager.
This PR  also add in the BookManager a sorting system that sort the books by the distance between their owner and the user's geolocation.

This PR doesn't have currently the test for the BookManager, so it shouldn't be merged.