### PR TITLE
Fix the book manager view model

### DIFF
--- a/app/src/main/java/com/android/bookswap/model/map/BookManagerViewModel.kt
+++ b/app/src/main/java/com/android/bookswap/model/map/BookManagerViewModel.kt
@@ -54,9 +54,10 @@ class BookManagerViewModel(
   val filteredUsers: StateFlow<List<UserBooksWithLocation>> = _filteredUsers.asStateFlow()
 
   private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private var updateBooksJob: Job? = null
 
   fun startUpdatingBooks() {
-    scope.launch {
+      updateBooksJob = scope.launch {
       while (true) {
         fetchBooksFromRepository()
         delay(REFRESH_TIME_DELAY)
@@ -67,7 +68,7 @@ class BookManagerViewModel(
   }
 
   fun stopUpdatingBooks() {
-    scope.cancel()
+      updateBooksJob?.cancel()
   }
 
   // Fetch books and users from the repository and update `_allBooks` and `_allUsers`

--- a/app/src/main/java/com/android/bookswap/model/map/BookManagerViewModel.kt
+++ b/app/src/main/java/com/android/bookswap/model/map/BookManagerViewModel.kt
@@ -54,21 +54,22 @@ class BookManagerViewModel(
   val filteredUsers: StateFlow<List<UserBooksWithLocation>> = _filteredUsers.asStateFlow()
 
   private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private var updateBooksJob: Job? = null
+  private var updateBooksJob: Job? = null
 
   fun startUpdatingBooks() {
-      updateBooksJob = scope.launch {
-      while (true) {
-        fetchBooksFromRepository()
-        delay(REFRESH_TIME_DELAY)
-      }
-    }
+    updateBooksJob =
+        scope.launch {
+          while (true) {
+            fetchBooksFromRepository()
+            delay(REFRESH_TIME_DELAY)
+          }
+        }
     computeDistanceOfUsers()
     combineFlowsAndFilterBooks()
   }
 
   fun stopUpdatingBooks() {
-      updateBooksJob?.cancel()
+    updateBooksJob?.cancel()
   }
 
   // Fetch books and users from the repository and update `_allBooks` and `_allUsers`
@@ -116,16 +117,18 @@ class BookManagerViewModel(
               _,
               _ ->
             val userBooksWithLocation =
-                userDistance.map { user ->
-                  UserBooksWithLocation(
-                      userUUID = user.first.userUUID,
-                      longitude = user.first.longitude,
-                      latitude = user.first.latitude,
-                      books =
-                          bookFilter.filterBooks(books).filter { book ->
-                            book.uuid in user.first.bookList
-                          })
-                }
+                userDistance
+                    .map { user ->
+                      UserBooksWithLocation(
+                          userUUID = user.first.userUUID,
+                          longitude = user.first.longitude,
+                          latitude = user.first.latitude,
+                          books =
+                              bookFilter.filterBooks(books).filter { book ->
+                                book.uuid in user.first.bookList
+                              })
+                    }
+                    .filter { it.books.isNotEmpty() }
 
             _filteredBooks.value = userBooksWithLocation.flatMap { it.books }
             _filteredUsers.value = userBooksWithLocation

--- a/app/src/main/java/com/android/bookswap/model/map/BookManagerViewModel.kt
+++ b/app/src/main/java/com/android/bookswap/model/map/BookManagerViewModel.kt
@@ -54,7 +54,7 @@ class BookManagerViewModel(
   val filteredUsers: StateFlow<List<UserBooksWithLocation>> = _filteredUsers.asStateFlow()
 
   private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-  private var fetchBooksFromRepository: Job? = null
+  private var fetchBooksFromRepositoryJob: Job? = null
   private var computeDistanceOfUsersJob: Job? = null
   private var combineFlowsAndFilterBooksJob: Job? = null
 
@@ -66,7 +66,7 @@ class BookManagerViewModel(
    * distances and combines the flows to filter books based on user preferences.
    */
   fun startUpdatingBooks() {
-    fetchBooksFromRepository =
+    fetchBooksFromRepositoryJob =
         scope.launch {
           while (true) {
             fetchBooksFromRepository()
@@ -78,7 +78,7 @@ class BookManagerViewModel(
   }
   /** Stops updating books by canceling the coroutine scope. */
   fun stopUpdatingBooks() {
-    fetchBooksFromRepository?.cancel()
+    fetchBooksFromRepositoryJob?.cancel()
     computeDistanceOfUsersJob?.cancel()
     combineFlowsAndFilterBooksJob?.cancel()
   }

--- a/app/src/test/java/com/android/bookswap/model/map/BookManagerViewModelTest.kt
+++ b/app/src/test/java/com/android/bookswap/model/map/BookManagerViewModelTest.kt
@@ -77,10 +77,7 @@ class BookManagerViewModelTest {
 
   private val userBooksWithLocation = listOf(userBooksWithLocation2, userBooksWithLocation1)
 
-  private val filteredBooksWithLocation =
-      listOf(
-          userBooksWithLocation2,
-          UserBooksWithLocation(user1.userUUID, user1.longitude, user1.latitude, emptyList()))
+  private val filteredBooksWithLocation = listOf(userBooksWithLocation2)
 
   private val geolocation1 = listOf(0.0, 0.0)
   private val geolocation2 = listOf(100.0, 100.0)
@@ -150,6 +147,23 @@ class BookManagerViewModelTest {
     val bookManagerViewModel =
         BookManagerViewModel(
             mockGeolocation1, mockBookRepository, mockUsersRepository, mockBookFilter, sortingTest)
+    bookManagerViewModel.startUpdatingBooks()
+    bookManagerViewModel.filteredBooks.first { it != emptyList<DataBook>() }
+    bookManagerViewModel.filteredUsers.first { it != emptyList<UserBooksWithLocation>() }
+    assertEquals(listOf(book3), bookManagerViewModel.filteredBooks.value)
+    assertEquals(filteredBooksWithLocation, bookManagerViewModel.filteredUsers.value)
+    bookManagerViewModel.stopUpdatingBooks()
+  }
+
+  @Test
+  fun startUpdatingWorksAfterStop() = runTest {
+    val bookManagerViewModel =
+        BookManagerViewModel(
+            mockGeolocation1, mockBookRepository, mockUsersRepository, mockBookFilter, sortingTest)
+    every { mockBookFilter.filterBooks(any()) } answers { emptyList() }
+    bookManagerViewModel.startUpdatingBooks()
+    bookManagerViewModel.stopUpdatingBooks()
+    every { mockBookFilter.filterBooks(any()) } answers { listOf(book3) }
     bookManagerViewModel.startUpdatingBooks()
     bookManagerViewModel.filteredBooks.first { it != emptyList<DataBook>() }
     bookManagerViewModel.filteredUsers.first { it != emptyList<UserBooksWithLocation>() }


### PR DESCRIPTION
This PR fixes the problem of certain CustomInfoWindows that didn't appear. It was because the book manager's list of user also contained the user without books, so the selectedUser value pointed to the wrong user. They were removed of this list as they should be filtered out for the map screen. 
This PR also removed the problem of the update logic of book manager. When stopping the updates, the book manager killed the coroutine so it couldn't be restarted. Therefore, once the user goes away of the map screen to go to another screen like the filter map screen, the book manager wouldn't start updating again after going back to the map screen. It was fixed by canceling the jobs of the coroutine and not the coroutine.