### PR TITLE
DataMessage refactoring to include message type

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import com.android.bookswap.data.DataMessage
+import com.android.bookswap.data.MessageType
 import com.android.bookswap.data.repository.MessageRepository
 import com.android.bookswap.ui.navigation.NavigationActions
 import com.android.bookswap.ui.theme.ColorVariable
@@ -43,6 +44,7 @@ class ChatScreenTest {
     placeHolderData =
         List(6) {
               DataMessage(
+                  messageType = MessageType.TEXT,
                   uuid = UUID.randomUUID(),
                   senderUUID = currentUserUUID,
                   receiverUUID = otherUserUUID,
@@ -52,6 +54,7 @@ class ChatScreenTest {
             .toMutableList()
     (placeHolderData as MutableList<DataMessage>).add(
         DataMessage(
+            messageType = MessageType.IMAGE,
             uuid = imageTestMessageUUID,
             senderUUID = currentUserUUID,
             receiverUUID = otherUserUUID,

--- a/app/src/main/java/com/android/bookswap/data/DataMessage.kt
+++ b/app/src/main/java/com/android/bookswap/data/DataMessage.kt
@@ -3,9 +3,15 @@ package com.android.bookswap.data
 import java.util.UUID
 
 data class DataMessage(
+    val messageType: MessageType = MessageType.TEXT,
     val uuid: UUID = UUID.randomUUID(),
     val text: String = "",
     val senderUUID: UUID,
     val receiverUUID: UUID,
     val timestamp: Long = 0L
 )
+
+enum class MessageType {
+  TEXT,
+  IMAGE
+}

--- a/app/src/main/java/com/android/bookswap/data/source/network/MessageFirestoreSource.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/network/MessageFirestoreSource.kt
@@ -46,11 +46,12 @@ class MessageFirestoreSource(private val db: FirebaseFirestore) : MessageReposit
   override fun sendMessage(message: DataMessage, callback: (Result<Unit>) -> Unit) {
     val messageMap =
         mapOf(
-            "uuid" to message.uuid,
+            "uuid" to message.uuid.toString(),
             "text" to message.text,
-            "senderId" to message.senderUUID,
-            "receiverId" to message.receiverUUID,
-            "timestamp" to message.timestamp)
+            "senderUUID" to message.senderUUID.toString(),
+            "receiverUUID" to message.receiverUUID.toString(),
+            "timestamp" to message.timestamp,
+            "messageType" to message.messageType.name)
 
     db.collection(COLLECTION_PATH)
         .document(message.uuid.toString())
@@ -167,8 +168,8 @@ class MessageFirestoreSource(private val db: FirebaseFirestore) : MessageReposit
               val messageMap =
                   mapOf(
                       "text" to message.text,
-                      "timestamp" to currentTime // Update the timestamp to the current time
-                      )
+                      "timestamp" to currentTime,
+                      "messageType" to message.messageType.name)
               db.collection(COLLECTION_PATH)
                   .document(message.uuid.toString())
                   .update(messageMap)

--- a/app/src/main/java/com/android/bookswap/data/source/network/MessageFirestoreSource.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/network/MessageFirestoreSource.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import android.widget.Toast
 import com.android.bookswap.data.DataMessage
+import com.android.bookswap.data.MessageType
 import com.android.bookswap.data.repository.MessageRepository
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
@@ -240,12 +241,13 @@ class MessageFirestoreSource(private val db: FirebaseFirestore) : MessageReposit
 
 fun documentToMessage(document: DocumentSnapshot): Result<DataMessage> {
   return try {
+    val type = MessageType.valueOf(document.getString("messageType")!!)
     val uuid = UUID.fromString(document.getString("uuid")!!)
     val text = document.getString("text")!!
     val senderUUID = UUID.fromString(document.getString("senderUUID")!!)
     val receiverUUID = UUID.fromString(document.getString("receiverUUID")!!)
     val timestamp = document.getLong("timestamp")!!
-    Result.success(DataMessage(uuid, text, senderUUID, receiverUUID, timestamp))
+    Result.success(DataMessage(type, uuid, text, senderUUID, receiverUUID, timestamp))
   } catch (e: Exception) {
     Log.e("MessageSource", "Error converting document to Message: ${e.message}")
     Result.failure(e)

--- a/app/src/main/java/com/android/bookswap/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/chat/ChatScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import com.android.bookswap.R
 import com.android.bookswap.data.DataMessage
+import com.android.bookswap.data.MessageType
 import com.android.bookswap.data.repository.MessageRepository
 import com.android.bookswap.ui.components.BackButtonComponent
 import com.android.bookswap.ui.navigation.NavigationActions
@@ -183,6 +184,7 @@ fun ChatScreen(
                       val messageId = messageRepository.getNewUUID()
                       val newMessage =
                           DataMessage(
+                              messageType = MessageType.TEXT,
                               uuid = messageId,
                               text = newMessageText.text,
                               senderUUID = currentUserUUID,
@@ -329,11 +331,13 @@ fun MessageItem(message: DataMessage, currentUserUUID: UUID, onLongPress: () -> 
                     .widthIn(max = (LocalConfiguration.current.screenWidthDp.dp * 2 / 3))
                     .border(1.dp, ColorVariable.Accent, shape)
                     .combinedClickable(
-                        onClick = { if (message.uuid == imageTestMessageUUID) showPopup = true },
+                        onClick = {
+                          if (message.messageType == MessageType.IMAGE) showPopup = true
+                        },
                         onLongClick = { onLongPress() })
                     .testTag("message_item ${message.uuid}")) {
               Column(modifier = Modifier.padding(16.dp)) {
-                if (message.uuid == imageTestMessageUUID) {
+                if (message.messageType == MessageType.IMAGE) {
                   Image(
                       painter = painterResource(id = R.drawable.the_hobbit_cover),
                       contentDescription = "Message Image",

--- a/app/src/test/java/com/android/bookswap/model/chat/DataMessageFirestoreSourceTest.kt
+++ b/app/src/test/java/com/android/bookswap/model/chat/DataMessageFirestoreSourceTest.kt
@@ -140,11 +140,12 @@ class DataMessageFirestoreSourceTest {
   fun sendMessage_callsFirestoreSet_onSuccess() {
     val messageMap =
         mapOf(
-            "uuid" to testMessage.uuid,
+            "uuid" to testMessage.uuid.toString(),
             "text" to testMessage.text,
-            "senderId" to testMessage.senderUUID,
-            "receiverId" to testMessage.receiverUUID,
-            "timestamp" to testMessage.timestamp)
+            "senderUUID" to testMessage.senderUUID.toString(),
+            "receiverUUID" to testMessage.receiverUUID.toString(),
+            "timestamp" to testMessage.timestamp,
+            "messageType" to testMessage.messageType.name)
     `when`(mockFirestore.collection(COLLECTION_PATH)).thenReturn(mockCollectionReference)
     `when`(mockCollectionReference.document(testMessage.uuid.toString()))
         .thenReturn(mockDocumentReference)
@@ -160,11 +161,12 @@ class DataMessageFirestoreSourceTest {
     val exception = RuntimeException("Firestore error")
     val messageMap =
         mapOf(
-            "uuid" to testMessage.uuid,
+            "uuid" to testMessage.uuid.toString(),
             "text" to testMessage.text,
-            "senderId" to testMessage.senderUUID,
-            "receiverId" to testMessage.receiverUUID,
-            "timestamp" to testMessage.timestamp)
+            "senderUUID" to testMessage.senderUUID.toString(),
+            "receiverUUID" to testMessage.receiverUUID.toString(),
+            "timestamp" to testMessage.timestamp,
+            "messageType" to testMessage.messageType.name)
     `when`(mockFirestore.collection(COLLECTION_PATH)).thenReturn(mockCollectionReference)
     `when`(mockCollectionReference.document(testMessage.uuid.toString()))
         .thenReturn(mockDocumentReference)

--- a/app/src/test/java/com/android/bookswap/model/chat/DataMessageFirestoreSourceTest.kt
+++ b/app/src/test/java/com/android/bookswap/model/chat/DataMessageFirestoreSourceTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import com.android.bookswap.data.DataMessage
+import com.android.bookswap.data.MessageType
 import com.android.bookswap.data.source.network.COLLECTION_PATH
 import com.android.bookswap.data.source.network.MessageFirestoreSource
 import com.android.bookswap.data.source.network.documentToMessage
@@ -45,6 +46,7 @@ class DataMessageFirestoreSourceTest {
 
   private val testMessage =
       DataMessage(
+          messageType = MessageType.TEXT,
           uuid = UUID.randomUUID(),
           text = "Test message",
           senderUUID = UUID.randomUUID(),
@@ -193,6 +195,7 @@ class DataMessageFirestoreSourceTest {
     `when`(mockDocumentSnapshot.getString("receiverUUID"))
         .thenReturn(recentMessage.receiverUUID.toString())
     `when`(mockDocumentSnapshot.getLong("timestamp")).thenReturn(recentMessage.timestamp)
+    `when`(mockDocumentSnapshot.getString("messageType")).thenReturn(recentMessage.messageType.name)
     `when`(mockDocumentReference.delete()).thenReturn(Tasks.forResult(null))
 
     messageFirestoreSource.deleteMessage(
@@ -553,6 +556,7 @@ class DataMessageFirestoreSourceTest {
     `when`(mockDocumentSnapshot.getString("receiverUUID"))
         .thenReturn(testMessage.receiverUUID.toString())
     `when`(mockDocumentSnapshot.getLong("timestamp")).thenReturn(1634567890L)
+    `when`(mockDocumentSnapshot.getString("messageType")).thenReturn("TEXT")
 
     val result = documentToMessage(mockDocumentSnapshot)
 
@@ -564,15 +568,17 @@ class DataMessageFirestoreSourceTest {
     assert(message?.senderUUID == testMessage.senderUUID)
     assert(message?.receiverUUID == testMessage.receiverUUID)
     assert(message?.timestamp == 1634567890L)
+    assert(message?.messageType == MessageType.TEXT)
   }
 
   @Test
   fun documentToMessage_returnsFailureWhenFieldIsMissing() {
     `when`(mockDocumentSnapshot.getString("uuid")).thenReturn(UUID.randomUUID().toString())
     `when`(mockDocumentSnapshot.getString("text")).thenReturn(null) // Missing field
-    `when`(mockDocumentSnapshot.getString("senderId")).thenReturn("sender1")
-    `when`(mockDocumentSnapshot.getString("receiverId")).thenReturn("receiver1")
+    `when`(mockDocumentSnapshot.getString("senderUUID")).thenReturn("sender1")
+    `when`(mockDocumentSnapshot.getString("receiverUUID")).thenReturn("receiver1")
     `when`(mockDocumentSnapshot.getLong("timestamp")).thenReturn(1634567890L)
+    `when`(mockDocumentSnapshot.getString("messageType")).thenReturn("TEXT")
 
     val result = documentToMessage(mockDocumentSnapshot)
 


### PR DESCRIPTION
### Refactoring DataMessage to include message type
Create an enum with types `TEXT` and `IMAGE`, then update all necessary files. The new DataMessage is as follows:
```kotlin
data class DataMessage(
    val messageType: MessageType = MessageType.TEXT,
    val uuid: UUID = UUID.randomUUID(),
    val text: String = "",
    val senderUUID: UUID,
    val receiverUUID: UUID,
    val timestamp: Long = 0L
)

enum class MessageType {
  TEXT,
  IMAGE
}
```

Then the chat screen and the firestore source files are updated with their respective tests. Another change is the usage of the type to check what message bubble will be used in the chat screen instead of a temporary id.