### PR TITLE
Fix the navigation to ensure that you can't go back to the auth route.

### DIFF
--- a/app/src/main/java/com/android/bookswap/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/bookswap/ui/navigation/NavigationActions.kt
@@ -98,7 +98,6 @@ open class NavigationActions(
     if (previousBackStackEntry?.destination?.route != C.Route.AUTH) {
       navController.popBackStack()
     }
-
   }
 
   /**

--- a/app/src/main/java/com/android/bookswap/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/bookswap/ui/navigation/NavigationActions.kt
@@ -92,7 +92,13 @@ open class NavigationActions(
 
   /** Navigate back to the previous screen. */
   open fun goBack() {
-    navController.popBackStack()
+    val previousBackStackEntry = navController.previousBackStackEntry
+
+    // Check if the previous route is C.Route.AUTH
+    if (previousBackStackEntry?.destination?.route != C.Route.AUTH) {
+      navController.popBackStack()
+    }
+
   }
 
   /**

--- a/app/src/test/java/com/android/bookswap/ui/navigation/NavigationActionsTest.kt
+++ b/app/src/test/java/com/android/bookswap/ui/navigation/NavigationActionsTest.kt
@@ -96,7 +96,7 @@ class NavigationActionsTest {
 
   @Test
   fun `go back when previous route is AUTH does nothing`() {
-    val mockPreviousBackStackEntry : NavBackStackEntry? = mockk()
+    val mockPreviousBackStackEntry: NavBackStackEntry? = mockk()
     every { mockPreviousBackStackEntry?.destination?.route } returns C.Route.AUTH
 
     every { navHostController.previousBackStackEntry } returns mockPreviousBackStackEntry

--- a/app/src/test/java/com/android/bookswap/ui/navigation/NavigationActionsTest.kt
+++ b/app/src/test/java/com/android/bookswap/ui/navigation/NavigationActionsTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.filled.MailOutline
 import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material.icons.outlined.AddCircle
 import androidx.compose.material.icons.outlined.Place
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptionsBuilder
@@ -75,14 +76,6 @@ class NavigationActionsTest {
   }
 
   @Test
-  fun goBackCallPopBackStack() {
-    every { navHostController.popBackStack() } returns true
-    navigationActions.goBack()
-
-    verify { navHostController.popBackStack() }
-  }
-
-  @Test
   fun topLevelDestinationsHaveCorrectIcon() {
     assertThat(TopLevelDestinations.CHAT.icon, `is`(Icons.Filled.MailOutline))
     assertThat(TopLevelDestinations.MAP.icon, `is`(Icons.Outlined.Place))
@@ -99,5 +92,17 @@ class NavigationActionsTest {
                 TopLevelDestinations.CHAT,
                 TopLevelDestinations.NEW_BOOK,
                 TopLevelDestinations.MAP)))
+  }
+
+  @Test
+  fun `go back when previous route is AUTH does nothing`() {
+    val mockPreviousBackStackEntry : NavBackStackEntry? = mockk()
+    every { mockPreviousBackStackEntry?.destination?.route } returns C.Route.AUTH
+
+    every { navHostController.previousBackStackEntry } returns mockPreviousBackStackEntry
+
+    navigationActions.goBack()
+
+    verify(exactly = 0) { navHostController.popBackStack() }
   }
 }


### PR DESCRIPTION
This PR fixes an issue where a new user navigating back using the `goBack` function on the Map screen could return to the `NEW USER` or `Login` screen if the previous route was `AUTH`. This behavior was unintended and has now been corrected.

In addition to this fix:
1. A new test has been added to ensure the `goBack` function prevents navigation back to `AUTH`.
2. The old `goBack` test has been removed as it is now obsolete due to the changes in functionality.

This change ensures a smoother and more intuitive navigation experience for new users.