### PR TITLE
Book manager retrieve users from firebase, fix UserFirestoreSource and move UserBooksWithLocation

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/endtoend/NavigationBarEndToEnd.kt
+++ b/app/src/androidTest/java/com/android/bookswap/endtoend/NavigationBarEndToEnd.kt
@@ -4,9 +4,9 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.android.bookswap.MainActivity
+import com.android.bookswap.data.repository.UsersRepository
 import com.android.bookswap.data.source.network.BooksFirestoreRepository
 import com.android.bookswap.data.source.network.MessageFirestoreSource
-import com.android.bookswap.data.source.network.UserFirestoreSource
 import com.android.bookswap.ui.navigation.Route
 import com.google.firebase.firestore.FirebaseFirestore
 import io.mockk.every
@@ -21,18 +21,21 @@ class NavigationBarEndToEnd {
   @get:Rule val composeTestRule = createComposeRule()
 
   private lateinit var mockBookRepository: BooksFirestoreRepository
+  private lateinit var mockUserRepository: UsersRepository
 
   @Before
   fun setUp() {
     mockBookRepository = mockk()
     every { mockBookRepository.getBook(any(), any()) } just runs
+    mockUserRepository = mockk()
+    every { mockUserRepository.getUsers(any()) } just runs
 
     composeTestRule.setContent {
       val db = FirebaseFirestore.getInstance()
 
       val messageRepository = MessageFirestoreSource(db)
-      val userRepository = UserFirestoreSource(db)
-      MainActivity().BookSwapApp(messageRepository, mockBookRepository, userRepository, Route.MAP)
+      MainActivity()
+          .BookSwapApp(messageRepository, mockBookRepository, mockUserRepository, Route.MAP)
     }
   }
 

--- a/app/src/androidTest/java/com/android/bookswap/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/map/MapScreenTest.kt
@@ -17,6 +17,7 @@ import com.android.bookswap.data.BookGenres
 import com.android.bookswap.data.BookLanguages
 import com.android.bookswap.data.DataBook
 import com.android.bookswap.data.DataUser
+import com.android.bookswap.data.UserBooksWithLocation
 import com.android.bookswap.model.map.BookManagerViewModel
 import com.android.bookswap.model.map.DefaultGeolocation
 import com.android.bookswap.ui.navigation.NavigationActions
@@ -73,12 +74,14 @@ class MapScreenTest {
   private val userLongList = listOf(DataUser(bookList = listOf(UUID(2000, 2000))))
 
   private val userBooksWithLocationList =
-      listOf(UserBooksWithLocation(user[0].longitude, user[0].latitude, books))
+      listOf(UserBooksWithLocation(UUID.randomUUID(), user[0].longitude, user[0].latitude, books))
   private val userBooksWithLocationLongList =
       listOf(
-          UserBooksWithLocation(userLongList[0].longitude, userLongList[0].latitude, longListBook))
+          UserBooksWithLocation(
+              UUID.randomUUID(), userLongList[0].longitude, userLongList[0].latitude, longListBook))
 
-  private val userWithoutBooks = listOf(UserBooksWithLocation(0.0, 0.0, emptyList()))
+  private val userWithoutBooks =
+      listOf(UserBooksWithLocation(UUID.randomUUID(), 0.0, 0.0, emptyList()))
   @get:Rule val composeTestRule = createComposeRule()
 
   private lateinit var mockBookManagerViewModel: BookManagerViewModel

--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -96,7 +96,8 @@ class MainActivity : ComponentActivity() {
     val navigationActions = NavigationActions(navController)
     val bookFilter = BookFilter()
     val userVM = UserViewModel(UUID.randomUUID(), userRepository)
-    val bookManagerViewModel = BookManagerViewModel(geolocation, bookRepository, user, bookFilter)
+    val bookManagerViewModel =
+        BookManagerViewModel(geolocation, bookRepository, userRepository, bookFilter)
 
     val currentUserUUID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
     val otherUserUUID = UUID.fromString("550e8400-e29b-41d4-a716-446655440001")
@@ -226,15 +227,3 @@ class MainActivity : ComponentActivity() {
     }
   }
 }
-
-// Temporary user list for the map as it is not yet linked to the database.
-// Better to see how the map screen should look like at the end.
-// Need to be removed in the future.
-val user =
-    listOf(
-        DataUser(longitude = 0.04, latitude = 0.04, bookList = listOf(UUID(12345678L, 87654321L))),
-        DataUser(longitude = -0.08, latitude = -0.08, bookList = listOf(UUID(-848484, 848484))),
-        DataUser(
-            longitude = 0.0,
-            latitude = 0.0,
-            bookList = listOf(UUID(763879565731911, 5074118859109511))))

--- a/app/src/main/java/com/android/bookswap/data/UserBooksWithLocation.kt
+++ b/app/src/main/java/com/android/bookswap/data/UserBooksWithLocation.kt
@@ -1,0 +1,18 @@
+package com.android.bookswap.data
+
+import java.util.UUID
+
+/**
+ * Represents a user's book collection along with their geographical location.
+ *
+ * @property userUUID Unique identifier for the user.
+ * @property longitude The user's longitude coordinate.
+ * @property latitude The user's latitude coordinate.
+ * @property books List of books associated with the user.
+ */
+data class UserBooksWithLocation(
+    val userUUID: UUID,
+    val longitude: Double,
+    val latitude: Double,
+    val books: List<DataBook>
+)

--- a/app/src/main/java/com/android/bookswap/data/source/network/UserFirestoreSource.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/network/UserFirestoreSource.kt
@@ -83,20 +83,26 @@ class UserFirestoreSource(private val db: FirebaseFirestore) : UsersRepository {
   fun documentToUser(document: DocumentSnapshot): Result<DataUser> {
 
     return try {
-      val userUUID = UUID.fromString(document.getString("UUID")!!)
-      val greeting = document.getString("Greeting")!!
-      val firstname = document.getString("Firstname")!!
-      val lastname = document.getString("Lastname")!!
-      val email = document.getString("Email")!!
-      val phoneNumber = document.getString("Phone")!!
-      val latitude = document.getDouble("Latitude")!!
-      val longitude = document.getDouble("Longitude")!!
-      val profilePicture = document.getString("Picture")!!
-      val bookList = (document.get("BookList") as List<String>).map { UUID.fromString(it) }
-      val googleUid = document.getString("GoogleUID")!!
+      val mostSignificantBits = document.getLong("userUUID.mostSignificantBits")!!
+      val leastSignificantBits = document.getLong("userUUID.leastSignificantBits")!!
+      val greeting = document.getString("greeting")!!
+      val firstname = document.getString("firstName")!!
+      val lastname = document.getString("lastName")!!
+      val email = document.getString("email")!!
+      val phoneNumber = document.getString("phoneNumber")!!
+      val latitude = document.getDouble("latitude")!!
+      val longitude = document.getDouble("longitude")!!
+      val profilePicture = document.getString("profilePictureUrl")!!
+      val googleUid = document.getString("googleUid")!!
+      val bookList =
+          (document.get("bookList") as List<Map<String, Long>>).map { bookMap ->
+            val mostSigBits = bookMap["mostSignificantBits"]!!
+            val leastSigBits = bookMap["leastSignificantBits"]!!
+            UUID(mostSigBits, leastSigBits)
+          }
       Result.success(
           DataUser(
-              userUUID,
+              UUID(mostSignificantBits, leastSignificantBits),
               greeting,
               firstname,
               lastname,

--- a/app/src/main/java/com/android/bookswap/model/map/BookManagerViewModel.kt
+++ b/app/src/main/java/com/android/bookswap/model/map/BookManagerViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import com.android.bookswap.data.DataBook
 import com.android.bookswap.data.DataUser
 import com.android.bookswap.data.repository.BooksRepository
+import com.android.bookswap.data.repository.UsersRepository
 import com.android.bookswap.ui.map.UserBooksWithLocation
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
@@ -23,16 +24,14 @@ private const val MAXIMUM_RETRIES = 3
  *
  * @param geolocation the geolocation of the current user
  * @param booksRepository an instance of [BooksRepository] to retrieve the books from the database.
- * @param listUser list of users [DataUser], will be replaced in the future by an instance of a
- *   UserFirestoreSource
+ * @param userRepository an instance of [UsersRepository] to retrieve the users from the database.
  * @param bookFilter an instance of [BookFilter] that manages the filter that needs to be applied.
  * @param computingDistanceMethod optional : a computation method for distances for testing purposes
  */
 class BookManagerViewModel(
     private val geolocation: IGeolocation,
     private val booksRepository: BooksRepository,
-    // TODO replace the listUser by a User repository to retrieve the users from the database
-    listUser: List<DataUser>,
+    private val userRepository: UsersRepository,
     private val bookFilter: BookFilter,
     // For the unit tests, the Android framework cannot be interacted with. The
     // Location.distanceBetween needs to be replaced for testing.
@@ -45,7 +44,7 @@ class BookManagerViewModel(
 ) : ViewModel() {
   // Internal MutableStateFlows to manage dynamic data
   private val _allBooks = MutableStateFlow<List<DataBook>>(emptyList())
-  private val _allUsers = MutableStateFlow(listUser)
+  private val _allUsers = MutableStateFlow<List<DataUser>>(emptyList())
   private val _allUserDistance = MutableStateFlow<List<Pair<DataUser, Double>>>(emptyList())
   private val _filteredBooks = MutableStateFlow<List<DataBook>>(emptyList())
   private val _filteredUsers = MutableStateFlow<List<UserBooksWithLocation>>(emptyList())
@@ -71,21 +70,30 @@ class BookManagerViewModel(
     scope.cancel()
   }
 
-  // Fetch books from the repository and update `_allBooks`
+  // Fetch books and users from the repository and update `_allBooks` and `_allUsers`
   private suspend fun fetchBooksFromRepository() {
-    var success = false
+    var successBooks = false
+    var successUsers = false
     var currentAttempt = 0
-    while (!success && currentAttempt < MAXIMUM_RETRIES) {
+    while ((!successBooks || !successUsers) && currentAttempt < MAXIMUM_RETRIES) {
+      userRepository.getUsers { users ->
+        if (users.isSuccess) {
+          _allUsers.value = users.getOrNull()!!
+          successUsers = true
+        } else {
+          Log.e("BookManagerViewModel", "Failed to fetch users.")
+        }
+      }
       booksRepository.getBook(
           OnSucess = { books ->
             _allBooks.value = books
-            success = true
+            successBooks = true
           },
           onFailure = { error ->
             Log.e("BookManagerViewModel", "Failed to fetch books: ${error.message}")
           })
 
-      if (!success) {
+      if (!successBooks || !successUsers) {
         currentAttempt++
         delay(RETRY_TIME_DELAY)
       }

--- a/app/src/main/java/com/android/bookswap/model/map/BookManagerViewModel.kt
+++ b/app/src/main/java/com/android/bookswap/model/map/BookManagerViewModel.kt
@@ -5,9 +5,9 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import com.android.bookswap.data.DataBook
 import com.android.bookswap.data.DataUser
+import com.android.bookswap.data.UserBooksWithLocation
 import com.android.bookswap.data.repository.BooksRepository
 import com.android.bookswap.data.repository.UsersRepository
-import com.android.bookswap.ui.map.UserBooksWithLocation
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 
@@ -114,6 +114,7 @@ class BookManagerViewModel(
             val userBooksWithLocation =
                 userDistance.map { user ->
                   UserBooksWithLocation(
+                      userUUID = user.first.userUUID,
                       longitude = user.first.longitude,
                       latitude = user.first.latitude,
                       books =

--- a/app/src/main/java/com/android/bookswap/ui/map/Map.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/Map.kt
@@ -494,9 +494,3 @@ private fun DisplayStarReview(rating: Int) {
     }
   }
 }
-
-data class UserBooksWithLocation(
-    val longitude: Double,
-    val latitude: Double,
-    val books: List<DataBook>
-)

--- a/app/src/test/java/com/android/bookswap/data/source/network/UserFirestoreSourceTest.kt
+++ b/app/src/test/java/com/android/bookswap/data/source/network/UserFirestoreSourceTest.kt
@@ -66,6 +66,23 @@ class UserFirestoreSourceTest {
     `when`(mockCollectionReference.document(ArgumentMatchers.any()))
         .thenReturn(mockDocumentReference)
     `when`(mockCollectionReference.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
+
+    `when`(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot))
+    `when`(mockDocumentSnapshot.getLong("userUUID.mostSignificantBits"))
+        .thenReturn(testUser.userUUID.mostSignificantBits)!!
+    `when`(mockDocumentSnapshot.getLong("userUUID.leastSignificantBits"))
+        .thenReturn(testUser.userUUID.leastSignificantBits)!!
+    `when`(mockDocumentSnapshot.getString("greeting")).thenReturn(testUser.greeting)
+    `when`(mockDocumentSnapshot.getString("firstName")).thenReturn(testUser.firstName)
+    `when`(mockDocumentSnapshot.getString("lastName")).thenReturn(testUser.lastName)
+    `when`(mockDocumentSnapshot.getString("email")).thenReturn(testUser.email)
+    `when`(mockDocumentSnapshot.getString("phoneNumber")).thenReturn(testUser.phoneNumber)
+    `when`(mockDocumentSnapshot.getDouble("latitude")).thenReturn(testUser.latitude)
+    `when`(mockDocumentSnapshot.getDouble("longitude")).thenReturn(testUser.longitude)
+    `when`(mockDocumentSnapshot.getString("profilePictureUrl"))
+        .thenReturn(testUser.profilePictureUrl)
+    `when`(mockDocumentSnapshot.get("bookList")).thenReturn(testUser.bookList)
+    `when`(mockDocumentSnapshot.getString("googleUid")).thenReturn(testUser.googleUid)
   }
 
   @After fun tearDown() {}
@@ -74,20 +91,6 @@ class UserFirestoreSourceTest {
 
   @Test
   fun getUsers() {
-    // Arrange
-    `when`(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot))
-    `when`(mockDocumentSnapshot.getString("UUID")).thenReturn(testUser.userUUID.toString())
-    `when`(mockDocumentSnapshot.getString("Greeting")).thenReturn(testUser.greeting)
-    `when`(mockDocumentSnapshot.getString("Firstname")).thenReturn(testUser.firstName)
-    `when`(mockDocumentSnapshot.getString("Lastname")).thenReturn(testUser.lastName)
-    `when`(mockDocumentSnapshot.getString("Email")).thenReturn(testUser.email)
-    `when`(mockDocumentSnapshot.getString("Phone")).thenReturn(testUser.phoneNumber)
-    `when`(mockDocumentSnapshot.getDouble("Latitude")).thenReturn(testUser.latitude)
-    `when`(mockDocumentSnapshot.getDouble("Longitude")).thenReturn(testUser.longitude)
-    `when`(mockDocumentSnapshot.getString("Picture")).thenReturn(testUser.profilePictureUrl)
-    `when`(mockDocumentSnapshot.get("BookList")).thenReturn(testUser.bookList)
-    `when`(mockDocumentSnapshot.getString("GoogleUID")).thenReturn(testUser.googleUid)
-
     // Act
     userFirestoreSource.getUsers { result ->
       result.fold(
@@ -106,21 +109,9 @@ class UserFirestoreSourceTest {
   @Test
   fun getUser() {
     // Arrange
-    `when`(mockQuerySnapshot.documents).thenReturn(listOf(mockDocumentSnapshot))
     `when`(mockCollectionReference.whereEqualTo(eq("UUID"), ArgumentMatchers.any()))
         .thenReturn(mockQuery)
     `when`(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
-    `when`(mockDocumentSnapshot.getString("UUID")).thenReturn(testUser.userUUID.toString())
-    `when`(mockDocumentSnapshot.getString("Greeting")).thenReturn(testUser.greeting)
-    `when`(mockDocumentSnapshot.getString("Firstname")).thenReturn(testUser.firstName)
-    `when`(mockDocumentSnapshot.getString("Lastname")).thenReturn(testUser.lastName)
-    `when`(mockDocumentSnapshot.getString("Email")).thenReturn(testUser.email)
-    `when`(mockDocumentSnapshot.getString("Phone")).thenReturn(testUser.phoneNumber)
-    `when`(mockDocumentSnapshot.getDouble("Latitude")).thenReturn(testUser.latitude)
-    `when`(mockDocumentSnapshot.getDouble("Longitude")).thenReturn(testUser.longitude)
-    `when`(mockDocumentSnapshot.getString("Picture")).thenReturn(testUser.profilePictureUrl)
-    `when`(mockDocumentSnapshot.get("BookList")).thenReturn(testUser.bookList)
-    `when`(mockDocumentSnapshot.getString("GoogleUID")).thenReturn(testUser.googleUid)
 
     // Act
     userFirestoreSource.getUser(testUser.userUUID) { result ->
@@ -180,19 +171,6 @@ class UserFirestoreSourceTest {
 
   @Test
   fun documentToUser_validDoc() {
-    // Arrange
-    `when`(mockDocumentSnapshot.getString("UUID")).thenReturn(testUser.userUUID.toString())
-    `when`(mockDocumentSnapshot.getString("Greeting")).thenReturn(testUser.greeting)
-    `when`(mockDocumentSnapshot.getString("Firstname")).thenReturn(testUser.firstName)
-    `when`(mockDocumentSnapshot.getString("Lastname")).thenReturn(testUser.lastName)
-    `when`(mockDocumentSnapshot.getString("Email")).thenReturn(testUser.email)
-    `when`(mockDocumentSnapshot.getString("Phone")).thenReturn(testUser.phoneNumber)
-    `when`(mockDocumentSnapshot.getDouble("Latitude")).thenReturn(testUser.latitude)
-    `when`(mockDocumentSnapshot.getDouble("Longitude")).thenReturn(testUser.longitude)
-    `when`(mockDocumentSnapshot.getString("Picture")).thenReturn(testUser.profilePictureUrl)
-    `when`(mockDocumentSnapshot.get("BookList")).thenReturn(testUser.bookList)
-    `when`(mockDocumentSnapshot.getString("GoogleUID")).thenReturn(testUser.googleUid)
-
     // Act
     val result = userFirestoreSource.documentToUser(mockDocumentSnapshot)
 
@@ -203,18 +181,7 @@ class UserFirestoreSourceTest {
 
   @Test
   fun documentToUser_invalidDoc() {
-    // Arrange
-    `when`(mockDocumentSnapshot.getString("UUID")).thenReturn(testUser.userUUID.toString())
-    `when`(mockDocumentSnapshot.getString("Greeting")).thenReturn(null)
-    `when`(mockDocumentSnapshot.getString("Firstname")).thenReturn(testUser.firstName)
-    `when`(mockDocumentSnapshot.getString("Lastname")).thenReturn(testUser.lastName)
-    `when`(mockDocumentSnapshot.getString("Email")).thenReturn(testUser.email)
-    `when`(mockDocumentSnapshot.getString("Phone")).thenReturn(testUser.phoneNumber)
-    `when`(mockDocumentSnapshot.getDouble("Latitude")).thenReturn(testUser.latitude)
-    `when`(mockDocumentSnapshot.getDouble("Longitude")).thenReturn(testUser.longitude)
-    `when`(mockDocumentSnapshot.getString("Picture")).thenReturn(testUser.profilePictureUrl)
-    `when`(mockDocumentSnapshot.get("BookList")).thenReturn(testUser.bookList)
-    `when`(mockDocumentSnapshot.getString("GoogleUID")).thenReturn(testUser.googleUid)
+    `when`(mockDocumentSnapshot.getString("greeting")).thenReturn(null)
 
     // Act
     val result = userFirestoreSource.documentToUser(mockDocumentSnapshot)

--- a/app/src/test/java/com/android/bookswap/model/map/BookManagerViewModelTest.kt
+++ b/app/src/test/java/com/android/bookswap/model/map/BookManagerViewModelTest.kt
@@ -21,8 +21,14 @@ import org.junit.Test
 class BookManagerViewModelTest {
 
   private val user1 =
-      DataUser(bookList = listOf(UUID(1, 2), UUID(2, 1)), longitude = 50.0, latitude = 50.0)
-  private val user2 = DataUser(bookList = listOf(UUID(1, 1)), longitude = 0.0, latitude = 0.0)
+      DataUser(
+          userUUID = UUID(1, 1),
+          bookList = listOf(UUID(1, 2), UUID(2, 1)),
+          longitude = 50.0,
+          latitude = 50.0)
+  private val user2 =
+      DataUser(
+          userUUID = UUID(2, 2), bookList = listOf(UUID(1, 1)), longitude = 0.0, latitude = 0.0)
   private val users = listOf(user2, user1)
 
   private val book1 =
@@ -64,18 +70,17 @@ class BookManagerViewModelTest {
   private val books = listOf(book3, book1, book2)
 
   private val userBooksWithLocation1 =
-      UserBooksWithLocation(
-          UUID.randomUUID(), user1.longitude, user1.latitude, listOf(book1, book2))
+      UserBooksWithLocation(user1.userUUID, user1.longitude, user1.latitude, listOf(book1, book2))
 
   private val userBooksWithLocation2 =
-      UserBooksWithLocation(UUID.randomUUID(), user2.longitude, user2.latitude, listOf(book3))
+      UserBooksWithLocation(user2.userUUID, user2.longitude, user2.latitude, listOf(book3))
 
   private val userBooksWithLocation = listOf(userBooksWithLocation2, userBooksWithLocation1)
 
   private val filteredBooksWithLocation =
       listOf(
           userBooksWithLocation2,
-          UserBooksWithLocation(UUID.randomUUID(), user1.longitude, user1.latitude, emptyList()))
+          UserBooksWithLocation(user1.userUUID, user1.longitude, user1.latitude, emptyList()))
 
   private val geolocation1 = listOf(0.0, 0.0)
   private val geolocation2 = listOf(100.0, 100.0)


### PR DESCRIPTION
This PR add the functionnality of retrieving the users from the firebase to the bookManager, it uses the same logic as to retrieve the books. During the development, it appeared that the function documentToUser of the UserFirestoreSource had the wrong strings to get the book and the bookList wasn't properly handled. 
This PR also moved the data class UserBooksWithLocation to its own file and added the useruuid to it. It was made as this class shouldn't be in the Map UI file and this PR already modified all the file using this dataclass, so I decided to do that in the process. The addition of useruuid is for a potential future feature that was talked, needing the userUUID on the marker.