### PR TITLE
Allow usage of URL instead of stored image for chat images

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
@@ -391,25 +391,27 @@ class ChatScreenTest {
         .onNodeWithTag("column", useUnmergedTree = true)
         .performScrollToIndex(mockMessageRepository.messages.size - 1)
 
-    composeTestRule.onNodeWithTag("hobbit", useUnmergedTree = true).performClick()
+    composeTestRule
+        .onNodeWithTag("message_item_column $imageTestMessageUUID", useUnmergedTree = true)
+        .performClick()
 
     composeTestRule.waitUntil(timeoutMillis = 5000) {
       composeTestRule
-          .onAllNodesWithTag("HobbitBig", useUnmergedTree = true)
+          .onAllNodesWithTag("popupImage", useUnmergedTree = true)
           .fetchSemanticsNodes()
           .isNotEmpty()
     }
-    composeTestRule.onNodeWithTag("HobbitBig", useUnmergedTree = true).assertIsDisplayed()
+    composeTestRule.onNodeWithTag("popupImage", useUnmergedTree = true).assertIsDisplayed()
 
-    composeTestRule.onNodeWithTag("HobbitBig", useUnmergedTree = true).performClick()
+    composeTestRule.onNodeWithTag("popupImage", useUnmergedTree = true).performClick()
 
     composeTestRule.waitUntil(timeoutMillis = 5000) {
       composeTestRule
-          .onAllNodesWithTag("HobbitBig", useUnmergedTree = true)
+          .onAllNodesWithTag("popupImage", useUnmergedTree = true)
           .fetchSemanticsNodes()
           .isEmpty()
     }
-    composeTestRule.onNodeWithTag("HobbitBig", useUnmergedTree = true).assertDoesNotExist()
+    composeTestRule.onNodeWithTag("popupImage", useUnmergedTree = true).assertDoesNotExist()
   }
 
   @Test

--- a/app/src/main/java/com/android/bookswap/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/chat/ChatScreen.kt
@@ -3,7 +3,6 @@ package com.android.bookswap.ui.chat
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -50,11 +49,10 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
-import com.android.bookswap.R
+import coil.compose.AsyncImage
 import com.android.bookswap.data.DataMessage
 import com.android.bookswap.data.repository.MessageRepository
 import com.android.bookswap.ui.components.BackButtonComponent
@@ -332,25 +330,28 @@ fun MessageItem(message: DataMessage, currentUserUUID: UUID, onLongPress: () -> 
                         onClick = { if (message.uuid == imageTestMessageUUID) showPopup = true },
                         onLongClick = { onLongPress() })
                     .testTag("message_item ${message.uuid}")) {
-              Column(modifier = Modifier.padding(16.dp)) {
-                if (message.uuid == imageTestMessageUUID) {
-                  Image(
-                      painter = painterResource(id = R.drawable.the_hobbit_cover),
-                      contentDescription = "Message Image",
-                      modifier = Modifier.testTag("hobbit"))
-                } else {
-                  Text(
-                      text = message.text,
-                      modifier = Modifier.testTag("message_text ${message.uuid}"),
-                      color = ColorVariable.Accent)
-                }
-                Text(
-                    text = formatTimestamp(message.timestamp),
-                    color = ColorVariable.AccentSecondary,
-                    style = MaterialTheme.typography.bodySmall,
-                    modifier =
-                        Modifier.align(Alignment.End).testTag("message_timestamp ${message.uuid}"))
-              }
+              Column(
+                  modifier =
+                      Modifier.padding(16.dp).testTag("message_item_column ${message.uuid}")) {
+                    if (message.uuid == imageTestMessageUUID) {
+                      AsyncImage(
+                          model = message.text,
+                          contentDescription = "Message Image",
+                          modifier = Modifier.testTag("hobbit"))
+                    } else {
+                      Text(
+                          text = message.text,
+                          modifier = Modifier.testTag("message_text ${message.uuid}"),
+                          color = ColorVariable.Accent)
+                    }
+                    Text(
+                        text = formatTimestamp(message.timestamp),
+                        color = ColorVariable.AccentSecondary,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier =
+                            Modifier.align(Alignment.End)
+                                .testTag("message_timestamp ${message.uuid}"))
+                  }
             }
       }
 
@@ -366,6 +367,7 @@ fun MessageItem(message: DataMessage, currentUserUUID: UUID, onLongPress: () -> 
           Box(
               modifier =
                   Modifier.fillMaxSize()
+                      .testTag("popupImage")
                       .background(Color.Black.copy(alpha = 0.8f))
                       .clickable {
                         showPopup = false
@@ -383,8 +385,8 @@ fun MessageItem(message: DataMessage, currentUserUUID: UUID, onLongPress: () -> 
                                 scaleY = scale,
                                 translationX = offsetX,
                                 translationY = offsetY)) {
-                      Image(
-                          painter = painterResource(id = R.drawable.the_hobbit_cover),
+                      AsyncImage(
+                          model = message.text,
                           contentDescription = "Enlarged Image",
                           modifier =
                               Modifier.size(imagePopUp * scale)


### PR DESCRIPTION
### URL usage for image in chat
This pull request is quite simple, it changes the usage of a placeholder stored image in the chat for the URL stored in the text of a message, for the moment it has been tested with the following URL: 
https://upload.wikimedia.org/wikipedia/pt/7/72/The_Hobbit_Cover.JPG
It is important to note that the URL must begin with "https://" or "http://", otherwise it won't work.
This is done through the usage of `io.coil-kt:coil-compose:2.1.0` and `AsyncImage`. 
For example:  
```kotlin
AsyncImage(
    model = message.text,
    contentDescription = "Message Image",
    modifier = Modifier
        .testTag("hobbit")
        .padding(padding8)
)
```

It also updates a test to ensure it works even if there is no wifi and the image cannot load because of it; essentially it tests the test bubble itself rather than the image for clicking purposes.