### PR TITLE
Fix the documentToBooks in the BooksFirestoreSource

### DIFF
--- a/app/src/main/java/com/android/bookswap/data/source/network/BookFirestoreSource.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/network/BookFirestoreSource.kt
@@ -93,7 +93,8 @@ class BooksFirestoreSource(private val db: FirebaseFirestore) : BooksRepository 
   // If any required field is missing, returns null to avoid incomplete objects
   fun documentToBooks(document: DocumentSnapshot): DataBook? {
     return try {
-      val uuid = UUID.fromString(document.getString("uuid")) ?: return null
+      val mostSignificantBits = document.getLong("uuid.mostSignificantBits") ?: return null
+      val leastSignificantBits = document.getLong("uuid.leastSignificantBits") ?: return null
       val title = document.getString("title") ?: return null
       val author = document.getString("author")
       val description = document.getString("description")
@@ -111,7 +112,15 @@ class BooksFirestoreSource(private val db: FirebaseFirestore) : BooksRepository 
             }
           }
       DataBook(
-          uuid, title, author, description, rating?.toInt(), photo, languageBook, isbn, bookGenres)
+          UUID(mostSignificantBits, leastSignificantBits),
+          title,
+          author,
+          description,
+          rating?.toInt(),
+          photo,
+          languageBook,
+          isbn,
+          bookGenres)
     } catch (e: Exception) {
       null // Return null in case of any exception during the conversion
     }

--- a/app/src/test/java/com/android/bookswap/data/source/network/BooksFirestoreSourceTest.kt
+++ b/app/src/test/java/com/android/bookswap/data/source/network/BooksFirestoreSourceTest.kt
@@ -53,8 +53,11 @@ class BooksFirestoreSourceTest {
     every { mockDocumentSnapshot.getString("photo") }.returns(testBook.photo)
     every { mockDocumentSnapshot.getString("language") }.returns(testBook.language.name)
     every { mockDocumentSnapshot.getString("isbn") }.returns(testBook.isbn)
-    every { mockDocumentSnapshot.getString("uuid") }.returns(testBook.uuid.toString())
     every { mockDocumentSnapshot.get("genres") }.returns(emptyList<String>())
+    every { mockDocumentSnapshot.getLong("uuid.mostSignificantBits") }
+        .returns(testBook.uuid.mostSignificantBits)
+    every { mockDocumentSnapshot.getLong("uuid.leastSignificantBits") }
+        .returns(testBook.uuid.leastSignificantBits)
   }
 
   @Test


### PR DESCRIPTION
This PR fixes the problem of the documentToBooks using the wrong method to retrieve the uuid of the book. It uses the old way of handling the uuid.