### PR TITLE
Implement new contact from new chat functionality

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/endtoend/ChatEndToEnd.kt
+++ b/app/src/androidTest/java/com/android/bookswap/endtoend/ChatEndToEnd.kt
@@ -25,6 +25,7 @@ import com.android.bookswap.data.MessageBox
 import com.android.bookswap.data.MessageType
 import com.android.bookswap.data.repository.MessageRepository
 import com.android.bookswap.data.repository.PhotoFirebaseStorageRepository
+import com.android.bookswap.data.source.network.UserFirestoreSource
 import com.android.bookswap.model.UserViewModel
 import com.android.bookswap.model.chat.ContactViewModel
 import com.android.bookswap.model.chat.OfflineMessageStorage
@@ -54,6 +55,7 @@ class ChatEndToEnd {
   private lateinit var mockMessageRepository: MockMessageRepository
   private lateinit var mockPhotoStorage: PhotoFirebaseStorageRepository
   private lateinit var mockMessageStorage: OfflineMessageStorage
+  private lateinit var mockUserRepository: UserFirestoreSource
   private lateinit var mockContext: Context
   private val navigateToChatScreen = mutableStateOf(false)
   private lateinit var mockUserVM: UserViewModel
@@ -66,6 +68,7 @@ class ChatEndToEnd {
     mockPhotoStorage = mockk()
     mockMessageStorage = mockk()
     mockContext = mockk()
+    mockUserRepository = mockk()
 
     // Initialize the mock message repository with placeholder messages
     mockMessageRepository = MockMessageRepository()
@@ -160,6 +163,7 @@ class ChatEndToEnd {
       if (navigateToChatScreen.value) {
         ChatScreen(
             mockMessageRepository,
+            mockUserRepository,
             DataUser(currentUserUUID, "Mr.", "John", "Doe", "", "", 0.0, 0.0, "", emptyList(), ""),
             DataUser(otherUserUUID, "Mr.", "Tester", "User", "", "", 0.0, 0.0, "", emptyList(), ""),
             mockNavigationActions,

--- a/app/src/androidTest/java/com/android/bookswap/endtoend/ChatEndToEnd.kt
+++ b/app/src/androidTest/java/com/android/bookswap/endtoend/ChatEndToEnd.kt
@@ -154,6 +154,8 @@ class ChatEndToEnd {
     every { mockMessageStorage.extractMessages(any(), any()) } returns placeholderMessages
     every { mockMessageStorage.addMessage(any()) } just Runs
     every { mockMessageStorage.setMessages() } just Runs
+    every { mockUserRepository.getUser(any<String>(), any()) } just Runs
+    every { mockUserRepository.getUser(any<UUID>(), any()) } just Runs
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
@@ -20,6 +20,7 @@ import com.android.bookswap.data.DataUser
 import com.android.bookswap.data.MessageType
 import com.android.bookswap.data.repository.MessageRepository
 import com.android.bookswap.data.repository.PhotoFirebaseStorageRepository
+import com.android.bookswap.data.source.network.UserFirestoreSource
 import com.android.bookswap.model.chat.OfflineMessageStorage
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.navigation.NavigationActions
@@ -43,6 +44,7 @@ class ChatScreenTest {
   private lateinit var mockMessageRepository: MessageRepository
   private lateinit var mockPhotoStorage: PhotoFirebaseStorageRepository
   private lateinit var mockMessageStorage: OfflineMessageStorage
+  private lateinit var mockUserRepository: UserFirestoreSource
   private val currentUserUUID = UUID.randomUUID()
   private val otherUserUUID = UUID.randomUUID()
   private lateinit var mockNavigationActions: NavigationActions
@@ -59,6 +61,7 @@ class ChatScreenTest {
     mockNavigationActions = mockk()
     mockMessageStorage = mockk()
     mockContext = mockk()
+    mockUserRepository = mockk()
 
     placeHolderData =
         List(6) {
@@ -110,6 +113,7 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           mockMessageRepository,
+          mockUserRepository,
           currentUser,
           otherUser,
           mockNavigationActions,
@@ -129,6 +133,7 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           mockMessageRepository,
+          mockUserRepository,
           currentUser,
           otherUser,
           mockNavigationActions,
@@ -174,6 +179,7 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           mockMessageRepository,
+          mockUserRepository,
           currentUser,
           otherUser,
           mockNavigationActions,
@@ -197,6 +203,7 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           mockMessageRepository,
+          mockUserRepository,
           currentUser,
           otherUser,
           mockNavigationActions,
@@ -212,6 +219,7 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           mockMessageRepository,
+          mockUserRepository,
           currentUser,
           otherUser,
           mockNavigationActions,
@@ -232,6 +240,7 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           mockMessageRepository,
+          mockUserRepository,
           currentUser,
           otherUser,
           mockNavigationActions,
@@ -258,6 +267,7 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           mockMessageRepository,
+          mockUserRepository,
           currentUser,
           otherUser,
           mockNavigationActions,
@@ -281,6 +291,7 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           mockMessageRepository,
+          mockUserRepository,
           currentUser,
           otherUser,
           mockNavigationActions,
@@ -330,6 +341,7 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           mockMessageRepository,
+          mockUserRepository,
           currentUser,
           otherUser,
           mockNavigationActions,
@@ -378,6 +390,7 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           mockMessageRepository,
+          mockUserRepository,
           currentUser,
           otherUser,
           mockNavigationActions,
@@ -454,6 +467,7 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           mockMessageRepository,
+          mockUserRepository,
           currentUser,
           otherUser,
           mockNavigationActions,
@@ -499,6 +513,7 @@ class ChatScreenTest {
     composeTestRule.setContent {
       ChatScreen(
           mockMessageRepository,
+          mockUserRepository,
           currentUser,
           otherUser,
           mockNavigationActions,

--- a/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
@@ -90,6 +90,8 @@ class ChatScreenTest {
     every { mockMessageStorage.extractMessages(any(), any()) } returns placeHolderData
     every { mockMessageStorage.addMessage(any()) } just Runs
     every { mockMessageStorage.setMessages() } just Runs
+    every { mockUserRepository.getUser(any<String>(), any()) } just Runs
+    every { mockUserRepository.getUser(any<UUID>(), any()) } just Runs
   }
 
   private val palette =

--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -240,6 +240,7 @@ class MainActivity : ComponentActivity() {
           if (user2 != null) {
             ChatScreen(
                 messageRepository,
+                userRepository,
                 userVM.getUser(),
                 user2,
                 navigationActions,

--- a/app/src/main/java/com/android/bookswap/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/android/bookswap/data/repository/UserRepository.kt
@@ -61,4 +61,22 @@ interface UsersRepository {
    *   Result.failure(exception) if error
    */
   fun deleteUser(uuid: UUID, callback: (Result<Unit>) -> Unit)
+
+  /**
+   * Function to add a contact to the user's contact list in the repository.
+   *
+   * @param userUUID UUID of the user whose contact list is being updated.
+   * @param contactUUID UUID of the contact to add.
+   * @param callback Callback for success or failure.
+   */
+  fun addContact(userUUID: UUID, contactUUID: String, callback: (Result<Unit>) -> Unit)
+
+  /**
+   * Function to remove a contact from the user's contact list in the repository.
+   *
+   * @param userUUID UUID of the user whose contact list is being updated.
+   * @param contactUUID UUID of the contact to remove.
+   * @param callback Callback for success or failure.
+   */
+  fun removeContact(userUUID: UUID, contactUUID: String, callback: (Result<Unit>) -> Unit)
 }

--- a/app/src/main/java/com/android/bookswap/data/source/network/UserFirestoreSource.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/network/UserFirestoreSource.kt
@@ -179,4 +179,62 @@ class UserFirestoreSource(private val db: FirebaseFirestore) : UsersRepository {
       }
     }
   }
+
+  /**
+   * Adds a contact to the user's contact list in Firestore.
+   *
+   * @param userUUID UUID of the user whose contact list is being updated.
+   * @param contactUUID UUID of the contact to add.
+   * @param callback Callback for success or failure.
+   */
+  override fun addContact(userUUID: UUID, contactUUID: String, callback: (Result<Unit>) -> Unit) {
+    db.collection(COLLECTION_NAME)
+        .document(userUUID.toString())
+        .get()
+        .addOnSuccessListener { document ->
+          val currentContactList = (document.get("contactList") as? List<String>) ?: emptyList()
+          if (!currentContactList.contains(contactUUID)) {
+            val updatedContactList = currentContactList + contactUUID
+            db.collection(COLLECTION_NAME)
+                .document(userUUID.toString())
+                .update("contactList", updatedContactList)
+                .addOnSuccessListener { callback(Result.success(Unit)) }
+                .addOnFailureListener { e -> callback(Result.failure(e)) }
+          } else {
+            callback(Result.success(Unit)) // Already in the contact list
+          }
+        }
+        .addOnFailureListener { e -> callback(Result.failure(e)) }
+  }
+
+  /**
+   * Removes a contact from the user's contact list in Firestore.
+   *
+   * @param userUUID UUID of the user whose contact list is being updated.
+   * @param contactUUID UUID of the contact to remove.
+   * @param callback Callback for success or failure.
+   */
+  override fun removeContact(
+      userUUID: UUID,
+      contactUUID: String,
+      callback: (Result<Unit>) -> Unit
+  ) {
+    db.collection(COLLECTION_NAME)
+        .document(userUUID.toString())
+        .get()
+        .addOnSuccessListener { document ->
+          val currentContactList = (document.get("contactList") as? List<String>) ?: emptyList()
+          if (currentContactList.contains(contactUUID)) {
+            val updatedContactList = currentContactList - contactUUID
+            db.collection(COLLECTION_NAME)
+                .document(userUUID.toString())
+                .update("contactList", updatedContactList)
+                .addOnSuccessListener { callback(Result.success(Unit)) }
+                .addOnFailureListener { e -> callback(Result.failure(e)) }
+          } else {
+            callback(Result.success(Unit)) // Already not in the contact list
+          }
+        }
+        .addOnFailureListener { e -> callback(Result.failure(e)) }
+  }
 }

--- a/app/src/test/java/com/android/bookswap/data/source/network/UserFirestoreSourceTest.kt
+++ b/app/src/test/java/com/android/bookswap/data/source/network/UserFirestoreSourceTest.kt
@@ -2,6 +2,7 @@ package com.android.bookswap.data.source.network
 
 import android.util.Log
 import com.android.bookswap.data.DataUser
+import com.android.bookswap.data.repository.UsersRepository
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference
@@ -14,6 +15,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import java.util.UUID
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -28,6 +30,7 @@ class UserFirestoreSourceTest {
   private val mockDocumentSnapshot: DocumentSnapshot = mockk()
   private val mockQuerySnapshot: QuerySnapshot = mockk()
   private val mockQuery: Query = mockk()
+  private lateinit var mockUsersRepository: UsersRepository
 
   private val userFirestoreSource: UserFirestoreSource = UserFirestoreSource(mockFirestore)
 
@@ -43,9 +46,13 @@ class UserFirestoreSourceTest {
           0.0,
           "dummyPic.png")
 
+  private val userUUID = UUID.randomUUID()
+  private val contactUUID = UUID.randomUUID().toString()
+
   @Before
   fun setUp() {
 
+    mockUsersRepository = mockk()
     userFirestoreSource
 
     every { mockFirestore.collection(any()) } returns mockCollectionReference
@@ -172,5 +179,69 @@ class UserFirestoreSourceTest {
     // Assert
     assert(result.getOrNull() == null)
     result.onFailure { Log.d("UserFirestoreSourceTest", "failure with message: ${it.message}") }
+  }
+
+  @Test
+  fun `addContact succeeds`() {
+    every { mockUsersRepository.addContact(userUUID, contactUUID, any()) } answers
+        {
+          val callback = it.invocation.args[2] as (Result<Unit>) -> Unit
+          callback(Result.success(Unit)) // Simulate success
+        }
+
+    var result: Result<Unit>? = null
+    mockUsersRepository.addContact(userUUID, contactUUID) { result = it }
+
+    assertTrue(result!!.isSuccess)
+    verify { mockUsersRepository.addContact(userUUID, contactUUID, any()) }
+  }
+
+  @Test
+  fun `addContact fails`() {
+    val exception = RuntimeException("Failed to add contact")
+    every { mockUsersRepository.addContact(userUUID, contactUUID, any()) } answers
+        {
+          val callback = it.invocation.args[2] as (Result<Unit>) -> Unit
+          callback(Result.failure(exception)) // Simulate failure
+        }
+
+    var result: Result<Unit>? = null
+    mockUsersRepository.addContact(userUUID, contactUUID) { result = it }
+
+    assertTrue(result!!.isFailure)
+    assertTrue(result!!.exceptionOrNull() == exception)
+    verify { mockUsersRepository.addContact(userUUID, contactUUID, any()) }
+  }
+
+  @Test
+  fun `removeContact succeeds`() {
+    every { mockUsersRepository.removeContact(userUUID, contactUUID, any()) } answers
+        {
+          val callback = it.invocation.args[2] as (Result<Unit>) -> Unit
+          callback(Result.success(Unit)) // Simulate success
+        }
+
+    var result: Result<Unit>? = null
+    mockUsersRepository.removeContact(userUUID, contactUUID) { result = it }
+
+    assertTrue(result!!.isSuccess)
+    verify { mockUsersRepository.removeContact(userUUID, contactUUID, any()) }
+  }
+
+  @Test
+  fun `removeContact fails`() {
+    val exception = RuntimeException("Failed to remove contact")
+    every { mockUsersRepository.removeContact(userUUID, contactUUID, any()) } answers
+        {
+          val callback = it.invocation.args[2] as (Result<Unit>) -> Unit
+          callback(Result.failure(exception)) // Simulate failure
+        }
+
+    var result: Result<Unit>? = null
+    mockUsersRepository.removeContact(userUUID, contactUUID) { result = it }
+
+    assertTrue(result!!.isFailure)
+    assertTrue(result!!.exceptionOrNull() == exception)
+    verify { mockUsersRepository.removeContact(userUUID, contactUUID, any()) }
   }
 }


### PR DESCRIPTION
## Contact gets added when new chat is created
This PR is quite simple, to the file `UserFirestoreSource.kt` it adds two methods, one to add a contact to the contact list of a given UUID and another one to remove the contact. It also adds the necessary tests. Additionally, in `ChatScreen.kt`, in the effect on launch, it tests if the list of messages is longer than 0, and if so, it checks if the contacts already exist within each others  `DataUser`. If they don't exist, they get added.