### PR TITLE
Add Dropdown for Language selection in `AddToBookScreen`

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/endtoend/AddBooksEndToEnd.kt
+++ b/app/src/androidTest/java/com/android/bookswap/endtoend/AddBooksEndToEnd.kt
@@ -3,6 +3,7 @@ package com.android.bookswap.endtoend
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import com.android.bookswap.MainActivity
@@ -45,9 +46,12 @@ class AddBooksEndToEnd {
 
     every { mockBookRepository.addBook(any(), any()) } just runs
 
-    mockedBook =
+    val testUUID = UUID.randomUUID()
+      every { mockBookRepository.getNewUUID() } returns testUUID
+
+      mockedBook =
         DataBook(
-            uuid = UUID.randomUUID(),
+            uuid = testUUID,
             title = "The Great Gatsby",
             author = "F. Scott Fitzgerald",
             description = "A classic novel set in the Jazz Age.",
@@ -100,10 +104,10 @@ class AddBooksEndToEnd {
     composeTestRule.onNodeWithTag("rating_field").performTextInput("5")
     composeTestRule.onNodeWithTag("isbn_field").performTextInput("9780743273565")
     composeTestRule.onNodeWithTag("photo_field").performTextInput("photo_url_test")
-    composeTestRule.onNodeWithTag("language_field").performTextInput("English")
-
     composeTestRule.onNodeWithTag("genre_field").performClick()
     composeTestRule.onNode(hasText("Fiction")).performClick()
+    composeTestRule.onNodeWithTag("language_field").performClick()
+    composeTestRule.onNodeWithText("English").performClick()
 
     composeTestRule.onNodeWithTag("save_button").performClick()
 

--- a/app/src/androidTest/java/com/android/bookswap/endtoend/AddBooksEndToEnd.kt
+++ b/app/src/androidTest/java/com/android/bookswap/endtoend/AddBooksEndToEnd.kt
@@ -47,9 +47,9 @@ class AddBooksEndToEnd {
     every { mockBookRepository.addBook(any(), any()) } just runs
 
     val testUUID = UUID.randomUUID()
-      every { mockBookRepository.getNewUUID() } returns testUUID
+    every { mockBookRepository.getNewUUID() } returns testUUID
 
-      mockedBook =
+    mockedBook =
         DataBook(
             uuid = testUUID,
             title = "The Great Gatsby",

--- a/app/src/androidTest/java/com/android/bookswap/ui/books/add/addBookTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/books/add/addBookTest.kt
@@ -2,10 +2,14 @@ package com.android.bookswap.ui.books.add
 
 import android.content.Context
 import android.widget.Toast
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.navigation.compose.rememberNavController
@@ -146,5 +150,60 @@ class AddToBookTest {
 
     // Check if the Save button is still disabled
     composeTestRule.onNodeWithTag("save_button").assertIsNotEnabled()
+  }
+
+  @Test
+  fun testDropdownMenuIsInitiallyClosed() {
+    composeTestRule.setContent { AddToBookScreen(mockBooksRepository) }
+
+    // Verify that the dropdown menu is initially not expanded
+    composeTestRule.onNodeWithTag("language_field").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Language*").assertIsDisplayed()
+  }
+
+  @Test
+  fun testDropdownMenuOpensOnClick() {
+    composeTestRule.setContent { AddToBookScreen(mockBooksRepository) }
+
+    // Simulate clicking the dropdown to expand it
+    composeTestRule.onNodeWithTag("language_field").performClick()
+
+    // Verify that dropdown items are displayed:
+    composeTestRule.onNodeWithText("French").assertIsDisplayed()
+    composeTestRule.onNodeWithText("German").assertIsDisplayed()
+    composeTestRule.onNodeWithText("English").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Spanish").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Italian").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Romansh").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Other").assertIsDisplayed()
+  }
+
+  @Test
+  fun testDropdownMenuItemSelection() {
+    composeTestRule.setContent { AddToBookScreen(mockBooksRepository) }
+
+    // Expand the dropdown menu:
+    composeTestRule.onNodeWithTag("language_field").performClick()
+
+    // Click on a specific language ("English")
+    composeTestRule.onNodeWithText("English").performClick()
+
+    // Verify the language field updates with the selected language
+    composeTestRule.onNodeWithText("English").assertExists()
+  }
+
+  @Test
+  fun testDropdownMenuClosesAfterSelection() {
+    composeTestRule.setContent { AddToBookScreen(mockBooksRepository) }
+
+    // Expand the dropdown menu
+    composeTestRule.onNodeWithTag("language_field").performClick()
+
+    // Select a language to close the dropdown
+    composeTestRule.onNodeWithText("English").performClick()
+
+    // Ensure the dropdown items are no longer displayed (here we juste looks that Italian is not
+    // visible)
+    composeTestRule.onNodeWithText("Italian").assertDoesNotExist()
   }
 }

--- a/app/src/androidTest/java/com/android/bookswap/ui/books/add/addBookTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/books/add/addBookTest.kt
@@ -2,11 +2,9 @@ package com.android.bookswap.ui.books.add
 
 import android.content.Context
 import android.widget.Toast
-import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText

--- a/app/src/androidTest/java/com/android/bookswap/ui/books/add/addBookTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/books/add/addBookTest.kt
@@ -171,7 +171,8 @@ class AddToBookTest {
 
   @Test
   fun testDropdownMenuIsInitiallyClosed() {
-    composeTestRule.setContent { AddToBookScreen(mockBooksRepository) }
+    val userId = UUID.randomUUID()
+    composeTestRule.setContent { AddToBookScreen(mockBooksRepository, userId = userId) }
 
     // Verify that the dropdown menu is initially not expanded
     composeTestRule.onNodeWithTag("language_field").assertIsDisplayed()
@@ -180,7 +181,8 @@ class AddToBookTest {
 
   @Test
   fun testDropdownMenuOpensOnClick() {
-    composeTestRule.setContent { AddToBookScreen(mockBooksRepository) }
+    val userId = UUID.randomUUID()
+    composeTestRule.setContent { AddToBookScreen(mockBooksRepository, userId = userId) }
 
     // Simulate clicking the dropdown to expand it
     composeTestRule.onNodeWithTag("language_field").performClick()
@@ -197,7 +199,9 @@ class AddToBookTest {
 
   @Test
   fun testDropdownMenuItemSelection() {
-    composeTestRule.setContent { AddToBookScreen(mockBooksRepository) }
+    val userId = UUID.randomUUID()
+
+    composeTestRule.setContent { AddToBookScreen(mockBooksRepository, userId = userId) }
 
     // Expand the dropdown menu:
     composeTestRule.onNodeWithTag("language_field").performClick()
@@ -211,7 +215,9 @@ class AddToBookTest {
 
   @Test
   fun testDropdownMenuClosesAfterSelection() {
-    composeTestRule.setContent { AddToBookScreen(mockBooksRepository) }
+    val userId = UUID.randomUUID()
+
+    composeTestRule.setContent { AddToBookScreen(mockBooksRepository, userId = userId) }
 
     // Expand the dropdown menu
     composeTestRule.onNodeWithTag("language_field").performClick()

--- a/app/src/main/java/com/android/bookswap/data/DataBook.kt
+++ b/app/src/main/java/com/android/bookswap/data/DataBook.kt
@@ -28,13 +28,13 @@ data class DataBook(
 
 /** All supported book language type */
 enum class BookLanguages(val languageCode: String) {
-  FRENCH("FR"), // French language
-  GERMAN("DE"), // German language
-  ENGLISH("EN"), // English language
-  SPANISH("ES"), // Spanish language
-  ITALIAN("IT"), // Italian language
-  ROMANSH("RM"), // Romansh, a language spoken in Switzerland
-  OTHER("OTHER") // All languages that are not yet implemented
+  FRENCH("French"), // French language
+  GERMAN("German"), // German language
+  ENGLISH("English"), // English language
+  SPANISH("Spanish"), // Spanish language
+  ITALIAN("Italian"), // Italian language
+  ROMANSH("Romansh"), // Romansh, a language spoken in Switzerland
+  OTHER("Other") // All languages that are not yet implemented
 }
 /** Genre of a book */
 enum class BookGenres(val Genre: String = "Other") {

--- a/app/src/main/java/com/android/bookswap/data/source/api/GoogleBookDataSource.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/api/GoogleBookDataSource.kt
@@ -58,11 +58,10 @@ class GoogleBookDataSource(context: Context) {
       // we do not always use get..OrNull()
       val item = json.getJSONArray("items").getJSONObject(0).getJSONObject("volumeInfo")
 
-      val language =
-          when (val languageCode = item.getStringOrNull("language")?.uppercase()) {
-            is String -> BookLanguages.values().first { it.languageCode == languageCode }
-            else -> null
-          }
+        val language =
+            item.getStringOrNull("language")?.lowercase()?.let { languageCode ->
+                BookLanguages.values().find { it.languageCode.equals(languageCode, ignoreCase = true) }
+            } ?: BookLanguages.OTHER
 
       // We do not know where the ISBN_13 is, so we need to filter for it
       val industryIdentifiers = item.getJSONArray("industryIdentifiers")

--- a/app/src/main/java/com/android/bookswap/data/source/api/GoogleBookDataSource.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/api/GoogleBookDataSource.kt
@@ -58,10 +58,10 @@ class GoogleBookDataSource(context: Context) {
       // we do not always use get..OrNull()
       val item = json.getJSONArray("items").getJSONObject(0).getJSONObject("volumeInfo")
 
-        val language =
-            item.getStringOrNull("language")?.lowercase()?.let { languageCode ->
-                BookLanguages.values().find { it.languageCode.equals(languageCode, ignoreCase = true) }
-            } ?: BookLanguages.OTHER
+      val language =
+          item.getStringOrNull("language")?.lowercase()?.let { languageCode ->
+            BookLanguages.values().find { it.languageCode.equals(languageCode, ignoreCase = true) }
+          } ?: BookLanguages.OTHER
 
       // We do not know where the ISBN_13 is, so we need to filter for it
       val industryIdentifiers = item.getJSONArray("industryIdentifiers")

--- a/app/src/main/java/com/android/bookswap/ui/books/add/AddToBook.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/add/AddToBook.kt
@@ -56,7 +56,10 @@ fun AddToBookScreen(
   var rating by remember { mutableStateOf("") }
   var isbn by remember { mutableStateOf("") }
   var photo by remember { mutableStateOf("") }
-  var language by remember { mutableStateOf("") }
+  // var language by remember { mutableStateOf("") }
+  var selectedLanguage by remember {
+    mutableStateOf<BookLanguages?>(null)
+  } // Language selection state
   var selectedGenre by remember { mutableStateOf<BookGenres?>(null) } // Genre selection state
   var expanded by remember { mutableStateOf(false) } // State for dropdown menu
   var expandedLanguage by remember { mutableStateOf(false) } // State for dropdown menu Language
@@ -166,6 +169,7 @@ fun AddToBookScreen(
                   value = photo) {
                     photo = it
                   }
+              /*
               FieldComponent(
                   modifier =
                       Modifier.testTag("language_field")
@@ -174,7 +178,40 @@ fun AddToBookScreen(
                   labelText = "Language",
                   value = language) {
                     language = it
+                  }*/
+              // Language Dropdown:
+              ExposedDropdownMenuBox(
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .padding(horizontal = HORIZONTAL_PADDING.dp)
+                          .testTag("language_field"),
+                  expanded = expandedLanguage,
+                  onExpandedChange = { expandedLanguage = !expandedLanguage }) {
+                    FieldComponent(
+                        value = selectedLanguage?.languageCode ?: "",
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text(text = "Language*") },
+                        modifier = Modifier.menuAnchor().fillMaxWidth())
+                    ExposedDropdownMenu(
+                        expanded = expandedLanguage,
+                        onDismissRequest = { expandedLanguage = false },
+                        modifier = Modifier.fillMaxWidth()) {
+                          BookLanguages.values().forEach { language ->
+                            DropdownMenuItem(
+                                text = {
+                                  Text(
+                                      text = language.languageCode,
+                                  )
+                                },
+                                onClick = {
+                                  selectedLanguage = language
+                                  expandedLanguage = false
+                                })
+                          }
+                        }
                   }
+
               ButtonComponent(
                   modifier =
                       Modifier.testTag("save_button")
@@ -194,7 +231,7 @@ fun AddToBookScreen(
                               description,
                               rating,
                               photo,
-                              language,
+                              selectedLanguage.toString(),
                               isbn,
                               listOf(selectedGenre!!))
                       if (book == null) {

--- a/app/src/test/java/com/android/bookswap/data/source/api/GoogleBookDataSourceTest.kt
+++ b/app/src/test/java/com/android/bookswap/data/source/api/GoogleBookDataSourceTest.kt
@@ -74,7 +74,7 @@ class GoogleBookDataSourceTest {
                 "smallThumbnail": "image1",
                 "thumbnail": "image2"
               },
-              "language": "en"
+              "language": "English"
             }
           }
         ]
@@ -131,7 +131,7 @@ class GoogleBookDataSourceTest {
                 "smallThumbnail": "image1",
                 "thumbnail": "image2"
               },
-              "language": "en"
+              "language": "English"
             }
           }
         ]


### PR DESCRIPTION
This PR introduces a dropdown menu for selecting the language in the `AddToBookScreen` UI. The changes improve user interaction by allowing selection from a predefined list of supported book languages instead of manually inputting the language. Additionally, it updates the test cases to validate the functionality of the new dropdown menu.

### Modification:

#### **Implement the UI for Languages:**
Implement the Language dropdown menu using a `ExposedDropdownMenuBox` and `ExposedDropdownMenu`

#### **Add test :**
1. Added and updated test cases in AddBookTest.kt to ensure:
    - The dropdown menu is initially closed (`testDropdownMenuIsInitiallyClosed`).
    - The dropdown opens on click and displays all supported languages (`testDropdownMenuOpensOnClick`).
    - A language can be selected and is reflected correctly in the field (`testDropdownMenuItemSelection`).
    - The dropdown menu closes after a language is selected (`testDropdownMenuClosesAfterSelection`).
2. Modify the `GoogleBookDataSourceTest` to use the new format of the Language for the DataBook
  
### **UI visual representation:**  
![Screenshot 2024-11-21 104931](https://github.com/user-attachments/assets/c1e80dda-dec5-4df1-abc9-41472ad73eb0)


