### PR TITLE
Fix navigation to Chat

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import com.android.bookswap.data.DataMessage
+import com.android.bookswap.data.DataUser
 import com.android.bookswap.data.MessageType
 import com.android.bookswap.data.repository.MessageRepository
 import com.android.bookswap.ui.navigation.NavigationActions
@@ -37,10 +38,16 @@ class ChatScreenTest {
   private val currentUserUUID = UUID.randomUUID()
   private val otherUserUUID = UUID.randomUUID()
   private lateinit var mockNavigationActions: NavigationActions
+  private val currentUser =
+      DataUser(
+          currentUserUUID, "Hello", "Jaime", "Oliver Pastor", "", "", 0.0, 0.0, "", emptyList(), "")
+  private val otherUser =
+      DataUser(otherUserUUID, "Hey", "Matias", "Salvade", "", "", 0.0, 0.0, "", emptyList(), "")
 
   @Before
   fun setUp() {
     mockNavigationActions = mockk()
+
     placeHolderData =
         List(6) {
               DataMessage(
@@ -87,8 +94,8 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           messageRepository = mockMessageRepository,
-          currentUserUUID = currentUserUUID,
-          otherUserUUID = otherUserUUID,
+          currentUser = currentUser,
+          otherUser = otherUser,
           mockNavigationActions)
     }
     composeTestRule.onNodeWithTag("message_input_field").assertIsDisplayed()
@@ -103,8 +110,8 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           messageRepository = mockMessageRepository,
-          currentUserUUID = currentUserUUID,
-          otherUserUUID = otherUserUUID,
+          currentUser = currentUser,
+          otherUser = otherUser,
           mockNavigationActions)
     }
     composeTestRule.onNodeWithTag("message_input_field").assertIsDisplayed()
@@ -137,15 +144,15 @@ class ChatScreenTest {
   }
 
   @Test
-  fun CheckLastMessageIsImage() {
+  fun checkLastMessageIsImage() {
     val mockMessageRepository =
         MockMessageFirestoreSource().apply { messages = placeHolderData.toMutableList() }
 
     composeTestRule.setContent {
       ChatScreen(
           messageRepository = mockMessageRepository,
-          currentUserUUID = currentUserUUID,
-          otherUserUUID = otherUserUUID,
+          currentUser = currentUser,
+          otherUser = otherUser,
           mockNavigationActions)
     }
 
@@ -163,8 +170,8 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           messageRepository = mockMessageRepository,
-          currentUserUUID = currentUserUUID,
-          otherUserUUID = otherUserUUID,
+          currentUser = currentUser,
+          otherUser = otherUser,
           mockNavigationActions)
     }
     composeTestRule.onNodeWithTag("send_button").assertHasClickAction()
@@ -175,8 +182,8 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           messageRepository = mockMessageRepository,
-          currentUserUUID = currentUserUUID,
-          otherUserUUID = otherUserUUID,
+          currentUser = currentUser,
+          otherUser = otherUser,
           mockNavigationActions)
     }
     val testInput = "Hello, World!"
@@ -192,8 +199,8 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           messageRepository = mockMessageRepository,
-          currentUserUUID = currentUserUUID,
-          otherUserUUID = otherUserUUID,
+          currentUser = currentUser,
+          otherUser = otherUser,
           mockNavigationActions)
     }
 
@@ -215,14 +222,16 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           messageRepository = mockMessageRepository,
-          currentUserUUID = currentUserUUID,
-          otherUserUUID = otherUserUUID,
+          currentUser = currentUser,
+          otherUser = otherUser,
           mockNavigationActions)
     }
 
     composeTestRule.onNodeWithTag("chatTopAppBar").assertIsDisplayed()
     composeTestRule.onNodeWithTag("chatName").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("chatName").assertTextEquals(otherUserUUID.toString())
+    composeTestRule
+        .onNodeWithTag("chatName")
+        .assertTextEquals(otherUser.firstName + " " + otherUser.lastName)
     composeTestRule.onNodeWithTag("profileIcon", useUnmergedTree = true).assertIsDisplayed()
   }
 
@@ -231,8 +240,8 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           messageRepository = mockMessageRepository,
-          currentUserUUID = currentUserUUID,
-          otherUserUUID = otherUserUUID,
+          currentUser = currentUser,
+          otherUser = otherUser,
           navController = mockNavigationActions)
     }
 
@@ -271,8 +280,8 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           messageRepository = mockMessageRepository,
-          currentUserUUID = currentUserUUID,
-          otherUserUUID = otherUserUUID,
+          currentUser = currentUser,
+          otherUser = otherUser,
           mockNavigationActions)
     }
 
@@ -315,8 +324,8 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           messageRepository = mockMessageRepository,
-          currentUserUUID = currentUserUUID,
-          otherUserUUID = otherUserUUID,
+          currentUser = currentUser,
+          otherUser = otherUser,
           navController = mockNavigationActions)
     }
 
@@ -385,8 +394,8 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           messageRepository = mockMessageRepository,
-          currentUserUUID = currentUserUUID,
-          otherUserUUID = otherUserUUID,
+          currentUser = currentUser,
+          otherUser = otherUser,
           mockNavigationActions)
     }
 
@@ -420,8 +429,8 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           messageRepository = mockMessageRepository,
-          currentUserUUID = currentUserUUID,
-          otherUserUUID = otherUserUUID,
+          currentUser = currentUser,
+          otherUser = otherUser,
           mockNavigationActions)
     }
 

--- a/app/src/androidTest/java/com/android/bookswap/ui/chat/ListChatScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/chat/ListChatScreenTest.kt
@@ -12,11 +12,13 @@ import androidx.compose.ui.test.onChild
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.navigation.compose.rememberNavController
-import com.android.bookswap.model.chat.MessageBox
+import com.android.bookswap.data.DataUser
+import com.android.bookswap.data.MessageBox
 import com.android.bookswap.ui.components.TopAppBarComponent
 import com.android.bookswap.ui.navigation.BottomNavigationMenu
 import com.android.bookswap.ui.navigation.List_Navigation_Bar_Destinations
 import com.android.bookswap.ui.navigation.NavigationActions
+import java.util.UUID
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -26,13 +28,28 @@ class ListChatScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
   private lateinit var placeHolderData: List<MessageBox>
   private lateinit var placeHolderDataEmpty: List<MessageBox>
+  private val currentUserUUID = UUID.randomUUID()
+  private val currentUser =
+      DataUser(
+          currentUserUUID, "Hello", "Jaime", "Oliver Pastor", "", "", 0.0, 0.0, "", emptyList(), "")
 
   @Before
   fun setUp() {
     placeHolderData =
         List(12) {
           MessageBox(
-              "Contact ${it + 1}",
+              DataUser(
+                  UUID.randomUUID(),
+                  "Hello",
+                  "First ${it + 1}",
+                  "Last ${it + 1}",
+                  "",
+                  "",
+                  0.0,
+                  0.0,
+                  "",
+                  emptyList(),
+                  "googleUid"),
               "Test message $it test for the feature of ellipsis in the message",
               "01.01.24")
         }
@@ -53,7 +70,8 @@ class ListChatScreenTest {
                 onTabSelect = { destination -> navigationActions.navigateTo(destination) },
                 tabList = List_Navigation_Bar_Destinations,
                 selectedItem = navigationActions.currentRoute())
-          })
+          },
+          currentUser)
     }
     composeTestRule.onNodeWithTag("TopAppBar").assertIsDisplayed()
     composeTestRule.onNodeWithTag("profileIconButton").assertIsDisplayed()
@@ -78,7 +96,8 @@ class ListChatScreenTest {
                 onTabSelect = { destination -> navigationActions.navigateTo(destination) },
                 tabList = List_Navigation_Bar_Destinations,
                 selectedItem = navigationActions.currentRoute())
-          })
+          },
+          currentUser)
     }
     composeTestRule.onNodeWithTag("TopAppBar").assertIsDisplayed()
     composeTestRule.onNodeWithTag("profileIconButton").assertIsDisplayed()
@@ -98,7 +117,14 @@ class ListChatScreenTest {
       ListChatScreen(
           placeHolderData,
           navigationActions,
-          { TopAppBarComponent(Modifier, navigationActions, "Messages") })
+          { TopAppBarComponent(Modifier, navigationActions, "Messages") },
+          {
+            BottomNavigationMenu(
+                onTabSelect = { destination -> navigationActions.navigateTo(destination) },
+                tabList = List_Navigation_Bar_Destinations,
+                selectedItem = navigationActions.currentRoute())
+          },
+          currentUser)
     }
     composeTestRule.onNodeWithTag("profileIconButton").assertHasClickAction()
   }
@@ -108,7 +134,17 @@ class ListChatScreenTest {
     composeTestRule.setContent {
       val navController = rememberNavController()
       val navigationActions = NavigationActions(navController)
-      ListChatScreen(placeHolderData, navigationActions)
+      ListChatScreen(
+          placeHolderData,
+          navigationActions,
+          { TopAppBarComponent(Modifier, navigationActions, "Messages") },
+          {
+            BottomNavigationMenu(
+                onTabSelect = { destination -> navigationActions.navigateTo(destination) },
+                tabList = List_Navigation_Bar_Destinations,
+                selectedItem = navigationActions.currentRoute())
+          },
+          currentUser)
     }
     val messageNodes = composeTestRule.onAllNodesWithTag("chat_messageBox")
     assert(messageNodes.fetchSemanticsNodes().isNotEmpty())

--- a/app/src/androidTest/java/com/android/bookswap/ui/chat/ListChatScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/chat/ListChatScreenTest.kt
@@ -28,7 +28,6 @@ class ListChatScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
   private lateinit var placeHolderData: List<MessageBox>
   private lateinit var placeHolderDataEmpty: List<MessageBox>
-  private val currentUserUUID = UUID.randomUUID()
 
   @Before
   fun setUp() {

--- a/app/src/androidTest/java/com/android/bookswap/ui/chat/ListChatScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/chat/ListChatScreenTest.kt
@@ -29,9 +29,6 @@ class ListChatScreenTest {
   private lateinit var placeHolderData: List<MessageBox>
   private lateinit var placeHolderDataEmpty: List<MessageBox>
   private val currentUserUUID = UUID.randomUUID()
-  private val currentUser =
-      DataUser(
-          currentUserUUID, "Hello", "Jaime", "Oliver Pastor", "", "", 0.0, 0.0, "", emptyList(), "")
 
   @Before
   fun setUp() {
@@ -70,8 +67,7 @@ class ListChatScreenTest {
                 onTabSelect = { destination -> navigationActions.navigateTo(destination) },
                 tabList = List_Navigation_Bar_Destinations,
                 selectedItem = navigationActions.currentRoute())
-          },
-          currentUser)
+          })
     }
     composeTestRule.onNodeWithTag("TopAppBar").assertIsDisplayed()
     composeTestRule.onNodeWithTag("profileIconButton").assertIsDisplayed()
@@ -96,8 +92,7 @@ class ListChatScreenTest {
                 onTabSelect = { destination -> navigationActions.navigateTo(destination) },
                 tabList = List_Navigation_Bar_Destinations,
                 selectedItem = navigationActions.currentRoute())
-          },
-          currentUser)
+          })
     }
     composeTestRule.onNodeWithTag("TopAppBar").assertIsDisplayed()
     composeTestRule.onNodeWithTag("profileIconButton").assertIsDisplayed()
@@ -123,8 +118,7 @@ class ListChatScreenTest {
                 onTabSelect = { destination -> navigationActions.navigateTo(destination) },
                 tabList = List_Navigation_Bar_Destinations,
                 selectedItem = navigationActions.currentRoute())
-          },
-          currentUser)
+          })
     }
     composeTestRule.onNodeWithTag("profileIconButton").assertHasClickAction()
   }
@@ -143,8 +137,7 @@ class ListChatScreenTest {
                 onTabSelect = { destination -> navigationActions.navigateTo(destination) },
                 tabList = List_Navigation_Bar_Destinations,
                 selectedItem = navigationActions.currentRoute())
-          },
-          currentUser)
+          })
     }
     val messageNodes = composeTestRule.onAllNodesWithTag("chat_messageBox")
     assert(messageNodes.fetchSemanticsNodes().isNotEmpty())

--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -1,7 +1,6 @@
 package com.android.bookswap
 
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
@@ -89,7 +88,7 @@ class MainActivity : ComponentActivity() {
       messageRepository: MessageRepository,
       bookRepository: BooksRepository,
       userRepository: UsersRepository,
-      startDestination: String = Route.AUTH,
+      startDestination: String = Route.MAP,
       geolocation: IGeolocation = DefaultGeolocation()
   ) {
     val navController = rememberNavController()
@@ -169,18 +168,19 @@ class MainActivity : ComponentActivity() {
               placeHolder,
               navigationActions,
               topAppBar = { topAppBar("Messages") },
-              bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
-              currentUser)
+              bottomAppBar = { bottomAppBar(this@navigation.route ?: "") })
         }
-        composable("${Screen.CHAT}/{user1}/{user2}") { backStackEntry ->
-          val user1UUID = UUID.fromString(backStackEntry.arguments?.getString("user1") ?: "")
-          val user2UUID = UUID.fromString(backStackEntry.arguments?.getString("user2") ?: "")
-          val user1 = placeHolder.firstOrNull { it.contact.userUUID == user1UUID }?.contact
+        composable("${Screen.CHAT}/{user2}") { backStackEntry ->
+          val user2UUID = UUID.fromString(backStackEntry.arguments?.getString("user2"))
           val user2 = placeHolder.firstOrNull { it.contact.userUUID == user2UUID }?.contact
-          if (user1 != null && user2 != null) {
-            ChatScreen(messageRepository, user1, user2, navigationActions)
+
+          if (user2 != null) {
+            ChatScreen(messageRepository, currentUser, user2, navigationActions)
           } else {
-            Log.e("MainActivity", "User not found in placeholder list")
+            BookAdditionChoiceScreen(
+                navigationActions,
+                topAppBar = { topAppBar("Add a Book") },
+                bottomAppBar = { bottomAppBar(this@navigation.route ?: "") })
           }
         }
       }

--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -88,7 +88,7 @@ class MainActivity : ComponentActivity() {
       messageRepository: MessageRepository,
       bookRepository: BooksRepository,
       userRepository: UsersRepository,
-      startDestination: String = Route.MAP,
+      startDestination: String = Route.AUTH,
       geolocation: IGeolocation = DefaultGeolocation()
   ) {
     val navController = rememberNavController()

--- a/app/src/main/java/com/android/bookswap/data/MessageBox.kt
+++ b/app/src/main/java/com/android/bookswap/data/MessageBox.kt
@@ -1,0 +1,4 @@
+package com.android.bookswap.data
+
+/** Data class for the message box */
+data class MessageBox(val contact: DataUser, val message: String, val date: String)

--- a/app/src/main/java/com/android/bookswap/model/chat/Chat.kt
+++ b/app/src/main/java/com/android/bookswap/model/chat/Chat.kt
@@ -1,4 +1,0 @@
-package com.android.bookswap.model.chat
-
-/** Data class for the message box */
-data class MessageBox(val contactName: String, val message: String, val date: String)

--- a/app/src/main/java/com/android/bookswap/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/chat/ChatScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import com.android.bookswap.R
 import com.android.bookswap.data.DataMessage
+import com.android.bookswap.data.DataUser
 import com.android.bookswap.data.MessageType
 import com.android.bookswap.data.repository.MessageRepository
 import com.android.bookswap.ui.components.BackButtonComponent
@@ -71,8 +72,8 @@ import kotlinx.coroutines.delay
 @Composable
 fun ChatScreen(
     messageRepository: MessageRepository,
-    currentUserUUID: UUID, // To identify the current user for aligning messages
-    otherUserUUID: UUID,
+    currentUser: DataUser,
+    otherUser: DataUser,
     navController: NavigationActions
 ) {
   val context = LocalContext.current
@@ -91,8 +92,10 @@ fun ChatScreen(
               result
                   .getOrThrow()
                   .filter {
-                    (it.senderUUID == currentUserUUID && it.receiverUUID == otherUserUUID) ||
-                        (it.senderUUID == otherUserUUID && it.receiverUUID == currentUserUUID)
+                    (it.senderUUID == currentUser.userUUID &&
+                        it.receiverUUID == otherUser.userUUID) ||
+                        (it.senderUUID == otherUser.userUUID &&
+                            it.receiverUUID == currentUser.userUUID)
                   }
                   .sortedBy { it.timestamp }
           Log.d("ChatScreen", "Fetched messages: $messages")
@@ -108,7 +111,7 @@ fun ChatScreen(
       TopAppBar(
           title = {
             Text(
-                text = otherUserUUID.toString(),
+                text = otherUser.firstName + " " + otherUser.lastName,
                 style = MaterialTheme.typography.titleMedium,
                 color = ColorVariable.Accent,
                 modifier =
@@ -136,7 +139,7 @@ fun ChatScreen(
               items(messages) { message ->
                 MessageItem(
                     message = message,
-                    currentUserUUID = currentUserUUID,
+                    currentUserUUID = currentUser.userUUID,
                     onLongPress = { selectedMessage = message })
               }
             }
@@ -187,8 +190,8 @@ fun ChatScreen(
                               messageType = MessageType.TEXT,
                               uuid = messageId,
                               text = newMessageText.text,
-                              senderUUID = currentUserUUID,
-                              receiverUUID = otherUserUUID, // Ensure receiverId is set here
+                              senderUUID = currentUser.userUUID,
+                              receiverUUID = otherUser.userUUID, // Ensure receiverId is set here
                               timestamp = System.currentTimeMillis())
                       // Send the message
                       messageRepository.sendMessage(

--- a/app/src/main/java/com/android/bookswap/ui/chat/ListChat.kt
+++ b/app/src/main/java/com/android/bookswap/ui/chat/ListChat.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.android.bookswap.data.DataUser
 import com.android.bookswap.data.MessageBox
 import com.android.bookswap.ui.navigation.NavigationActions
 import com.android.bookswap.ui.navigation.Screen
@@ -44,7 +43,6 @@ fun ListChatScreen(
     navigationActions: NavigationActions,
     topAppBar: @Composable () -> Unit = {},
     bottomAppBar: @Composable () -> Unit = {},
-    currentUser: DataUser
 ) {
   Scaffold(
       modifier = Modifier.testTag("chat_listScreen"),
@@ -71,7 +69,7 @@ fun ListChatScreen(
                 items(placeHolderData.size) { message ->
                   MessageBoxDisplay(placeHolderData[message]) {
                     navigationActions.navigateTo(
-                        Screen.CHAT, currentUser, placeHolderData[message].contact)
+                        Screen.CHAT, placeHolderData[message].contact.userUUID.toString())
                   }
                   MessageDivider()
                 }

--- a/app/src/main/java/com/android/bookswap/ui/chat/ListChat.kt
+++ b/app/src/main/java/com/android/bookswap/ui/chat/ListChat.kt
@@ -30,7 +30,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.android.bookswap.model.chat.MessageBox
+import com.android.bookswap.data.DataUser
+import com.android.bookswap.data.MessageBox
 import com.android.bookswap.ui.navigation.NavigationActions
 import com.android.bookswap.ui.navigation.Screen
 import com.android.bookswap.ui.theme.ColorVariable
@@ -42,7 +43,8 @@ fun ListChatScreen(
     placeHolderData: List<MessageBox> = emptyList(),
     navigationActions: NavigationActions,
     topAppBar: @Composable () -> Unit = {},
-    bottomAppBar: @Composable () -> Unit = {}
+    bottomAppBar: @Composable () -> Unit = {},
+    currentUser: DataUser
 ) {
   Scaffold(
       modifier = Modifier.testTag("chat_listScreen"),
@@ -69,7 +71,7 @@ fun ListChatScreen(
                 items(placeHolderData.size) { message ->
                   MessageBoxDisplay(placeHolderData[message]) {
                     navigationActions.navigateTo(
-                        Screen.CHAT, "user123", placeHolderData[message].contactName)
+                        Screen.CHAT, currentUser, placeHolderData[message].contact)
                   }
                   MessageDivider()
                 }
@@ -103,7 +105,7 @@ fun MessageBoxDisplay(message: MessageBox, onClick: () -> Unit = {}) {
               modifier = Modifier.fillMaxWidth(),
               horizontalArrangement = Arrangement.SpaceBetween) {
                 Text(
-                    text = message.contactName,
+                    text = message.contact.firstName + " " + message.contact.lastName,
                     fontWeight = FontWeight.Medium,
                     fontSize = 18.sp,
                     color = ColorVariable.Accent,

--- a/app/src/main/java/com/android/bookswap/ui/components/TopAppBarComponent.kt
+++ b/app/src/main/java/com/android/bookswap/ui/components/TopAppBarComponent.kt
@@ -1,7 +1,6 @@
 package com.android.bookswap.ui.components
 
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -10,6 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import com.android.bookswap.ui.navigation.NavigationActions
 import com.android.bookswap.ui.profile.ProfileIcon
+import com.android.bookswap.ui.theme.ColorVariable
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -24,5 +24,5 @@ fun TopAppBarComponent(
       { BackButtonComponent(navActions = navigationActions) },
       { ProfileIcon(navigationActions = navigationActions) },
       TopAppBarDefaults.windowInsets,
-      TopAppBarDefaults.topAppBarColors(MaterialTheme.colorScheme.background))
+      TopAppBarDefaults.topAppBarColors(ColorVariable.BackGround))
 }

--- a/app/src/main/java/com/android/bookswap/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/bookswap/ui/navigation/NavigationActions.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.outlined.Place
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
+import com.android.bookswap.data.DataUser
 
 object Route {
   const val CHAT = "Chat"
@@ -82,13 +83,13 @@ open class NavigationActions(
    * Navigate to the specified screen with optional parameters.
    *
    * @param screen The screen to navigate to
-   * @param user1 The first user parameter
-   * @param user2 The second user parameter
+   * @param user1 The first user to pass to the screen
+   * @param user2 The second user to pass to the screen
    */
-  open fun navigateTo(screen: String, user1: String? = null, user2: String? = null) {
+  open fun navigateTo(screen: String, user1: DataUser? = null, user2: DataUser? = null) {
     val route =
         when (screen) {
-          Screen.CHAT -> "$screen/$user1/$user2"
+          Screen.CHAT -> "$screen/${user1?.userUUID}/${user2?.userUUID}"
           else -> screen
         }
     navController.navigate(route)

--- a/app/src/main/java/com/android/bookswap/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/bookswap/ui/navigation/NavigationActions.kt
@@ -8,7 +8,6 @@ import androidx.compose.material.icons.outlined.Place
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
-import com.android.bookswap.data.DataUser
 
 object Route {
   const val CHAT = "Chat"
@@ -86,12 +85,8 @@ open class NavigationActions(
    * @param user1 The first user to pass to the screen
    * @param user2 The second user to pass to the screen
    */
-  open fun navigateTo(screen: String, user1: DataUser? = null, user2: DataUser? = null) {
-    val route =
-        when (screen) {
-          Screen.CHAT -> "$screen/${user1?.userUUID}/${user2?.userUUID}"
-          else -> screen
-        }
+  open fun navigateTo(screen: String, otherUserUUID: String) {
+    val route = "$screen/$otherUserUUID"
     navController.navigate(route)
   }
 


### PR DESCRIPTION
## Fix navigation to chat
This pull request seeks to fix the issue arisen with the new implementation of UUIDs everywhere that impeded accessing individual chats due to an `IllegalArgumentException` when changing from usernames to UUID. This has been fixed by implementing the use of `DataUser` in `ListChat` and `ChatScreen`.
The new `ChatScreen` looks as follows (to give an example):
```kotlin
fun ChatScreen(
    messageRepository: MessageRepository,
    currentUser: DataUser,
    otherUser: DataUser,
    navController: NavigationActions
) {
   //content
}
````
As it can be seen, they use DataUser now. Additionally, the navigation has been updated both in the main activity and the `NavigationActions`. Furthermore, a current user has been added to the main activity, which for the moment I have filled with my own information, such that it can be used, but it should be updated upon a login to be the right one.