### PR TITLE
Add common AppConfig available in all the Components

### DIFF
--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -64,7 +64,7 @@ import java.util.UUID
 
 class MainActivity : ComponentActivity() {
 
-    override fun onCreate(savedInstanceState: Bundle?) {
+  override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     // permissionHandler = PermissionHandler(this)
     // permissionHandler.askNotificationPermission()

--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -29,6 +29,8 @@ import com.android.bookswap.data.source.network.BooksFirestoreSource
 import com.android.bookswap.data.source.network.MessageFirestoreSource
 import com.android.bookswap.data.source.network.PhotoFirebaseStorageSource
 import com.android.bookswap.data.source.network.UserFirestoreSource
+import com.android.bookswap.model.AppConfig
+import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.model.UserViewModel
 import com.android.bookswap.model.chat.ContactViewModel
 import com.android.bookswap.model.chat.OfflineMessageStorage
@@ -154,115 +156,118 @@ class MainActivity : ComponentActivity() {
               selectedItem = s ?: "")
         }
 
-    NavHost(navController = navController, startDestination = startDestination) {
-      navigation(startDestination = C.Screen.AUTH, route = C.Route.AUTH) {
-        composable(C.Screen.AUTH) { SignInScreen(navigationActions, userVM) }
-        composable(C.Screen.NEW_USER) { NewUserScreen(navigationActions, userVM) }
-      }
-      navigation(startDestination = C.Screen.CHAT_LIST, route = C.Route.CHAT_LIST) {
-        composable(C.Screen.CHAT_LIST) {
-          ListChatScreen(
-              navigationActions,
-              topAppBar = { topAppBar("Messages") },
-              bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
-              contactViewModel = contactViewModel)
-        }
-        composable("${C.Screen.CHAT}/{user2}") { backStackEntry ->
-          val user2UUID = UUID.fromString(backStackEntry.arguments?.getString("user2"))
-          val user2: DataUser? = contactViewModel.getUserInMessageBoxMap(user2UUID)
-          if (user2 != null) {
-            ChatScreen(
-                messageRepository,
-                userVM.getUser(),
-                user2,
-                navigationActions,
-                photoStorage,
-                messageStorage,
-                context)
-          } else {
-            BookAdditionChoiceScreen(
-                navigationActions,
-                topAppBar = { topAppBar("Add a Book") },
-                bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
-                photoFirebaseStorageRepository = photoStorage,
-                booksRepository = bookRepository,
-                userUUID = userVM.uuid)
-          }
-        }
-      }
-      navigation(startDestination = C.Screen.MAP, route = C.Route.MAP) {
-        composable(C.Screen.MAP) {
-          MapScreen(
-              bookManagerViewModel,
-              navigationActions = navigationActions,
-              geolocation = geolocation,
-              topAppBar = { topAppBar("Map") },
-              bottomAppBar = { bottomAppBar(this@navigation.route ?: "") })
-        }
-        composable(C.Screen.MAP_FILTER) { FilterMapScreen(navigationActions, bookFilter) }
-      }
-      navigation(startDestination = C.Screen.NEW_BOOK, route = C.Route.NEW_BOOK) {
-        composable(C.Screen.NEW_BOOK) {
-          BookAdditionChoiceScreen(
-              navigationActions,
-              topAppBar = { topAppBar("Add a Book") },
-              bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
-              photoFirebaseStorageRepository = photoStorage,
-              booksRepository = bookRepository,
-              userUUID = userVM.uuid)
-        }
-        composable(C.Screen.ADD_BOOK_MANUALLY) {
-          AddToBookScreen(
-              bookRepository,
-              userVM,
-              topAppBar = { topAppBar("Add your Book") },
-              bottomAppBar = { bottomAppBar(this@navigation.route ?: "") })
-        }
-        composable(C.Screen.ADD_BOOK_ISBN) {
-          AddISBNScreen(
-              navigationActions,
-              bookRepository,
-              userVM,
-              topAppBar = { topAppBar(null) },
-              bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
-          )
-        }
-      }
-      navigation(startDestination = C.Screen.USER_PROFILE, route = C.Route.USER_PROFILE) {
-        composable(C.Screen.USER_PROFILE) { UserProfile(userVM) }
-        composable(C.Screen.BOOK_PROFILE) { backStackEntry ->
-          val bookId = backStackEntry.arguments?.getString("bookId")?.let { UUID.fromString(it) }
+      //CompositionLocalProvider provides LocalAppConfig to every child
+      CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = userVM) ) {
+          NavHost(navController = navController, startDestination = startDestination) {
+              navigation(startDestination = C.Screen.AUTH, route = C.Route.AUTH) {
+                  composable(C.Screen.AUTH) { SignInScreen(navigationActions, userVM) }
+                  composable(C.Screen.NEW_USER) { NewUserScreen(navigationActions, userVM) }
+              }
+              navigation(startDestination = C.Screen.CHAT_LIST, route = C.Route.CHAT_LIST) {
+                  composable(C.Screen.CHAT_LIST) {
+                      ListChatScreen(
+                          navigationActions,
+                          topAppBar = { topAppBar("Messages") },
+                          bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
+                          contactViewModel = contactViewModel)
+                  }
+                  composable("${C.Screen.CHAT}/{user2}") { backStackEntry ->
+                      val user2UUID = UUID.fromString(backStackEntry.arguments?.getString("user2"))
+                      val user2: DataUser? = contactViewModel.getUserInMessageBoxMap(user2UUID)
+                      if (user2 != null) {
+                          ChatScreen(
+                              messageRepository,
+                              userVM.getUser(),
+                              user2,
+                              navigationActions,
+                              photoStorage,
+                              messageStorage,
+                              context)
+                      } else {
+                          BookAdditionChoiceScreen(
+                              navigationActions,
+                              topAppBar = { topAppBar("Add a Book") },
+                              bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
+                              photoFirebaseStorageRepository = photoStorage,
+                              booksRepository = bookRepository,
+                              userUUID = userVM.uuid)
+                      }
+                  }
+              }
+              navigation(startDestination = C.Screen.MAP, route = C.Route.MAP) {
+                  composable(C.Screen.MAP) {
+                      MapScreen(
+                          bookManagerViewModel,
+                          navigationActions = navigationActions,
+                          geolocation = geolocation,
+                          topAppBar = { topAppBar("Map") },
+                          bottomAppBar = { bottomAppBar(this@navigation.route ?: "") })
+                  }
+                  composable(C.Screen.MAP_FILTER) { FilterMapScreen(navigationActions, bookFilter) }
+              }
+              navigation(startDestination = C.Screen.NEW_BOOK, route = C.Route.NEW_BOOK) {
+                  composable(C.Screen.NEW_BOOK) {
+                      BookAdditionChoiceScreen(
+                          navigationActions,
+                          topAppBar = { topAppBar("Add a Book") },
+                          bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
+                          photoFirebaseStorageRepository = photoStorage,
+                          booksRepository = bookRepository,
+                          userUUID = userVM.uuid)
+                  }
+                  composable(C.Screen.ADD_BOOK_MANUALLY) {
+                      AddToBookScreen(
+                          bookRepository,
+                          userVM,
+                          topAppBar = { topAppBar("Add your Book") },
+                          bottomAppBar = { bottomAppBar(this@navigation.route ?: "") })
+                  }
+                  composable(C.Screen.ADD_BOOK_ISBN) {
+                      AddISBNScreen(
+                          navigationActions,
+                          bookRepository,
+                          userVM,
+                          topAppBar = { topAppBar(null) },
+                          bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
+                      )
+                  }
+              }
+              navigation(startDestination = C.Screen.USER_PROFILE, route = C.Route.USER_PROFILE) {
+                  composable(C.Screen.USER_PROFILE) { UserProfile(userVM) }
+                  composable(C.Screen.BOOK_PROFILE) { backStackEntry ->
+                      val bookId = backStackEntry.arguments?.getString("bookId")?.let { UUID.fromString(it) }
 
-          if (bookId != null) {
-            BookProfileScreen(
-                bookId = bookId ?: UUID.randomUUID(), // Default for testing
-                booksRepository = BooksFirestoreSource(FirebaseFirestore.getInstance()),
-                navController = NavigationActions(navController),
-                currentUserId = UUID.randomUUID() // Pass the actual logged-in user ID
-                )
-          } else {
-            Log.e("Navigation", "Invalid bookId passed to BookProfileScreen")
-          }
-        }
-        composable("${C.Screen.EDIT_BOOK}/{bookId}") { backStackEntry ->
-          val bookId = backStackEntry.arguments?.getString("bookId")?.let { UUID.fromString(it) }
-          var book: DataBook? = null // How to create a book that will be assigned after ?
-          // Fetch book data
-          if (bookId != null) {
+                      if (bookId != null) {
+                          BookProfileScreen(
+                              bookId = bookId ?: UUID.randomUUID(), // Default for testing
+                              booksRepository = BooksFirestoreSource(FirebaseFirestore.getInstance()),
+                              navController = NavigationActions(navController),
+                              currentUserId = UUID.randomUUID() // Pass the actual logged-in user ID
+                          )
+                      } else {
+                          Log.e("Navigation", "Invalid bookId passed to BookProfileScreen")
+                      }
+                  }
+                  composable("${C.Screen.EDIT_BOOK}/{bookId}") { backStackEntry ->
+                      val bookId = backStackEntry.arguments?.getString("bookId")?.let { UUID.fromString(it) }
+                      var book: DataBook? = null // How to create a book that will be assigned after ?
+                      // Fetch book data
+                      if (bookId != null) {
 
-            bookRepository.getBook(
-                uuid = bookId,
-                OnSucess = { fetchedbook -> book = fetchedbook },
-                onFailure = { Log.d("EditScreen", "Error while loading the book") })
-            EditBookScreen(
-                booksRepository = bookRepository,
-                navigationActions = NavigationActions(navController),
-                book = book!!)
-          } else {
-            Log.e("Navigation", "Invalid bookId passed to EditBookScreen")
+                          bookRepository.getBook(
+                              uuid = bookId,
+                              OnSucess = { fetchedbook -> book = fetchedbook },
+                              onFailure = { Log.d("EditScreen", "Error while loading the book") })
+                          EditBookScreen(
+                              booksRepository = bookRepository,
+                              navigationActions = NavigationActions(navController),
+                              book = book!!)
+                      } else {
+                          Log.e("Navigation", "Invalid bookId passed to EditBookScreen")
+                      }
+                  }
+              }
           }
-        }
       }
-    }
   }
 }

--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.semantics
@@ -137,75 +138,7 @@ class MainActivity : ComponentActivity() {
     val bookManagerViewModel =
         BookManagerViewModel(geolocation, bookRepository, userRepository, bookFilter)
 
-    val currentUserUUID = UUID.fromString("77942cd7-8b99-41ba-a0a5-147214703434")
-    val otherUserUUID = UUID.fromString("7284fd9d-3edc-458b-93cd-2b0c4a8c0fc0")
-    val testUserUUID = UUID.fromString("550e8400-e29b-41d4-a716-446655440002")
-    val currentUserPlaceholder =
-        DataUser(
-            currentUserUUID,
-            "Mr.",
-            "Jaime",
-            "Oliver Pastor",
-            "",
-            "",
-            42.5717,
-            0.5471,
-            "https://media.istockphoto.com/id/693813718/photo/the-fortress-of-jaca-soain.jpg?s=612x612&w=0&k=20&c=MdnKl1VJIKQRwGdrGwBFx_L00vS8UVphR9J-nS6J90c=",
-            emptyList(),
-            "googleUid")
 
-    val otherUser =
-        DataUser(
-            otherUserUUID,
-            "Mr.",
-            "Théo",
-            "Schlaeppi",
-            "",
-            "",
-            46.3,
-            6.43,
-            "https://www.shutterstock.com/image-photo/wonderful-epesses-fairtytale-village-middle-600nw-2174791585.jpg",
-            emptyList(),
-            "googleUid")
-    val testUser =
-        DataUser(
-            testUserUUID,
-            "Mr.",
-            "John",
-            "Doe",
-            "john.doe@hotmail.com",
-            "+41999999999",
-            0.0,
-            0.0,
-            "john_doe.jpg",
-            emptyList(),
-            "googleUid")
-
-    val placeHolder =
-        listOf(
-            MessageBox(otherUser, message = "Welcome message for user124", date = "01.01.24"),
-            MessageBox(
-                currentUserPlaceholder,
-                message = "Welcome message for user123",
-                date = "01.01.24")) +
-            List(5) {
-              MessageBox(
-                  DataUser(
-                      UUID.randomUUID(),
-                      "Hello",
-                      "First ${it + 1}",
-                      "Last ${it + 1}",
-                      "",
-                      "",
-                      0.0,
-                      0.0,
-                      "",
-                      emptyList(),
-                      "googleUid"),
-                  message = "Test message $it test for the feature of ellipsis in the message",
-                  date = "01.01.24")
-            } +
-            listOf(MessageBox(testUser, message = "Welcome message for test", date = "01.01.24"))
     val topAppBar =
         @Composable { s: String? ->
           TopAppBarComponent(
@@ -253,7 +186,7 @@ class MainActivity : ComponentActivity() {
                 bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
                 photoFirebaseStorageRepository = photoStorage,
                 booksRepository = bookRepository,
-                userUUID = currentUserUUID)
+                userUUID = userVM.uuid)
           }
         }
       }
@@ -276,7 +209,7 @@ class MainActivity : ComponentActivity() {
               bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
               photoFirebaseStorageRepository = photoStorage,
               booksRepository = bookRepository,
-              userUUID = currentUserUUID)
+              userUUID = userVM.uuid)
         }
         composable(C.Screen.ADD_BOOK_MANUALLY) {
           AddToBookScreen(

--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -20,7 +20,6 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navigation
 import com.android.bookswap.data.DataBook
 import com.android.bookswap.data.DataUser
-import com.android.bookswap.data.MessageBox
 import com.android.bookswap.data.repository.BooksRepository
 import com.android.bookswap.data.repository.MessageRepository
 import com.android.bookswap.data.repository.PhotoFirebaseStorageRepository
@@ -140,7 +139,6 @@ class MainActivity : ComponentActivity() {
     val bookManagerViewModel =
         BookManagerViewModel(geolocation, bookRepository, userRepository, bookFilter)
 
-
     val topAppBar =
         @Composable { s: String? ->
           TopAppBarComponent(
@@ -156,118 +154,118 @@ class MainActivity : ComponentActivity() {
               selectedItem = s ?: "")
         }
 
-      //CompositionLocalProvider provides LocalAppConfig to every child
-      CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = userVM) ) {
-          NavHost(navController = navController, startDestination = startDestination) {
-              navigation(startDestination = C.Screen.AUTH, route = C.Route.AUTH) {
-                  composable(C.Screen.AUTH) { SignInScreen(navigationActions, userVM) }
-                  composable(C.Screen.NEW_USER) { NewUserScreen(navigationActions, userVM) }
-              }
-              navigation(startDestination = C.Screen.CHAT_LIST, route = C.Route.CHAT_LIST) {
-                  composable(C.Screen.CHAT_LIST) {
-                      ListChatScreen(
-                          navigationActions,
-                          topAppBar = { topAppBar("Messages") },
-                          bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
-                          contactViewModel = contactViewModel)
-                  }
-                  composable("${C.Screen.CHAT}/{user2}") { backStackEntry ->
-                      val user2UUID = UUID.fromString(backStackEntry.arguments?.getString("user2"))
-                      val user2: DataUser? = contactViewModel.getUserInMessageBoxMap(user2UUID)
-                      if (user2 != null) {
-                          ChatScreen(
-                              messageRepository,
-                              userVM.getUser(),
-                              user2,
-                              navigationActions,
-                              photoStorage,
-                              messageStorage,
-                              context)
-                      } else {
-                          BookAdditionChoiceScreen(
-                              navigationActions,
-                              topAppBar = { topAppBar("Add a Book") },
-                              bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
-                              photoFirebaseStorageRepository = photoStorage,
-                              booksRepository = bookRepository,
-                              userUUID = userVM.uuid)
-                      }
-                  }
-              }
-              navigation(startDestination = C.Screen.MAP, route = C.Route.MAP) {
-                  composable(C.Screen.MAP) {
-                      MapScreen(
-                          bookManagerViewModel,
-                          navigationActions = navigationActions,
-                          geolocation = geolocation,
-                          topAppBar = { topAppBar("Map") },
-                          bottomAppBar = { bottomAppBar(this@navigation.route ?: "") })
-                  }
-                  composable(C.Screen.MAP_FILTER) { FilterMapScreen(navigationActions, bookFilter) }
-              }
-              navigation(startDestination = C.Screen.NEW_BOOK, route = C.Route.NEW_BOOK) {
-                  composable(C.Screen.NEW_BOOK) {
-                      BookAdditionChoiceScreen(
-                          navigationActions,
-                          topAppBar = { topAppBar("Add a Book") },
-                          bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
-                          photoFirebaseStorageRepository = photoStorage,
-                          booksRepository = bookRepository,
-                          userUUID = userVM.uuid)
-                  }
-                  composable(C.Screen.ADD_BOOK_MANUALLY) {
-                      AddToBookScreen(
-                          bookRepository,
-                          userVM,
-                          topAppBar = { topAppBar("Add your Book") },
-                          bottomAppBar = { bottomAppBar(this@navigation.route ?: "") })
-                  }
-                  composable(C.Screen.ADD_BOOK_ISBN) {
-                      AddISBNScreen(
-                          navigationActions,
-                          bookRepository,
-                          userVM,
-                          topAppBar = { topAppBar(null) },
-                          bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
-                      )
-                  }
-              }
-              navigation(startDestination = C.Screen.USER_PROFILE, route = C.Route.USER_PROFILE) {
-                  composable(C.Screen.USER_PROFILE) { UserProfile(userVM) }
-                  composable(C.Screen.BOOK_PROFILE) { backStackEntry ->
-                      val bookId = backStackEntry.arguments?.getString("bookId")?.let { UUID.fromString(it) }
-
-                      if (bookId != null) {
-                          BookProfileScreen(
-                              bookId = bookId ?: UUID.randomUUID(), // Default for testing
-                              booksRepository = BooksFirestoreSource(FirebaseFirestore.getInstance()),
-                              navController = NavigationActions(navController),
-                              currentUserId = UUID.randomUUID() // Pass the actual logged-in user ID
-                          )
-                      } else {
-                          Log.e("Navigation", "Invalid bookId passed to BookProfileScreen")
-                      }
-                  }
-                  composable("${C.Screen.EDIT_BOOK}/{bookId}") { backStackEntry ->
-                      val bookId = backStackEntry.arguments?.getString("bookId")?.let { UUID.fromString(it) }
-                      var book: DataBook? = null // How to create a book that will be assigned after ?
-                      // Fetch book data
-                      if (bookId != null) {
-
-                          bookRepository.getBook(
-                              uuid = bookId,
-                              OnSucess = { fetchedbook -> book = fetchedbook },
-                              onFailure = { Log.d("EditScreen", "Error while loading the book") })
-                          EditBookScreen(
-                              booksRepository = bookRepository,
-                              navigationActions = NavigationActions(navController),
-                              book = book!!)
-                      } else {
-                          Log.e("Navigation", "Invalid bookId passed to EditBookScreen")
-                      }
-                  }
-              }
+    // CompositionLocalProvider provides LocalAppConfig to every child
+    CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = userVM)) {
+      NavHost(navController = navController, startDestination = startDestination) {
+        navigation(startDestination = C.Screen.AUTH, route = C.Route.AUTH) {
+          composable(C.Screen.AUTH) { SignInScreen(navigationActions, userVM) }
+          composable(C.Screen.NEW_USER) { NewUserScreen(navigationActions, userVM) }
+        }
+        navigation(startDestination = C.Screen.CHAT_LIST, route = C.Route.CHAT_LIST) {
+          composable(C.Screen.CHAT_LIST) {
+            ListChatScreen(
+                navigationActions,
+                topAppBar = { topAppBar("Messages") },
+                bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
+                contactViewModel = contactViewModel)
           }
+          composable("${C.Screen.CHAT}/{user2}") { backStackEntry ->
+            val user2UUID = UUID.fromString(backStackEntry.arguments?.getString("user2"))
+            val user2: DataUser? = contactViewModel.getUserInMessageBoxMap(user2UUID)
+            if (user2 != null) {
+              ChatScreen(
+                  messageRepository,
+                  userVM.getUser(),
+                  user2,
+                  navigationActions,
+                  photoStorage,
+                  messageStorage,
+                  context)
+            } else {
+              BookAdditionChoiceScreen(
+                  navigationActions,
+                  topAppBar = { topAppBar("Add a Book") },
+                  bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
+                  photoFirebaseStorageRepository = photoStorage,
+                  booksRepository = bookRepository,
+                  userUUID = userVM.uuid)
+            }
+          }
+        }
+        navigation(startDestination = C.Screen.MAP, route = C.Route.MAP) {
+          composable(C.Screen.MAP) {
+            MapScreen(
+                bookManagerViewModel,
+                navigationActions = navigationActions,
+                geolocation = geolocation,
+                topAppBar = { topAppBar("Map") },
+                bottomAppBar = { bottomAppBar(this@navigation.route ?: "") })
+          }
+          composable(C.Screen.MAP_FILTER) { FilterMapScreen(navigationActions, bookFilter) }
+        }
+        navigation(startDestination = C.Screen.NEW_BOOK, route = C.Route.NEW_BOOK) {
+          composable(C.Screen.NEW_BOOK) {
+            BookAdditionChoiceScreen(
+                navigationActions,
+                topAppBar = { topAppBar("Add a Book") },
+                bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
+                photoFirebaseStorageRepository = photoStorage,
+                booksRepository = bookRepository,
+                userUUID = userVM.uuid)
+          }
+          composable(C.Screen.ADD_BOOK_MANUALLY) {
+            AddToBookScreen(
+                bookRepository,
+                userVM,
+                topAppBar = { topAppBar("Add your Book") },
+                bottomAppBar = { bottomAppBar(this@navigation.route ?: "") })
+          }
+          composable(C.Screen.ADD_BOOK_ISBN) {
+            AddISBNScreen(
+                navigationActions,
+                bookRepository,
+                userVM,
+                topAppBar = { topAppBar(null) },
+                bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
+            )
+          }
+        }
+        navigation(startDestination = C.Screen.USER_PROFILE, route = C.Route.USER_PROFILE) {
+          composable(C.Screen.USER_PROFILE) { UserProfile(userVM) }
+          composable(C.Screen.BOOK_PROFILE) { backStackEntry ->
+            val bookId = backStackEntry.arguments?.getString("bookId")?.let { UUID.fromString(it) }
+
+            if (bookId != null) {
+              BookProfileScreen(
+                  bookId = bookId ?: UUID.randomUUID(), // Default for testing
+                  booksRepository = BooksFirestoreSource(FirebaseFirestore.getInstance()),
+                  navController = NavigationActions(navController),
+                  currentUserId = UUID.randomUUID() // Pass the actual logged-in user ID
+                  )
+            } else {
+              Log.e("Navigation", "Invalid bookId passed to BookProfileScreen")
+            }
+          }
+          composable("${C.Screen.EDIT_BOOK}/{bookId}") { backStackEntry ->
+            val bookId = backStackEntry.arguments?.getString("bookId")?.let { UUID.fromString(it) }
+            var book: DataBook? = null // How to create a book that will be assigned after ?
+            // Fetch book data
+            if (bookId != null) {
+
+              bookRepository.getBook(
+                  uuid = bookId,
+                  OnSucess = { fetchedbook -> book = fetchedbook },
+                  onFailure = { Log.d("EditScreen", "Error while loading the book") })
+              EditBookScreen(
+                  booksRepository = bookRepository,
+                  navigationActions = NavigationActions(navController),
+                  book = book!!)
+            } else {
+              Log.e("Navigation", "Invalid bookId passed to EditBookScreen")
+            }
+          }
+        }
       }
+    }
   }
 }

--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -33,7 +33,6 @@ import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.model.UserViewModel
 import com.android.bookswap.model.chat.ContactViewModel
 import com.android.bookswap.model.chat.OfflineMessageStorage
-import com.android.bookswap.model.chat.PermissionHandler
 import com.android.bookswap.model.map.BookFilter
 import com.android.bookswap.model.map.BookManagerViewModel
 import com.android.bookswap.model.map.DefaultGeolocation
@@ -65,9 +64,7 @@ import java.util.UUID
 
 class MainActivity : ComponentActivity() {
 
-  private lateinit var permissionHandler: PermissionHandler
-
-  override fun onCreate(savedInstanceState: Bundle?) {
+    override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     // permissionHandler = PermissionHandler(this)
     // permissionHandler.askNotificationPermission()
@@ -237,7 +234,7 @@ class MainActivity : ComponentActivity() {
 
             if (bookId != null) {
               BookProfileScreen(
-                  bookId = bookId ?: UUID.randomUUID(), // Default for testing
+                  bookId = bookId, // Default for testing
                   booksRepository = BooksFirestoreSource(FirebaseFirestore.getInstance()),
                   navController = NavigationActions(navController),
                   currentUserId = UUID.randomUUID() // Pass the actual logged-in user ID

--- a/app/src/main/java/com/android/bookswap/model/AppConfig.kt
+++ b/app/src/main/java/com/android/bookswap/model/AppConfig.kt
@@ -1,0 +1,23 @@
+package com.android.bookswap.model
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import java.util.UUID
+import com.android.bookswap.MainActivity
+
+/**
+ * Data stored across the whole app through Static CompositionLocal
+ * Used for rarely updated data.
+ * @param userViewModel the user view model storing the user information.
+ */
+data class AppConfig(
+    val userViewModel: UserViewModel
+)
+
+
+/**
+ * Static provider of the app Local config.
+ * This is used by [MainActivity] in CompositionLocalProvider
+ */
+val LocalAppConfig = staticCompositionLocalOf {
+    AppConfig(userViewModel = UserViewModel(UUID.randomUUID())) //By default the user doesn't really exist thus the random UUID
+}

--- a/app/src/main/java/com/android/bookswap/model/AppConfig.kt
+++ b/app/src/main/java/com/android/bookswap/model/AppConfig.kt
@@ -1,23 +1,23 @@
 package com.android.bookswap.model
 
 import androidx.compose.runtime.staticCompositionLocalOf
-import java.util.UUID
 import com.android.bookswap.MainActivity
+import java.util.UUID
 
 /**
- * Data stored across the whole app through Static CompositionLocal
- * Used for rarely updated data.
+ * Data stored across the whole app through Static CompositionLocal Used for rarely updated data.
+ *
  * @param userViewModel the user view model storing the user information.
  */
-data class AppConfig(
-    val userViewModel: UserViewModel
-)
-
+data class AppConfig(val userViewModel: UserViewModel)
 
 /**
- * Static provider of the app Local config.
- * This is used by [MainActivity] in CompositionLocalProvider
+ * Static provider of the app Local config. This is used by [MainActivity] in
+ * CompositionLocalProvider
  */
 val LocalAppConfig = staticCompositionLocalOf {
-    AppConfig(userViewModel = UserViewModel(UUID.randomUUID())) //By default the user doesn't really exist thus the random UUID
+  AppConfig(
+      userViewModel =
+          UserViewModel(
+              UUID.randomUUID())) // By default the user doesn't really exist thus the random UUID
 }

--- a/app/src/test/java/com/android/bookswap/model/AppConfigTest.kt
+++ b/app/src/test/java/com/android/bookswap/model/AppConfigTest.kt
@@ -6,13 +6,11 @@ import org.junit.Test
 
 class AppConfigTest {
 
-    @Test
-    fun `assert creation of data class`() {
-        val mockUserViewModel: UserViewModel = mockk()
-        val appConfig = AppConfig(
-            userViewModel = mockUserViewModel
-        )
+  @Test
+  fun `assert creation of data class`() {
+    val mockUserViewModel: UserViewModel = mockk()
+    val appConfig = AppConfig(userViewModel = mockUserViewModel)
 
-        assertEquals(mockUserViewModel, appConfig.userViewModel)
-    }
+    assertEquals(mockUserViewModel, appConfig.userViewModel)
+  }
 }

--- a/app/src/test/java/com/android/bookswap/model/AppConfigTest.kt
+++ b/app/src/test/java/com/android/bookswap/model/AppConfigTest.kt
@@ -1,0 +1,18 @@
+package com.android.bookswap.model
+
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AppConfigTest {
+
+    @Test
+    fun `assert creation of data class`() {
+        val mockUserViewModel: UserViewModel = mockk()
+        val appConfig = AppConfig(
+            userViewModel = mockUserViewModel
+        )
+
+        assertEquals(mockUserViewModel, appConfig.userViewModel)
+    }
+}


### PR DESCRIPTION
As indicated by [this](https://developer.android.com/develop/ui/compose/compositionlocal?hl=fr).
Android Compose provides a simple way for developer to access common data from any component.

AppConfig can store all the data that should be stay the same across the whole app.

data can be accessed using `val config = LocalAppConfig.current` in a composable environment.

This PR does not pass SonarCloud, this is normal see [this](https://github.com/BookswapEPFL/Bookswap/pull/275#issuecomment-2505081421)