### PR TITLE
Make everything use the AppConfig UserViewModel

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/ui/authentication/LoginTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/authentication/LoginTest.kt
@@ -1,5 +1,6 @@
 package com.android.bookswap.ui.authentication
 
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
@@ -11,6 +12,8 @@ import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.toPackage
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.bookswap.model.AppConfig
+import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.model.UserViewModel
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.navigation.NavigationActions
@@ -51,7 +54,9 @@ class LoginTest : TestCase() {
     composeTestRule.setContent {
       val navController = rememberNavController()
       val navigationActions = NavigationActions(navController)
-      SignInScreen(navigationActions, userVM)
+      CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = userVM)) {
+        SignInScreen(navigationActions)
+      }
     }
     composeTestRule.onNodeWithTag(C.Tag.TopAppBar.screen_title).assertIsDisplayed()
     composeTestRule.onNodeWithTag(C.Tag.TopAppBar.screen_title).assertTextEquals("Welcome to")
@@ -68,7 +73,9 @@ class LoginTest : TestCase() {
     composeTestRule.setContent {
       val navController = rememberNavController()
       val navigationActions = NavigationActions(navController)
-      SignInScreen(navigationActions, userVM)
+      CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = userVM)) {
+        SignInScreen(navigationActions)
+      }
     }
     composeTestRule.onNodeWithTag(C.Tag.SignIn.signIn).performClick()
     composeTestRule.waitForIdle()
@@ -79,7 +86,11 @@ class LoginTest : TestCase() {
   @Test
   fun navigateToNewUserScreenWhenUserIsNotStored() {
     every { userVM.isStored } returns MutableStateFlow(false)
-    composeTestRule.setContent { SignInScreen(mocknavi, userVM) }
+    composeTestRule.setContent {
+      CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = userVM)) {
+        SignInScreen(mocknavi)
+      }
+    }
     composeTestRule.onNodeWithTag(C.Tag.SignIn.signIn).performClick()
     composeTestRule.waitForIdle()
     verify { mocknavi.navigateTo(C.Screen.NEW_USER) }

--- a/app/src/androidTest/java/com/android/bookswap/ui/books/BookProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/books/BookProfileScreenTest.kt
@@ -1,5 +1,6 @@
 package com.android.bookswap.ui.books
 
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
@@ -12,9 +13,13 @@ import com.android.bookswap.data.BookGenres
 import com.android.bookswap.data.BookLanguages
 import com.android.bookswap.data.DataBook
 import com.android.bookswap.data.repository.BooksRepository
+import com.android.bookswap.model.AppConfig
+import com.android.bookswap.model.LocalAppConfig
+import com.android.bookswap.model.UserViewModel
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.navigation.NavigationActions
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import java.util.UUID
 import org.junit.Before
@@ -27,20 +32,27 @@ class BookProfileScreenTest {
   private lateinit var mockNavController: NavigationActions
   private lateinit var mockBookRepo: BooksRepository
   private val testBookId = UUID.randomUUID()
-  private val currentUserId = UUID.randomUUID()
+  private val mockUserViewModel: UserViewModel = mockk()
+  private lateinit var testBook: DataBook
 
-  private val testBook =
-      DataBook(
-          testBookId,
-          "Historia de España",
-          "Jose Ignacio Pastor Iglesias",
-          "Recuento de la historia de España desde los primeros pobladores hasta la actualidad.",
-          9,
-          null,
-          BookLanguages.SPANISH,
-          "978-84-09025-23-5",
-          listOf(BookGenres.HISTORICAL, BookGenres.NONFICTION, BookGenres.BIOGRAPHY),
-          currentUserId)
+    @Before
+    fun setup() {
+        val userUUID = UUID.randomUUID()
+        every { mockUserViewModel.uuid } returns userUUID
+        testBook =
+            DataBook(
+            testBookId,
+            "Historia de España",
+            "Jose Ignacio Pastor Iglesias",
+            "Recuento de la historia de España desde los primeros pobladores hasta la actualidad.",
+            9,
+            null,
+            BookLanguages.SPANISH,
+            "978-84-09025-23-5",
+            listOf(BookGenres.HISTORICAL, BookGenres.NONFICTION, BookGenres.BIOGRAPHY),
+            mockUserViewModel.uuid
+            )
+    }
 
   @Before
   fun setUp() {
@@ -60,7 +72,9 @@ class BookProfileScreenTest {
     composeTestRule.setContent {
       val navController = rememberNavController()
       val navigationActions = NavigationActions(navController)
-      BookProfileScreen(testBookId, mockBookRepo, navigationActions, currentUserId = currentUserId)
+        CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
+            BookProfileScreen(testBookId, mockBookRepo, navigationActions)
+        }
     }
 
     composeTestRule.onNodeWithTag(C.Tag.BookProfile.title).assertIsDisplayed()
@@ -86,7 +100,9 @@ class BookProfileScreenTest {
     composeTestRule.setContent {
       val navController = rememberNavController()
       val navigationActions = NavigationActions(navController)
-      BookProfileScreen(testBookId, mockBookRepo, navigationActions, currentUserId = currentUserId)
+        CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
+            BookProfileScreen(testBookId, mockBookRepo, navigationActions)
+        }
     }
 
     composeTestRule.onNodeWithTag(C.Tag.BookProfile.previous_image).assertHasClickAction()
@@ -98,7 +114,9 @@ class BookProfileScreenTest {
     composeTestRule.setContent {
       val navController = rememberNavController()
       val navigationActions = NavigationActions(navController)
-      BookProfileScreen(testBookId, mockBookRepo, navigationActions, currentUserId = currentUserId)
+        CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
+            BookProfileScreen(testBookId, mockBookRepo, navigationActions)
+        }
     }
 
     // Verify the first picture is displayed

--- a/app/src/androidTest/java/com/android/bookswap/ui/books/BookProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/books/BookProfileScreenTest.kt
@@ -35,12 +35,12 @@ class BookProfileScreenTest {
   private val mockUserViewModel: UserViewModel = mockk()
   private lateinit var testBook: DataBook
 
-    @Before
-    fun setup() {
-        val userUUID = UUID.randomUUID()
-        every { mockUserViewModel.uuid } returns userUUID
-        testBook =
-            DataBook(
+  @Before
+  fun setup() {
+    val userUUID = UUID.randomUUID()
+    every { mockUserViewModel.uuid } returns userUUID
+    testBook =
+        DataBook(
             testBookId,
             "Historia de España",
             "Jose Ignacio Pastor Iglesias",
@@ -50,9 +50,8 @@ class BookProfileScreenTest {
             BookLanguages.SPANISH,
             "978-84-09025-23-5",
             listOf(BookGenres.HISTORICAL, BookGenres.NONFICTION, BookGenres.BIOGRAPHY),
-            mockUserViewModel.uuid
-            )
-    }
+            mockUserViewModel.uuid)
+  }
 
   @Before
   fun setUp() {
@@ -72,9 +71,10 @@ class BookProfileScreenTest {
     composeTestRule.setContent {
       val navController = rememberNavController()
       val navigationActions = NavigationActions(navController)
-        CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
+      CompositionLocalProvider(
+          LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
             BookProfileScreen(testBookId, mockBookRepo, navigationActions)
-        }
+          }
     }
 
     composeTestRule.onNodeWithTag(C.Tag.BookProfile.title).assertIsDisplayed()
@@ -100,9 +100,10 @@ class BookProfileScreenTest {
     composeTestRule.setContent {
       val navController = rememberNavController()
       val navigationActions = NavigationActions(navController)
-        CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
+      CompositionLocalProvider(
+          LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
             BookProfileScreen(testBookId, mockBookRepo, navigationActions)
-        }
+          }
     }
 
     composeTestRule.onNodeWithTag(C.Tag.BookProfile.previous_image).assertHasClickAction()
@@ -114,9 +115,10 @@ class BookProfileScreenTest {
     composeTestRule.setContent {
       val navController = rememberNavController()
       val navigationActions = NavigationActions(navController)
-        CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
+      CompositionLocalProvider(
+          LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
             BookProfileScreen(testBookId, mockBookRepo, navigationActions)
-        }
+          }
     }
 
     // Verify the first picture is displayed

--- a/app/src/androidTest/java/com/android/bookswap/ui/books/add/BookAdditionChoiceScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/books/add/BookAdditionChoiceScreenTest.kt
@@ -9,7 +9,6 @@ import com.android.bookswap.data.repository.PhotoFirebaseStorageRepository
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.navigation.NavigationActions
 import io.mockk.mockk
-import java.util.UUID
 import org.junit.Rule
 import org.junit.Test
 
@@ -26,8 +25,7 @@ class BookAdditionChoiceScreenTest {
       BookAdditionChoiceScreen(
           mockNavigationActions,
           photoFirebaseStorageRepository = mockPhotoFirebaseStorageRepository,
-          booksRepository = booksRepository
-      )
+          booksRepository = booksRepository)
     }
     composeTestRule
         .onNodeWithTag("Manually" + C.Tag.NewBookChoice.btnWIcon.button)
@@ -46,8 +44,7 @@ class BookAdditionChoiceScreenTest {
       BookAdditionChoiceScreen(
           mockNavigationActions,
           photoFirebaseStorageRepository = mockPhotoFirebaseStorageRepository,
-          booksRepository = booksRepository
-      )
+          booksRepository = booksRepository)
     }
     composeTestRule
         .onNodeWithTag("Manually" + C.Tag.NewBookChoice.btnWIcon.button)

--- a/app/src/androidTest/java/com/android/bookswap/ui/books/add/BookAdditionChoiceScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/books/add/BookAdditionChoiceScreenTest.kt
@@ -26,8 +26,8 @@ class BookAdditionChoiceScreenTest {
       BookAdditionChoiceScreen(
           mockNavigationActions,
           photoFirebaseStorageRepository = mockPhotoFirebaseStorageRepository,
-          booksRepository = booksRepository,
-          userUUID = UUID.randomUUID())
+          booksRepository = booksRepository
+      )
     }
     composeTestRule
         .onNodeWithTag("Manually" + C.Tag.NewBookChoice.btnWIcon.button)
@@ -46,8 +46,8 @@ class BookAdditionChoiceScreenTest {
       BookAdditionChoiceScreen(
           mockNavigationActions,
           photoFirebaseStorageRepository = mockPhotoFirebaseStorageRepository,
-          booksRepository = booksRepository,
-          userUUID = UUID.randomUUID())
+          booksRepository = booksRepository
+      )
     }
     composeTestRule
         .onNodeWithTag("Manually" + C.Tag.NewBookChoice.btnWIcon.button)

--- a/app/src/androidTest/java/com/android/bookswap/ui/books/add/ISBNAddTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/books/add/ISBNAddTest.kt
@@ -28,7 +28,6 @@ import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.mockk.Runs
 import io.mockk.andThenJust
 import io.mockk.every
-import io.mockk.impl.annotations.SpyK
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkConstructor
@@ -55,30 +54,33 @@ class ISBNAddTest : TestCase() {
     toastMock = mockk<Toast>()
     every { toastMock.show() } returns Unit
     every { Toast.makeText(any(), any<String>(), any()) } returns toastMock
-      val userUUid = UUID.randomUUID()
+    val userUUid = UUID.randomUUID()
 
-      val dataUser = DataUser(
-          userUUid,
-          "Hello",
-          "John",
-          "Doe",
-          "eleanorroosevelt@myownpersonaldomain.com",
-          "+1234567890",
-          0.0,
-          0.0,
-          "https://www.example.com/profile.jpg",
-          listOf(UUID.randomUUID()),
-          "googleUID",
-          listOf("contact1", "contact2")
-      )
+    val dataUser =
+        DataUser(
+            userUUid,
+            "Hello",
+            "John",
+            "Doe",
+            "eleanorroosevelt@myownpersonaldomain.com",
+            "+1234567890",
+            0.0,
+            0.0,
+            "https://www.example.com/profile.jpg",
+            listOf(UUID.randomUUID()),
+            "googleUID",
+            listOf("contact1", "contact2"))
 
-      val mockUserRepository: UsersRepository = mockk()
+    val mockUserRepository: UsersRepository = mockk()
 
-      mockUserVM = spyk(UserViewModel(userUUid, mockUserRepository, dataUser))
+    mockUserVM = spyk(UserViewModel(userUUid, mockUserRepository, dataUser))
 
-      every { mockUserVM.uuid } returns userUUid
-      every { mockUserVM.getUser() } returns dataUser
-      every { mockUserVM.updateUser(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } just runs
+    every { mockUserVM.uuid } returns userUUid
+    every { mockUserVM.getUser() } returns dataUser
+    every {
+      mockUserVM.updateUser(
+          any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+    } just runs
   }
 
   @Test
@@ -119,53 +121,53 @@ class ISBNAddTest : TestCase() {
         isbnField.fetchSemanticsNode().config[SemanticsProperties.EditableText].text)
   }
 
-    @Suppress("TestFunctionName")
-    @Test
-    fun ISBNRequestSucceeded() {
-      val dataBook =
-          DataBook(
-              uuid = UUID.randomUUID(),
-              title = "Flowers for Algernon",
-              author = null,
-              description = null,
-              rating = null,
-              photo = null,
-              language = BookLanguages.OTHER,
-              isbn = "9780435123437",
-              userId = mockUserVM.uuid
-          )
+  @Suppress("TestFunctionName")
+  @Test
+  fun ISBNRequestSucceeded() {
+    val dataBook =
+        DataBook(
+            uuid = UUID.randomUUID(),
+            title = "Flowers for Algernon",
+            author = null,
+            description = null,
+            rating = null,
+            photo = null,
+            language = BookLanguages.OTHER,
+            isbn = "9780435123437",
+            userId = mockUserVM.uuid)
 
-      // Mock call to repository
-      val mockBooksRepository: BooksRepository = mockk()
-      every { mockBooksRepository.addBook(matchDataBook(dataBook), any()) } answers
-          {
-            secondArg<(Result<Unit>) -> Unit>()(Result.success(Unit))
-          } andThenJust
-          Runs
+    // Mock call to repository
+    val mockBooksRepository: BooksRepository = mockk()
+    every { mockBooksRepository.addBook(matchDataBook(dataBook), any()) } answers
+        {
+          secondArg<(Result<Unit>) -> Unit>()(Result.success(Unit))
+        } andThenJust
+        Runs
 
     // Mock call to api
     mockkConstructor(GoogleBookDataSource::class)
-    every {
-      anyConstructed<GoogleBookDataSource>().getBookFromISBN(any(), any(), any())
-    } answers { thirdArg<(Result<DataBook>) -> Unit>()(Result.success(dataBook)) } andThenJust Runs
+    every { anyConstructed<GoogleBookDataSource>().getBookFromISBN(any(), any(), any()) } answers
+        {
+          thirdArg<(Result<DataBook>) -> Unit>()(Result.success(dataBook))
+        } andThenJust
+        Runs
 
-
-      // Mock the navigation
-      val mockNavigationActions: NavigationActions = mockk()
-      every { mockNavigationActions.navigateTo(any(TopLevelDestination::class)) } just Runs
+    // Mock the navigation
+    val mockNavigationActions: NavigationActions = mockk()
+    every { mockNavigationActions.navigateTo(any(TopLevelDestination::class)) } just Runs
 
     composeTestRule.setContent {
-        CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserVM)) {
-            AddISBNScreen(mockNavigationActions, mockBooksRepository)
-        }
-
+      CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserVM)) {
+        AddISBNScreen(mockNavigationActions, mockBooksRepository)
+      }
     }
 
     composeTestRule.onNodeWithTag(C.Tag.NewBookISBN.isbn).performTextInput(dataBook.isbn!!)
     composeTestRule.onNodeWithTag(C.Tag.NewBookISBN.search).performClick()
 
     verify {
-      anyConstructed<GoogleBookDataSource>().getBookFromISBN(dataBook.isbn!!, dataBook.userId, any())
+      anyConstructed<GoogleBookDataSource>()
+          .getBookFromISBN(dataBook.isbn!!, dataBook.userId, any())
     } // Api is called
     verify { mockBooksRepository.addBook(matchDataBook(dataBook), any()) } // Book is added
     verify {
@@ -189,9 +191,7 @@ class ISBNAddTest : TestCase() {
     // Mock call to repository
     val mockBooksRepository: BooksRepository = mockk()
 
-    composeTestRule.setContent {
-      AddISBNScreen(mockNavigationActions, mockBooksRepository)
-    }
+    composeTestRule.setContent { AddISBNScreen(mockNavigationActions, mockBooksRepository) }
 
     composeTestRule.onNodeWithTag(C.Tag.NewBookISBN.isbn).performTextInput("BAD_ISBN")
     composeTestRule.onNodeWithTag(C.Tag.NewBookISBN.search).performClick()
@@ -239,9 +239,9 @@ class ISBNAddTest : TestCase() {
     val mockNavigationActions: NavigationActions = mockk()
 
     composeTestRule.setContent {
-        CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserVM)) {
-            AddISBNScreen(mockNavigationActions, mockBooksRepository)
-        }
+      CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserVM)) {
+        AddISBNScreen(mockNavigationActions, mockBooksRepository)
+      }
     }
 
     composeTestRule.onNodeWithTag(C.Tag.NewBookISBN.isbn).performTextInput(bookISBN)

--- a/app/src/androidTest/java/com/android/bookswap/ui/books/add/ISBNAddTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/books/add/ISBNAddTest.kt
@@ -1,6 +1,7 @@
 package com.android.bookswap.ui.books.add
 
 import android.widget.Toast
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
@@ -14,17 +15,26 @@ import com.android.bookswap.data.BookLanguages
 import com.android.bookswap.data.DataBook
 import com.android.bookswap.data.DataUser
 import com.android.bookswap.data.repository.BooksRepository
+import com.android.bookswap.data.repository.UsersRepository
 import com.android.bookswap.data.source.api.GoogleBookDataSource
+import com.android.bookswap.model.AppConfig
+import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.model.UserViewModel
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.navigation.NavigationActions
+import com.android.bookswap.ui.navigation.TopLevelDestination
+import com.android.bookswap.utils.matchDataBook
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.mockk.Runs
 import io.mockk.andThenJust
 import io.mockk.every
+import io.mockk.impl.annotations.SpyK
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.spyk
 import io.mockk.verify
 import java.util.UUID
 import org.junit.Assert
@@ -45,36 +55,30 @@ class ISBNAddTest : TestCase() {
     toastMock = mockk<Toast>()
     every { toastMock.show() } returns Unit
     every { Toast.makeText(any(), any<String>(), any()) } returns toastMock
+      val userUUid = UUID.randomUUID()
 
-    mockUserVM = mockk(relaxed = true)
-    every { mockUserVM.getUser() } returns
-        DataUser(
-            UUID.randomUUID(),
-            "Hello",
-            "John",
-            "Doe",
-            "eleanorroosevelt@myownpersonaldomain.com",
-            "+1234567890",
-            0.0,
-            0.0,
-            "https://www.example.com/profile.jpg",
-            listOf(UUID.randomUUID()),
-            "googleUID",
-            listOf("contact1", "contact2"))
+      val dataUser = DataUser(
+          userUUid,
+          "Hello",
+          "John",
+          "Doe",
+          "eleanorroosevelt@myownpersonaldomain.com",
+          "+1234567890",
+          0.0,
+          0.0,
+          "https://www.example.com/profile.jpg",
+          listOf(UUID.randomUUID()),
+          "googleUID",
+          listOf("contact1", "contact2")
+      )
 
-    mockkConstructor(DataUser::class)
+      val mockUserRepository: UsersRepository = mockk()
 
-    every { anyConstructed<DataUser>().greeting } returns "Hello"
-    every { anyConstructed<DataUser>().firstName } returns "John"
-    every { anyConstructed<DataUser>().lastName } returns "Doe"
-    every { anyConstructed<DataUser>().email } returns "john.doe@example.com"
-    every { anyConstructed<DataUser>().phoneNumber } returns "+1234567890"
-    every { anyConstructed<DataUser>().latitude } returns 0.0
-    every { anyConstructed<DataUser>().longitude } returns 0.0
-    every { anyConstructed<DataUser>().profilePictureUrl } returns "mockPicUrl.png"
-    every { anyConstructed<DataUser>().bookList } returns emptyList()
-    every { anyConstructed<DataUser>().googleUid } returns "mockGoogleUid"
-    every { anyConstructed<DataUser>().contactList } returns emptyList()
+      mockUserVM = spyk(UserViewModel(userUUid, mockUserRepository, dataUser))
+
+      every { mockUserVM.uuid } returns userUUid
+      every { mockUserVM.getUser() } returns dataUser
+      every { mockUserVM.updateUser(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } just runs
   }
 
   @Test
@@ -82,7 +86,7 @@ class ISBNAddTest : TestCase() {
     composeTestRule.setContent {
       val mockNavigationActions: NavigationActions = mockk()
       val mockBooksRepository: BooksRepository = mockk()
-      AddISBNScreen(mockNavigationActions, mockBooksRepository, mockUserVM)
+      AddISBNScreen(mockNavigationActions, mockBooksRepository)
     }
 
     val isbnField = composeTestRule.onNodeWithTag(C.Tag.NewBookISBN.isbn)
@@ -100,7 +104,7 @@ class ISBNAddTest : TestCase() {
     composeTestRule.setContent {
       val mockNavigationActions: NavigationActions = mockk()
       val mockBooksRepository: BooksRepository = mockk()
-      AddISBNScreen(mockNavigationActions, mockBooksRepository, mockUserVM)
+      AddISBNScreen(mockNavigationActions, mockBooksRepository)
     }
     val isbnField = composeTestRule.onNodeWithTag(C.Tag.NewBookISBN.isbn)
 
@@ -114,7 +118,7 @@ class ISBNAddTest : TestCase() {
         "978-3-16-148410-0",
         isbnField.fetchSemanticsNode().config[SemanticsProperties.EditableText].text)
   }
-  /*
+
     @Suppress("TestFunctionName")
     @Test
     fun ISBNRequestSucceeded() {
@@ -127,8 +131,9 @@ class ISBNAddTest : TestCase() {
               rating = null,
               photo = null,
               language = BookLanguages.OTHER,
-              isbn = "9780435123437")
-
+              isbn = "9780435123437",
+              userId = mockUserVM.uuid
+          )
 
       // Mock call to repository
       val mockBooksRepository: BooksRepository = mockk()
@@ -141,7 +146,7 @@ class ISBNAddTest : TestCase() {
     // Mock call to api
     mockkConstructor(GoogleBookDataSource::class)
     every {
-      anyConstructed<GoogleBookDataSource>().getBookFromISBN(bookISBN, userUUID, any())
+      anyConstructed<GoogleBookDataSource>().getBookFromISBN(any(), any(), any())
     } answers { thirdArg<(Result<DataBook>) -> Unit>()(Result.success(dataBook)) } andThenJust Runs
 
 
@@ -149,28 +154,24 @@ class ISBNAddTest : TestCase() {
       val mockNavigationActions: NavigationActions = mockk()
       every { mockNavigationActions.navigateTo(any(TopLevelDestination::class)) } just Runs
 
-      composeTestRule.setContent { AddISBNScreen(mockNavigationActions, mockBooksRepository, mockUserVM) }
-
-      composeTestRule.onNodeWithTag("isbn_field").performTextInput(dataBook.isbn!!)
-      composeTestRule.onNodeWithTag("isbn_searchButton").performClick()
-
     composeTestRule.setContent {
-      AddISBNScreen(mockNavigationActions, mockBooksRepository, userId = userUUID)
+        CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserVM)) {
+            AddISBNScreen(mockNavigationActions, mockBooksRepository)
+        }
+
     }
 
-    composeTestRule.onNodeWithTag(C.Tag.NewBookISBN.isbn).performTextInput(bookISBN)
+    composeTestRule.onNodeWithTag(C.Tag.NewBookISBN.isbn).performTextInput(dataBook.isbn!!)
     composeTestRule.onNodeWithTag(C.Tag.NewBookISBN.search).performClick()
 
     verify {
-      anyConstructed<GoogleBookDataSource>().getBookFromISBN(bookISBN, userUUID, any())
+      anyConstructed<GoogleBookDataSource>().getBookFromISBN(dataBook.isbn!!, dataBook.userId, any())
     } // Api is called
     verify { mockBooksRepository.addBook(matchDataBook(dataBook), any()) } // Book is added
     verify {
       mockNavigationActions.navigateTo(any(TopLevelDestination::class))
     } // Navigation is called when book is added
   }
-
-  */
 
   @Suppress("TestFunctionName")
   @Test
@@ -189,7 +190,7 @@ class ISBNAddTest : TestCase() {
     val mockBooksRepository: BooksRepository = mockk()
 
     composeTestRule.setContent {
-      AddISBNScreen(mockNavigationActions, mockBooksRepository, mockUserVM)
+      AddISBNScreen(mockNavigationActions, mockBooksRepository)
     }
 
     composeTestRule.onNodeWithTag(C.Tag.NewBookISBN.isbn).performTextInput("BAD_ISBN")
@@ -238,7 +239,9 @@ class ISBNAddTest : TestCase() {
     val mockNavigationActions: NavigationActions = mockk()
 
     composeTestRule.setContent {
-      AddISBNScreen(mockNavigationActions, mockBooksRepository, mockUserVM)
+        CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserVM)) {
+            AddISBNScreen(mockNavigationActions, mockBooksRepository)
+        }
     }
 
     composeTestRule.onNodeWithTag(C.Tag.NewBookISBN.isbn).performTextInput(bookISBN)

--- a/app/src/androidTest/java/com/android/bookswap/ui/books/add/addBookTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/books/add/addBookTest.kt
@@ -14,26 +14,24 @@ import androidx.navigation.compose.rememberNavController
 import com.android.bookswap.data.BookGenres
 import com.android.bookswap.data.BookLanguages
 import com.android.bookswap.data.repository.BooksRepository
-import com.android.bookswap.model.UserViewModel
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.navigation.NavigationActions
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import java.util.UUID
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.util.UUID
 
 class AddToBookTest {
   @get:Rule val composeTestRule = createComposeRule()
   private val mockContext: Context = mockk()
   private val mockBooksRepository: BooksRepository = mockk()
-  private val mockUserVM: UserViewModel = mockk(relaxed = true)
 
-  @Before
+    @Before
   fun init() {
     mockkStatic(Toast::class)
     val toastMock = mockk<Toast>()
@@ -44,9 +42,7 @@ class AddToBookTest {
   @Test
   fun testSaveButtonDisabledInitially() {
     composeTestRule.setContent {
-      val navController = rememberNavController()
-      val navigationActions = NavigationActions(navController)
-      AddToBookScreen(mockBooksRepository, mockUserVM)
+      AddToBookScreen(mockBooksRepository)
     }
 
     // Check if the Save button is initially disabled
@@ -56,9 +52,7 @@ class AddToBookTest {
   @Test
   fun testSaveButtonEnabledWhenRequiredFieldsAreFilled() {
     composeTestRule.setContent {
-      val navController = rememberNavController()
-      val navigationActions = NavigationActions(navController)
-      AddToBookScreen(mockBooksRepository, mockUserVM)
+      AddToBookScreen(mockBooksRepository)
     }
 
     // Fill in the Title and ISBN fields
@@ -161,9 +155,9 @@ class AddToBookTest {
   fun testSaveButtonDisabledWhenTitleIsEmpty() {
     composeTestRule.setContent {
       val navController = rememberNavController()
-      val navigationActions = NavigationActions(navController)
+        NavigationActions(navController)
 
-      AddToBookScreen(mockBooksRepository, mockUserVM)
+      AddToBookScreen(mockBooksRepository)
     }
     // Fill in the ISBN field but leave the Title field empty
     composeTestRule.onNodeWithTag(C.Tag.NewBookManually.isbn).performTextInput("1234567890")
@@ -174,8 +168,7 @@ class AddToBookTest {
 
   @Test
   fun testDropdownMenuIsInitiallyClosed() {
-    val userId = UUID.randomUUID()
-    composeTestRule.setContent { AddToBookScreen(mockBooksRepository, mockUserVM) }
+    composeTestRule.setContent { AddToBookScreen(mockBooksRepository) }
 
     // Verify that the dropdown menu is initially not expanded
     composeTestRule.onNodeWithTag(C.Tag.NewBookManually.language).assertIsDisplayed()
@@ -184,8 +177,7 @@ class AddToBookTest {
 
   @Test
   fun testDropdownMenuOpensOnClick() {
-    val userId = UUID.randomUUID()
-    composeTestRule.setContent { AddToBookScreen(mockBooksRepository, mockUserVM) }
+    composeTestRule.setContent { AddToBookScreen(mockBooksRepository) }
 
     // Simulate clicking the dropdown to expand it
     composeTestRule.onNodeWithTag(C.Tag.NewBookManually.language).performClick()
@@ -202,9 +194,7 @@ class AddToBookTest {
 
   @Test
   fun testDropdownMenuItemSelection() {
-    val userId = UUID.randomUUID()
-
-    composeTestRule.setContent { AddToBookScreen(mockBooksRepository, mockUserVM) }
+    composeTestRule.setContent { AddToBookScreen(mockBooksRepository) }
 
     // Expand the dropdown menu:
     composeTestRule.onNodeWithTag(C.Tag.NewBookManually.language).performClick()
@@ -218,9 +208,7 @@ class AddToBookTest {
 
   @Test
   fun testDropdownMenuClosesAfterSelection() {
-    val userId = UUID.randomUUID()
-
-    composeTestRule.setContent { AddToBookScreen(mockBooksRepository, mockUserVM) }
+    composeTestRule.setContent { AddToBookScreen(mockBooksRepository) }
 
     // Expand the dropdown menu
     composeTestRule.onNodeWithTag(C.Tag.NewBookManually.language).performClick()

--- a/app/src/androidTest/java/com/android/bookswap/ui/books/add/addBookTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/books/add/addBookTest.kt
@@ -19,19 +19,19 @@ import com.android.bookswap.ui.navigation.NavigationActions
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import java.util.UUID
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import java.util.UUID
 
 class AddToBookTest {
   @get:Rule val composeTestRule = createComposeRule()
   private val mockContext: Context = mockk()
   private val mockBooksRepository: BooksRepository = mockk()
 
-    @Before
+  @Before
   fun init() {
     mockkStatic(Toast::class)
     val toastMock = mockk<Toast>()
@@ -41,9 +41,7 @@ class AddToBookTest {
 
   @Test
   fun testSaveButtonDisabledInitially() {
-    composeTestRule.setContent {
-      AddToBookScreen(mockBooksRepository)
-    }
+    composeTestRule.setContent { AddToBookScreen(mockBooksRepository) }
 
     // Check if the Save button is initially disabled
     composeTestRule.onNodeWithTag(C.Tag.NewBookManually.save).assertIsNotEnabled()
@@ -51,9 +49,7 @@ class AddToBookTest {
 
   @Test
   fun testSaveButtonEnabledWhenRequiredFieldsAreFilled() {
-    composeTestRule.setContent {
-      AddToBookScreen(mockBooksRepository)
-    }
+    composeTestRule.setContent { AddToBookScreen(mockBooksRepository) }
 
     // Fill in the Title and ISBN fields
     composeTestRule.onNodeWithTag(C.Tag.NewBookManually.title).performTextInput("My Book Title")
@@ -155,7 +151,7 @@ class AddToBookTest {
   fun testSaveButtonDisabledWhenTitleIsEmpty() {
     composeTestRule.setContent {
       val navController = rememberNavController()
-        NavigationActions(navController)
+      NavigationActions(navController)
 
       AddToBookScreen(mockBooksRepository)
     }

--- a/app/src/androidTest/java/com/android/bookswap/ui/navigation/NavigationFromBookProfileToEditBookTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/navigation/NavigationFromBookProfileToEditBookTest.kt
@@ -40,8 +40,8 @@ class NavigationFromBookProfileToEditBookTest {
   fun EditBookScreen_allows_editing_when_currentUser_is_bookUser() {
     // Arrange
     val currentUserId = UUID.randomUUID()
-      val mockUserViewModel: UserViewModel = mockk()
-      every { mockUserViewModel.uuid } returns currentUserId
+    val mockUserViewModel: UserViewModel = mockk()
+    every { mockUserViewModel.uuid } returns currentUserId
     val testBookId = UUID.randomUUID()
     val testBook =
         DataBook(
@@ -65,25 +65,23 @@ class NavigationFromBookProfileToEditBookTest {
 
     composeTestRule.setContent {
       val navController = rememberNavController()
-        CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel    )) {
+      CompositionLocalProvider(
+          LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
             // Add a NavHost to handle navigation
             NavHost(navController, C.Screen.BOOK_PROFILE) {
-                composable(C.Screen.BOOK_PROFILE) {
-                    BookProfileScreen(
-                        testBookId,
-                        mockBookRepo,
-                        NavigationActions(navController))
+              composable(C.Screen.BOOK_PROFILE) {
+                BookProfileScreen(testBookId, mockBookRepo, NavigationActions(navController))
+              }
+              composable("${C.Screen.EDIT_BOOK}/{bookId}") { backStackEntry ->
+                val bookId =
+                    backStackEntry.arguments?.getString("bookId")?.let { UUID.fromString(it) }
+                if (bookId != null) {
+                  EditBookScreen(
+                      mockBookRepo, NavigationActions(navController), testBook.copy(uuid = bookId))
                 }
-                composable("${C.Screen.EDIT_BOOK}/{bookId}") { backStackEntry ->
-                    val bookId = backStackEntry.arguments?.getString("bookId")?.let { UUID.fromString(it) }
-                    if (bookId != null) {
-                        EditBookScreen(
-                            mockBookRepo, NavigationActions(navController), testBook.copy(uuid = bookId))
-                    }
-                }
-        }
-
-      }
+              }
+            }
+          }
     }
     // This is juste temporary as when Matias will do the MainActivity part for the navigation
     // from the Profile to the BookProfile then I will finish the navigation in the main from the

--- a/app/src/androidTest/java/com/android/bookswap/ui/profile/EditProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/profile/EditProfileScreenTest.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.android.bookswap.data.DataUser
 import com.android.bookswap.model.AppConfig
 import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.model.UserViewModel
@@ -13,8 +12,8 @@ import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
 import io.mockk.every
 import io.mockk.mockk
-import org.junit.Before
 import java.util.UUID
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -33,18 +32,20 @@ class EditProfileScreenTest : TestCase() {
   fun setup() {
     every { mockUserViewModel.uuid } returns UUID.randomUUID()
   }
+
   @get:Rule val composeTestRule = createComposeRule()
 
   @Test
   fun testDisplay() =
       run(testName = "test alert display") {
         composeTestRule.setContent {
-          CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
-            EditProfileDialog(
-              { Log.d("EditProfileTest_Dismiss", "User info discarded") },
-              { Log.d("EditProfileTest_Save", "User info saved ${it.printFullname()}") },
-            )
-          }
+          CompositionLocalProvider(
+              LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
+                EditProfileDialog(
+                    { Log.d("EditProfileTest_Dismiss", "User info discarded") },
+                    { Log.d("EditProfileTest_Save", "User info saved ${it.printFullname()}") },
+                )
+              }
         }
         step("try displaying the alert box") {
           ComposeScreen.onComposeScreen<EditProfileScreen>(composeTestRule) {
@@ -105,12 +106,12 @@ class EditProfileScreenTest : TestCase() {
   fun testEdit() =
       run(testName = "test alert edit") {
         composeTestRule.setContent {
-          CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
-            EditProfileDialog(
-              { Log.d("EditProfileTest_Dismiss", "User info discarded") },
-              { Log.d("EditProfileTest_Save", "User info saved ${it.printFullname()}") }
-            )
-          }
+          CompositionLocalProvider(
+              LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
+                EditProfileDialog(
+                    { Log.d("EditProfileTest_Dismiss", "User info discarded") },
+                    { Log.d("EditProfileTest_Save", "User info saved ${it.printFullname()}") })
+              }
         }
         step("try editing the textbox values") {
           ComposeScreen.onComposeScreen<EditProfileScreen>(composeTestRule) {
@@ -181,12 +182,12 @@ class EditProfileScreenTest : TestCase() {
   fun testEditConfirm() =
       run(testName = "test edit and confirm") {
         composeTestRule.setContent {
-          CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
-            EditProfileDialog(
-              { Log.d("EditProfileTest_Dismiss", "User info discarded") },
-              { Log.d("EditProfileTest_Save", "User info saved ${it.printFullname()}") }
-            )
-          }
+          CompositionLocalProvider(
+              LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
+                EditProfileDialog(
+                    { Log.d("EditProfileTest_Dismiss", "User info discarded") },
+                    { Log.d("EditProfileTest_Save", "User info saved ${it.printFullname()}") })
+              }
         }
         step("try editing the textbox values then confirming the changes") {
           ComposeScreen.onComposeScreen<EditProfileScreen>(composeTestRule) {
@@ -290,13 +291,12 @@ class EditProfileScreenTest : TestCase() {
   fun testEditDismiss() =
       run(testName = "test alert display") {
         composeTestRule.setContent {
-          CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
-
-            EditProfileDialog(
-              { Log.d("EditProfileTest_Dismiss", "User info discarded") },
-              { Log.d("EditProfileTest_Save", "User info saved ${it.printFullname()}") }
-            )
-          }
+          CompositionLocalProvider(
+              LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
+                EditProfileDialog(
+                    { Log.d("EditProfileTest_Dismiss", "User info discarded") },
+                    { Log.d("EditProfileTest_Save", "User info saved ${it.printFullname()}") })
+              }
         }
         step("try editing the textbox values then cancelling the changes") {
           ComposeScreen.onComposeScreen<EditProfileScreen>(composeTestRule) {

--- a/app/src/androidTest/java/com/android/bookswap/ui/profile/EditProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/profile/EditProfileScreenTest.kt
@@ -1,12 +1,19 @@
 package com.android.bookswap.ui.profile
 
 import android.util.Log
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.bookswap.data.DataUser
+import com.android.bookswap.model.AppConfig
+import com.android.bookswap.model.LocalAppConfig
+import com.android.bookswap.model.UserViewModel
 import com.android.bookswap.screen.EditProfileScreen
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Before
 import java.util.UUID
 import org.junit.Rule
 import org.junit.Test
@@ -19,29 +26,25 @@ import org.junit.runner.RunWith
  */
 @RunWith(AndroidJUnit4::class)
 class EditProfileScreenTest : TestCase() {
-  @get:Rule val composeTestRule = createComposeRule()
 
-  private val standardUser =
-      DataUser(
-          UUID.randomUUID(),
-          "M.",
-          "John",
-          "Doe",
-          "John.Doe@example.com",
-          "+41223456789",
-          0.0,
-          0.0,
-          "dummyPic.png")
+  private val mockUserViewModel: UserViewModel = mockk(relaxed = true)
+
+  @Before
+  fun setup() {
+    every { mockUserViewModel.uuid } returns UUID.randomUUID()
+  }
+  @get:Rule val composeTestRule = createComposeRule()
 
   @Test
   fun testDisplay() =
       run(testName = "test alert display") {
-        val userUUID = UUID.randomUUID()
         composeTestRule.setContent {
-          EditProfileDialog(
+          CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
+            EditProfileDialog(
               { Log.d("EditProfileTest_Dismiss", "User info discarded") },
               { Log.d("EditProfileTest_Save", "User info saved ${it.printFullname()}") },
-              DataUser(userUUID, "", "", "", "", "", 0.0, 0.0, ""))
+            )
+          }
         }
         step("try displaying the alert box") {
           ComposeScreen.onComposeScreen<EditProfileScreen>(composeTestRule) {
@@ -102,10 +105,12 @@ class EditProfileScreenTest : TestCase() {
   fun testEdit() =
       run(testName = "test alert edit") {
         composeTestRule.setContent {
-          EditProfileDialog(
+          CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
+            EditProfileDialog(
               { Log.d("EditProfileTest_Dismiss", "User info discarded") },
-              { Log.d("EditProfileTest_Save", "User info saved ${it.printFullname()}") },
-              standardUser)
+              { Log.d("EditProfileTest_Save", "User info saved ${it.printFullname()}") }
+            )
+          }
         }
         step("try editing the textbox values") {
           ComposeScreen.onComposeScreen<EditProfileScreen>(composeTestRule) {
@@ -176,10 +181,12 @@ class EditProfileScreenTest : TestCase() {
   fun testEditConfirm() =
       run(testName = "test edit and confirm") {
         composeTestRule.setContent {
-          EditProfileDialog(
+          CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
+            EditProfileDialog(
               { Log.d("EditProfileTest_Dismiss", "User info discarded") },
-              { Log.d("EditProfileTest_Save", "User info saved ${it.printFullname()}") },
-              standardUser)
+              { Log.d("EditProfileTest_Save", "User info saved ${it.printFullname()}") }
+            )
+          }
         }
         step("try editing the textbox values then confirming the changes") {
           ComposeScreen.onComposeScreen<EditProfileScreen>(composeTestRule) {
@@ -283,10 +290,13 @@ class EditProfileScreenTest : TestCase() {
   fun testEditDismiss() =
       run(testName = "test alert display") {
         composeTestRule.setContent {
-          EditProfileDialog(
+          CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
+
+            EditProfileDialog(
               { Log.d("EditProfileTest_Dismiss", "User info discarded") },
-              { Log.d("EditProfileTest_Save", "User info saved ${it.printFullname()}") },
-              standardUser)
+              { Log.d("EditProfileTest_Save", "User info saved ${it.printFullname()}") }
+            )
+          }
         }
         step("try editing the textbox values then cancelling the changes") {
           ComposeScreen.onComposeScreen<EditProfileScreen>(composeTestRule) {

--- a/app/src/androidTest/java/com/android/bookswap/ui/profile/NewUserScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/profile/NewUserScreenTest.kt
@@ -26,7 +26,7 @@ class NewUserScreenTest {
   fun setUp() {
     navigationActions = mockk(relaxed = true)
     userVM = mockk(relaxed = true)
-    composeTestRule.setContent { NewUserScreen(navigationActions, userVM) }
+    composeTestRule.setContent { NewUserScreen(navigationActions) }
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/bookswap/ui/profile/UserProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/profile/UserProfileScreenTest.kt
@@ -49,7 +49,7 @@ class UserProfileScreenTest : TestCase() {
     composeTestRule.setContent {
       val navController = rememberNavController()
       val navigationActions = NavigationActions(navController)
-      UserProfile(userVM = userVM, { TopAppBarComponent(Modifier, navigationActions, "Messages") })
+      UserProfile({ TopAppBarComponent(Modifier, navigationActions, "Messages") })
     }
   }
 

--- a/app/src/androidTest/java/com/android/bookswap/ui/profile/UserProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/profile/UserProfileScreenTest.kt
@@ -1,10 +1,13 @@
 package com.android.bookswap.ui.profile
 
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.bookswap.data.DataUser
+import com.android.bookswap.model.AppConfig
+import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.model.UserViewModel
 import com.android.bookswap.screen.UserProfileScreen
 import com.android.bookswap.ui.components.TopAppBarComponent
@@ -49,7 +52,9 @@ class UserProfileScreenTest : TestCase() {
     composeTestRule.setContent {
       val navController = rememberNavController()
       val navigationActions = NavigationActions(navController)
-      UserProfile({ TopAppBarComponent(Modifier, navigationActions, "Messages") })
+      CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = userVM)) {
+        UserProfile({ TopAppBarComponent(Modifier, navigationActions, "Messages") })
+      }
     }
   }
 

--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -155,8 +155,8 @@ class MainActivity : ComponentActivity() {
     CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = userVM)) {
       NavHost(navController = navController, startDestination = startDestination) {
         navigation(startDestination = C.Screen.AUTH, route = C.Route.AUTH) {
-          composable(C.Screen.AUTH) { SignInScreen(navigationActions, userVM) }
-          composable(C.Screen.NEW_USER) { NewUserScreen(navigationActions, userVM) }
+          composable(C.Screen.AUTH) { SignInScreen(navigationActions) }
+          composable(C.Screen.NEW_USER) { NewUserScreen(navigationActions) }
         }
         navigation(startDestination = C.Screen.CHAT_LIST, route = C.Route.CHAT_LIST) {
           composable(C.Screen.CHAT_LIST) {
@@ -184,8 +184,7 @@ class MainActivity : ComponentActivity() {
                   topAppBar = { topAppBar("Add a Book") },
                   bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
                   photoFirebaseStorageRepository = photoStorage,
-                  booksRepository = bookRepository,
-                  userUUID = userVM.uuid)
+                  booksRepository = bookRepository)
             }
           }
         }
@@ -207,13 +206,11 @@ class MainActivity : ComponentActivity() {
                 topAppBar = { topAppBar("Add a Book") },
                 bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
                 photoFirebaseStorageRepository = photoStorage,
-                booksRepository = bookRepository,
-                userUUID = userVM.uuid)
+                booksRepository = bookRepository)
           }
           composable(C.Screen.ADD_BOOK_MANUALLY) {
             AddToBookScreen(
                 bookRepository,
-                userVM,
                 topAppBar = { topAppBar("Add your Book") },
                 bottomAppBar = { bottomAppBar(this@navigation.route ?: "") })
           }
@@ -221,14 +218,13 @@ class MainActivity : ComponentActivity() {
             AddISBNScreen(
                 navigationActions,
                 bookRepository,
-                userVM,
                 topAppBar = { topAppBar(null) },
                 bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
             )
           }
         }
         navigation(startDestination = C.Screen.USER_PROFILE, route = C.Route.USER_PROFILE) {
-          composable(C.Screen.USER_PROFILE) { UserProfile(userVM) }
+          composable(C.Screen.USER_PROFILE) { UserProfile() }
           composable(C.Screen.BOOK_PROFILE) { backStackEntry ->
             val bookId = backStackEntry.arguments?.getString("bookId")?.let { UUID.fromString(it) }
 
@@ -237,8 +233,7 @@ class MainActivity : ComponentActivity() {
                   bookId = bookId, // Default for testing
                   booksRepository = BooksFirestoreSource(FirebaseFirestore.getInstance()),
                   navController = NavigationActions(navController),
-                  currentUserId = UUID.randomUUID() // Pass the actual logged-in user ID
-                  )
+              )
             } else {
               Log.e("Navigation", "Invalid bookId passed to BookProfileScreen")
             }

--- a/app/src/main/java/com/android/bookswap/model/chat/ContactViewModel.kt
+++ b/app/src/main/java/com/android/bookswap/model/chat/ContactViewModel.kt
@@ -23,9 +23,10 @@ import kotlinx.coroutines.flow.StateFlow
  * @param messageFirestoreSource MessageFirestoreSource object
  */
 class ContactViewModel(
-    val userVM: UserViewModel = UserViewModel(UUID.randomUUID()),
-    val userFirestoreSource: UsersRepository = UserFirestoreSource(FirebaseFirestore.getInstance()),
-    val messageFirestoreSource: MessageRepository =
+    val userVM: UserViewModel,
+    private val userFirestoreSource: UsersRepository =
+        UserFirestoreSource(FirebaseFirestore.getInstance()),
+    private val messageFirestoreSource: MessageRepository =
         MessageFirestoreSource(FirebaseFirestore.getInstance())
 ) : ViewModel() {
 

--- a/app/src/main/java/com/android/bookswap/model/userViewModel.kt
+++ b/app/src/main/java/com/android/bookswap/model/userViewModel.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.flow.StateFlow
 open class UserViewModel(
     var uuid: UUID,
     repository: UsersRepository = UserFirestoreSource(FirebaseFirestore.getInstance()),
-    private var dataUser: DataUser = DataUser(uuid) //Allows easier testing
+    private var dataUser: DataUser = DataUser(uuid) // Allows easier testing
 ) : ViewModel() {
   private var isLoaded = false
   private val _isStored = MutableStateFlow<Boolean?>(null)

--- a/app/src/main/java/com/android/bookswap/model/userViewModel.kt
+++ b/app/src/main/java/com/android/bookswap/model/userViewModel.kt
@@ -20,9 +20,9 @@ import kotlinx.coroutines.flow.StateFlow
  */
 open class UserViewModel(
     var uuid: UUID,
-    repository: UsersRepository = UserFirestoreSource(FirebaseFirestore.getInstance())
+    repository: UsersRepository = UserFirestoreSource(FirebaseFirestore.getInstance()),
+    private var dataUser: DataUser = DataUser(uuid) //Allows easier testing
 ) : ViewModel() {
-  private var dataUser = DataUser(uuid)
   private var isLoaded = false
   private val _isStored = MutableStateFlow<Boolean?>(null)
   val isStored: StateFlow<Boolean?> = _isStored

--- a/app/src/main/java/com/android/bookswap/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/bookswap/ui/authentication/SignIn.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.bookswap.R
-import com.android.bookswap.model.UserViewModel
+import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.navigation.NavigationActions
 import com.android.bookswap.ui.theme.ColorVariable
@@ -64,12 +64,10 @@ import kotlinx.coroutines.tasks.await
  * @param userVM ViewModel for user-related operations.
  */
 @Composable
-fun SignInScreen(
-    navigationActions: NavigationActions,
-    userVM: UserViewModel
-) { // Add this when navigation is
+fun SignInScreen(navigationActions: NavigationActions) { // Add this when navigation is
   // implemented
   val context = LocalContext.current
+  val appConfig = LocalAppConfig.current
   var googleUid = ""
   // Check if user is already signed in
   LaunchedEffect(Unit) {
@@ -83,8 +81,8 @@ fun SignInScreen(
           onAuthComplete = { result ->
             val googleUserName = result.user?.displayName ?: ""
             googleUid = result.user?.uid ?: ""
-            userVM.getUserByGoogleUid(googleUid)
-            Log.d("SignInScreen", "isStored: ${userVM.isStored}")
+            appConfig.userViewModel.getUserByGoogleUid(googleUid)
+            Log.d("SignInScreen", "isStored: ${appConfig.userViewModel.isStored}")
             Log.d("SignInScreen", "User signed in: $googleUserName")
             Toast.makeText(context, "Welcome $googleUserName!", Toast.LENGTH_LONG).show()
           },
@@ -94,7 +92,7 @@ fun SignInScreen(
           })
   val token = stringResource(R.string.default_web_client_id)
 
-  val isStored by userVM.isStored.collectAsState()
+  val isStored by appConfig.userViewModel.isStored.collectAsState()
 
   LaunchedEffect(isStored) {
     when (isStored) {

--- a/app/src/main/java/com/android/bookswap/ui/books/BookProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/BookProfile.kt
@@ -17,7 +17,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -42,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import com.android.bookswap.R
 import com.android.bookswap.data.DataBook
 import com.android.bookswap.data.repository.BooksRepository
+import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.components.ButtonComponent
 import com.android.bookswap.ui.navigation.NavigationActions
@@ -56,15 +56,13 @@ import java.util.UUID
  * @param topAppBar A composable function to display the top app bar.
  * @param bottomAppBar A composable function to display the bottom app bar.
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BookProfileScreen(
     bookId: UUID,
     booksRepository: BooksRepository,
     navController: NavigationActions,
     topAppBar: @Composable () -> Unit = {},
-    bottomAppBar: @Composable () -> Unit = {},
-    currentUserId: UUID
+    bottomAppBar: @Composable () -> Unit = {}
 ) {
   val columnPadding = 8.dp
   val pictureWidth = (LocalConfiguration.current.screenWidthDp.dp * (0.60f))
@@ -74,6 +72,7 @@ fun BookProfileScreen(
   val imagesDescription = listOf("Isabel La Catolica", "Felipe II")
   var currentImageIndex by remember { mutableIntStateOf(0) }
 
+  val appConfig = LocalAppConfig.current
   // State to hold the book data and loading status
   val (dataBook, setDataBook) = remember { mutableStateOf<DataBook?>(null) }
   val (isLoading, setLoading) = remember { mutableStateOf(true) }
@@ -259,7 +258,7 @@ fun BookProfileScreen(
                     }
                   }
                   // Conditionally display the "Edit Book" button if the current user owns the book
-                  if (dataBook.userId == currentUserId) {
+                  if (dataBook.userId == appConfig.userViewModel.uuid) {
                     item { Spacer(modifier = Modifier.height(columnPadding)) }
                     item {
                       ButtonComponent(

--- a/app/src/main/java/com/android/bookswap/ui/books/add/AddISBNScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/add/AddISBNScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -29,7 +28,7 @@ import androidx.compose.ui.unit.dp
 import com.android.bookswap.data.repository.BooksRepository
 import com.android.bookswap.data.source.api.GoogleBookDataSource
 import com.android.bookswap.model.InputVerification
-import com.android.bookswap.model.UserViewModel
+import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.MAXLENGTHISBN
 import com.android.bookswap.ui.components.ButtonComponent
@@ -37,21 +36,18 @@ import com.android.bookswap.ui.components.FieldComponent
 import com.android.bookswap.ui.navigation.NavigationActions
 import com.android.bookswap.ui.navigation.TopLevelDestinations
 import com.android.bookswap.ui.theme.ColorVariable
-import java.util.UUID
 
 /** This is the main screen for the chat feature. It displays the list of messages */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddISBNScreen(
     navigationActions: NavigationActions,
     booksRepository: BooksRepository,
-    userVM: UserViewModel = UserViewModel(UUID.randomUUID()),
     topAppBar: @Composable () -> Unit = {},
     bottomAppBar: @Composable () -> Unit = {}
 ) {
   val context = LocalContext.current
   val inputVerification = InputVerification()
-  val user = userVM.getUser()
+  val appConfig = LocalAppConfig.current
   Scaffold(
       modifier = Modifier.testTag(C.Tag.new_book_isbn_screen_container),
       topBar = topAppBar,
@@ -79,34 +75,37 @@ fun AddISBNScreen(
                     ButtonComponent(
                         modifier = Modifier.testTag(C.Tag.NewBookISBN.search),
                         onClick = {
-                          GoogleBookDataSource(context).getBookFromISBN(isbn, user.userUUID) {
-                              result ->
-                            if (result.isFailure) {
-                              Toast.makeText(context, "Search unsuccessful", Toast.LENGTH_LONG)
-                                  .show()
-                              Log.e("AddBook", result.exceptionOrNull().toString())
-                            } else {
-                              booksRepository.addBook(
-                                  result.getOrThrow(),
-                                  callback = { res ->
-                                    if (res.isSuccess) {
-                                      val newBookList = user.bookList + result.getOrNull()?.uuid!!
-                                      userVM.updateUser(bookList = newBookList)
-                                      Toast.makeText(
-                                              context,
-                                              "${result.getOrNull()?.title} added",
-                                              Toast.LENGTH_LONG)
-                                          .show()
-                                      navigationActions.navigateTo(TopLevelDestinations.NEW_BOOK)
-                                    } else {
-                                      val error = res.exceptionOrNull()!!
-                                      Log.e("AddBook", res.toString())
-                                      Toast.makeText(context, error.message, Toast.LENGTH_LONG)
-                                          .show()
-                                    }
-                                  })
-                            }
-                          }
+                          GoogleBookDataSource(context).getBookFromISBN(
+                              isbn, appConfig.userViewModel.uuid) { result ->
+                                if (result.isFailure) {
+                                  Toast.makeText(context, "Search unsuccessful", Toast.LENGTH_LONG)
+                                      .show()
+                                  Log.e("AddBook", result.exceptionOrNull().toString())
+                                } else {
+                                  booksRepository.addBook(
+                                      result.getOrThrow(),
+                                      callback = { res ->
+                                        if (res.isSuccess) {
+                                          val newBookList =
+                                              appConfig.userViewModel.getUser().bookList +
+                                                  result.getOrNull()?.uuid!!
+                                          appConfig.userViewModel.updateUser(bookList = newBookList)
+                                          Toast.makeText(
+                                                  context,
+                                                  "${result.getOrNull()?.title} added",
+                                                  Toast.LENGTH_LONG)
+                                              .show()
+                                          navigationActions.navigateTo(
+                                              TopLevelDestinations.NEW_BOOK)
+                                        } else {
+                                          val error = res.exceptionOrNull()!!
+                                          Log.e("AddBook", res.toString())
+                                          Toast.makeText(context, error.message, Toast.LENGTH_LONG)
+                                              .show()
+                                        }
+                                      })
+                                }
+                              }
                         }) {
                           Row(verticalAlignment = Alignment.CenterVertically) {
                             Text("Search")

--- a/app/src/main/java/com/android/bookswap/ui/books/add/AddToBook.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/add/AddToBook.kt
@@ -30,7 +30,7 @@ import com.android.bookswap.data.BookLanguages
 import com.android.bookswap.data.DataBook
 import com.android.bookswap.data.repository.BooksRepository
 import com.android.bookswap.model.InputVerification
-import com.android.bookswap.model.UserViewModel
+import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.MAXLENGTHAUTHOR
 import com.android.bookswap.ui.MAXLENGTHDESCRIPTION
@@ -55,11 +55,9 @@ private const val HORIZONTAL_PADDING = 30
 @Composable
 fun AddToBookScreen(
     repository: BooksRepository,
-    userVM: UserViewModel = UserViewModel(UUID.randomUUID()),
     topAppBar: @Composable () -> Unit = {},
     bottomAppBar: @Composable () -> Unit = {}
 ) {
-  var user = userVM.getUser()
   // State variables to store the values entered by the user
   var title by remember { mutableStateOf("") }
   var author by remember { mutableStateOf("") }
@@ -77,6 +75,8 @@ fun AddToBookScreen(
   // Getting the context for showing Toast messages
   val context = LocalContext.current
   val inputVerification = InputVerification()
+
+  val appConfig = LocalAppConfig.current
 
   // Scaffold to provide basic UI structure with a top app bar
   Scaffold(
@@ -255,7 +255,7 @@ fun AddToBookScreen(
                               selectedLanguage.toString(),
                               isbn,
                               listOf(selectedGenre!!),
-                              user.userUUID)
+                              appConfig.userViewModel.uuid)
 
                       if (book == null) {
                         Log.e("AddToBookScreen", "Invalid argument")
@@ -266,8 +266,9 @@ fun AddToBookScreen(
                             book,
                             callback = {
                               if (it.isSuccess) {
-                                val newBookList = user.bookList + book.uuid
-                                userVM.updateUser(bookList = newBookList)
+                                val newBookList =
+                                    appConfig.userViewModel.getUser().bookList + book.uuid
+                                appConfig.userViewModel.updateUser(bookList = newBookList)
                                 Toast.makeText(context, "${book.title} added", Toast.LENGTH_LONG)
                                     .show()
                               } else {

--- a/app/src/main/java/com/android/bookswap/ui/books/add/BookAdditionChoiceScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/add/BookAdditionChoiceScreen.kt
@@ -32,11 +32,11 @@ import com.android.bookswap.R
 import com.android.bookswap.data.repository.BooksRepository
 import com.android.bookswap.data.repository.PhotoFirebaseStorageRepository
 import com.android.bookswap.model.BookFromChatGPT
+import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.model.PhotoRequester
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.navigation.NavigationActions
 import com.android.bookswap.ui.theme.ColorVariable
-import java.util.UUID
 
 /**
  * Composable function to display the screen for choosing how to add a book.
@@ -54,13 +54,13 @@ fun BookAdditionChoiceScreen(
     topAppBar: @Composable () -> Unit = {},
     bottomAppBar: @Composable () -> Unit = {},
     photoFirebaseStorageRepository: PhotoFirebaseStorageRepository,
-    booksRepository: BooksRepository,
-    userUUID: UUID
+    booksRepository: BooksRepository
 ) {
   val columnPadding = 16.dp
   val context = LocalContext.current
   val buttonWidth = (LocalConfiguration.current.screenWidthDp.dp * (0.75f))
 
+  val appConfig = LocalAppConfig.current
   // When the Photo is taken execute the lambda
   val photoRequester =
       PhotoRequester(LocalContext.current) { result ->
@@ -69,7 +69,7 @@ fun BookAdditionChoiceScreen(
         BookFromChatGPT(context, photoFirebaseStorageRepository, booksRepository).addBookFromImage(
             // Display error message in a toast.
             result.getOrThrow().asAndroidBitmap(),
-            userUUID) { error ->
+            appConfig.userViewModel.uuid) { error ->
               Toast.makeText(
                       context, context.resources.getString(error.message), Toast.LENGTH_SHORT)
                   .show()

--- a/app/src/main/java/com/android/bookswap/ui/chat/ListChat.kt
+++ b/app/src/main/java/com/android/bookswap/ui/chat/ListChat.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Person
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
@@ -34,19 +33,19 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.bookswap.data.MessageBox
+import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.model.chat.ContactViewModel
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.navigation.NavigationActions
 import com.android.bookswap.ui.theme.ColorVariable
 
 /** This is the main screen for the chat feature. It displays the list of messages */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ListChatScreen(
     navigationActions: NavigationActions,
     topAppBar: @Composable () -> Unit = {},
     bottomAppBar: @Composable () -> Unit = {},
-    contactViewModel: ContactViewModel = ContactViewModel()
+    contactViewModel: ContactViewModel = ContactViewModel(LocalAppConfig.current.userViewModel)
 ) {
   LaunchedEffect(Unit) { contactViewModel.updateMessageBoxMap() }
   val messageBoxMap by contactViewModel.messageBoxMap.collectAsState()
@@ -122,7 +121,7 @@ fun MessageBoxDisplay(message: MessageBox, onClick: () -> Unit = {}) {
               }
 
           Text(
-              text = message.message?.takeUnless { it.isNullOrEmpty() } ?: "No messages yet",
+              text = message.message?.takeUnless { it.isEmpty() } ?: "No messages yet",
               fontSize = 14.sp,
               color = ColorVariable.AccentSecondary,
               maxLines = 1,

--- a/app/src/main/java/com/android/bookswap/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/profile/EditProfile.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.android.bookswap.data.DataUser
 import com.android.bookswap.model.InputVerification
+import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.MAXLENGTHEMAIL
 import com.android.bookswap.ui.MAXLENGTHFIRSTNAME
@@ -34,8 +35,9 @@ import com.android.bookswap.ui.theme.BookSwapAppTheme
  * @param dataUser The DataUser object containing the user's current profile information.
  */
 @Composable
-fun EditProfileDialog(onDismiss: () -> Unit, onSave: (DataUser) -> Unit, dataUser: DataUser) {
-
+fun EditProfileDialog(onDismiss: () -> Unit, onSave: (DataUser) -> Unit) {
+  val appConfig = LocalAppConfig.current
+  val dataUser = appConfig.userViewModel.getUser()
   val _email = remember { mutableStateOf<String>(dataUser.email) }
   val _phone = remember { mutableStateOf<String>(dataUser.phoneNumber) }
   val _greeting = remember { mutableStateOf<String>(dataUser.greeting) }

--- a/app/src/main/java/com/android/bookswap/ui/profile/NewUser.kt
+++ b/app/src/main/java/com/android/bookswap/ui/profile/NewUser.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.bookswap.model.InputVerification
-import com.android.bookswap.model.UserViewModel
+import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.MAXLENGTHEMAIL
 import com.android.bookswap.ui.MAXLENGTHFIRSTNAME
@@ -69,7 +69,7 @@ private val ERROR_FONT_SIZE = 12.sp
  * @param navigationActions: NavigationActions
  */
 @Composable
-fun NewUserScreen(navigationActions: NavigationActions, userVM: UserViewModel) {
+fun NewUserScreen(navigationActions: NavigationActions) {
   val context = LocalContext.current
   val verification = InputVerification()
 
@@ -84,6 +84,7 @@ fun NewUserScreen(navigationActions: NavigationActions, userVM: UserViewModel) {
   val firstNameError = remember { mutableStateOf<String?>("First name required") }
   val lastNameError = remember { mutableStateOf<String?>("Last name required") }
 
+  val appConfig = LocalAppConfig.current
   var firstAttempt = true
 
   LazyColumn(
@@ -239,7 +240,7 @@ fun NewUserScreen(navigationActions: NavigationActions, userVM: UserViewModel) {
                       verification.validatePhone(phone.value) &&
                       verification.validateNonEmpty(firstName.value) &&
                       verification.validateNonEmpty(lastName.value)) {
-                    userVM.updateUser(
+                    appConfig.userViewModel.updateUser(
                         greeting = greeting.value,
                         firstName = firstName.value,
                         lastName = lastName.value,

--- a/app/src/main/java/com/android/bookswap/ui/profile/UserProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/profile/UserProfile.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import com.android.bookswap.model.UserViewModel
+import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.components.ButtonComponent
 import com.android.bookswap.ui.theme.*
@@ -40,13 +40,10 @@ import com.android.bookswap.ui.theme.*
  *   composable.
  */
 @Composable
-fun UserProfile(
-    userVM: UserViewModel = UserViewModel(java.util.UUID.randomUUID()),
-    topAppBar: @Composable () -> Unit = {},
-    bottomAppBar: @Composable () -> Unit = {}
-) {
+fun UserProfile(topAppBar: @Composable () -> Unit = {}, bottomAppBar: @Composable () -> Unit = {}) {
 
-  var user = userVM.getUser()
+  val appConfig = LocalAppConfig.current
+  var userData = appConfig.userViewModel.getUser()
   var showEditProfile by remember { mutableStateOf(false) }
 
   var needRecompose by remember { mutableStateOf(false) }
@@ -58,23 +55,22 @@ fun UserProfile(
           needRecompose = true
         },
         onSave = {
-          userVM.updateUser(
+          appConfig.userViewModel.updateUser(
               greeting = it.greeting,
               firstName = it.firstName,
               lastName = it.lastName,
               email = it.email,
               phone = it.phoneNumber,
-              user.latitude,
-              user.longitude,
-              picURL = user.profilePictureUrl)
+              userData.latitude,
+              userData.longitude,
+              picURL = userData.profilePictureUrl)
           showEditProfile = false
           needRecompose = true
-        },
-        dataUser = user)
+        })
   }
 
-  LaunchedEffect(userVM.uuid, needRecompose) {
-    user = userVM.getUser()
+  LaunchedEffect(appConfig.userViewModel.uuid, needRecompose) {
+    userData = appConfig.userViewModel.getUser()
     needRecompose = false
   }
 
@@ -116,18 +112,20 @@ fun UserProfile(
               Column(Modifier.fillMaxHeight().fillMaxWidth(), Arrangement.spacedBy(8.dp)) {
                 // Full name text
                 Text(
-                    text = "${user.greeting} ${user.firstName} ${user.lastName}",
+                    text = "${userData.greeting} ${userData.firstName} ${userData.lastName}",
                     modifier = Modifier.testTag(C.Tag.UserProfile.fullname))
 
                 // Email text
-                Text(text = user.email, modifier = Modifier.testTag(C.Tag.UserProfile.email))
+                Text(text = userData.email, modifier = Modifier.testTag(C.Tag.UserProfile.email))
 
                 // Phone number text
-                Text(text = user.phoneNumber, modifier = Modifier.testTag(C.Tag.UserProfile.phone))
+                Text(
+                    text = userData.phoneNumber,
+                    modifier = Modifier.testTag(C.Tag.UserProfile.phone))
 
                 // User address
                 Text(
-                    text = "${user.latitude}, ${user.longitude}",
+                    text = "${userData.latitude}, ${userData.longitude}",
                     modifier = Modifier.testTag(C.Tag.UserProfile.address))
 
                 // Edit Button

--- a/app/src/main/java/com/android/bookswap/ui/profile/UserProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/profile/UserProfile.kt
@@ -36,7 +36,6 @@ import coil.compose.AsyncImage
 import com.android.bookswap.data.repository.PhotoFirebaseStorageRepository
 import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.model.PhotoRequester
-import com.android.bookswap.model.UserViewModel
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.components.ButtonComponent
 import com.android.bookswap.ui.theme.*
@@ -57,8 +56,8 @@ fun UserProfile(
     bottomAppBar: @Composable () -> Unit = {}
 ) {
   val context = LocalContext.current
-    val appConfig = LocalAppConfig.current
-    var userData = appConfig.userViewModel.getUser()
+  val appConfig = LocalAppConfig.current
+  var userData = appConfig.userViewModel.getUser()
   val showEditPicture = remember { mutableStateOf(false) }
   var showEditProfile by remember { mutableStateOf(false) }
 
@@ -121,8 +120,7 @@ fun UserProfile(
 
     Dialog(
         onDismissRequest = { showEditPicture.value = false },
-        properties = DialogProperties(dismissOnBackPress = true, dismissOnClickOutside = true)
-    ) {
+        properties = DialogProperties(dismissOnBackPress = true, dismissOnClickOutside = true)) {
           Card(Modifier.testTag(C.Tag.UserProfile.profileImageBox).padding(16.dp)) {
             Column(
                 Modifier.fillMaxWidth().padding(16.dp),


### PR DESCRIPTION
Before, when an userViewModel was needed, people often recreated a new UserViewModel, or passed down from MainActivity the userViewModel.
This was complicated especially since some code used a random UUID or a random user.
Now everything should use AppLocalConfig (so a single common userViewModel) to interact with a user. 