### PR TITLE
Changes to How Messages Are Stored in Firebase

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/endtoend/ChatEndToEnd.kt
+++ b/app/src/androidTest/java/com/android/bookswap/endtoend/ChatEndToEnd.kt
@@ -332,35 +332,56 @@ class ChatEndToEnd {
   }
 
   class MockMessageRepository : MessageRepository {
-    val messages = mutableListOf<DataMessage>()
-    private var nextUUID = UUID.randomUUID()
-
-    override fun getNewUUID(): UUID {
-      val currentUUID = nextUUID
-      nextUUID = UUID.randomUUID()
-      return currentUUID
-    }
+    var mockNewUUID: UUID = UUID.randomUUID()
+    var messages: MutableList<DataMessage> = mutableListOf()
+    private var sendMessageResult: Result<Unit> = Result.success(Unit)
 
     override fun init(callback: (Result<Unit>) -> Unit) {
-      callback(Result.success(Unit)) // Simulates successful initialization
+      callback(Result.success(Unit))
     }
 
-    override fun getMessages(callback: (Result<List<DataMessage>>) -> Unit) {
-      callback(Result.success(messages))
+    override fun getNewUUID(): UUID {
+      return mockNewUUID
+    }
+
+    override fun getMessages(
+        user1UUID: UUID,
+        user2UUID: UUID,
+        callback: (Result<List<DataMessage>>) -> Unit
+    ) {
+      // Filter messages to only include those between user1 and user2
+      val filteredMessages =
+          messages.filter { message ->
+            (message.senderUUID == user1UUID && message.receiverUUID == user2UUID) ||
+                (message.senderUUID == user2UUID && message.receiverUUID == user1UUID)
+          }
+      callback(Result.success(filteredMessages))
     }
 
     override fun sendMessage(message: DataMessage, callback: (Result<Unit>) -> Unit) {
       messages.add(message)
-      callback(Result.success(Unit))
+      callback(sendMessageResult)
     }
 
     override fun deleteMessage(
         messageUUID: UUID,
+        user1UUID: UUID,
+        user2UUID: UUID,
         callback: (Result<Unit>) -> Unit,
         context: Context
     ) {
-      messages.removeIf { it.uuid == messageUUID }
-      callback(Result.success(Unit))
+      // Remove the message if it matches the UUID and is between the two users
+      val removed =
+          messages.removeIf { message ->
+            message.uuid == messageUUID &&
+                ((message.senderUUID == user1UUID && message.receiverUUID == user2UUID) ||
+                    (message.senderUUID == user2UUID && message.receiverUUID == user1UUID))
+          }
+      if (removed) {
+        callback(Result.success(Unit))
+      } else {
+        callback(Result.failure(Exception("Message not found")))
+      }
     }
 
     override fun deleteAllMessages(
@@ -368,21 +389,28 @@ class ChatEndToEnd {
         user2UUID: UUID,
         callback: (Result<Unit>) -> Unit
     ) {
-      messages.removeIf {
-        (it.senderUUID == user1UUID && it.receiverUUID == user2UUID) ||
-            (it.senderUUID == user2UUID && it.receiverUUID == user1UUID)
+      // Remove all messages between the two users
+      messages.removeIf { message ->
+        (message.senderUUID == user1UUID && message.receiverUUID == user2UUID) ||
+            (message.senderUUID == user2UUID && message.receiverUUID == user1UUID)
       }
       callback(Result.success(Unit))
     }
 
     override fun updateMessage(
         message: DataMessage,
+        user1UUID: UUID,
+        user2UUID: UUID,
         callback: (Result<Unit>) -> Unit,
         context: Context
     ) {
       val index = messages.indexOfFirst { it.uuid == message.uuid }
-      if (index != -1) {
-        messages[index] = message.copy(text = message.text) // Update the message text
+      if (index != -1 &&
+          ((messages[index].senderUUID == user1UUID && messages[index].receiverUUID == user2UUID) ||
+              (messages[index].senderUUID == user2UUID &&
+                  messages[index].receiverUUID == user1UUID))) {
+        // Update the message text and timestamp
+        messages[index] = message.copy(text = message.text, timestamp = System.currentTimeMillis())
         callback(Result.success(Unit))
       } else {
         callback(Result.failure(Exception("Message not found")))
@@ -394,9 +422,18 @@ class ChatEndToEnd {
         currentUserUUID: UUID,
         callback: (Result<List<DataMessage>>) -> Unit
     ): ListenerRegistration {
-      // Immediately provide the existing messages for testing
-      callback(Result.success(messages))
-      return mockk() // Return a mock ListenerRegistration
+      requireNotNull(otherUserUUID) { "otherUserId must not be null" }
+      requireNotNull(currentUserUUID) { "currentUserId must not be null" }
+
+      // Return messages between the two users
+      val filteredMessages =
+          messages.filter { message ->
+            (message.senderUUID == currentUserUUID && message.receiverUUID == otherUserUUID) ||
+                (message.senderUUID == otherUserUUID && message.receiverUUID == currentUserUUID)
+          }
+      callback(Result.success(filteredMessages))
+
+      return mockk()
     }
   }
 }

--- a/app/src/androidTest/java/com/android/bookswap/endtoend/ChatEndToEnd.kt
+++ b/app/src/androidTest/java/com/android/bookswap/endtoend/ChatEndToEnd.kt
@@ -373,8 +373,7 @@ class ChatEndToEnd {
         messageUUID: UUID,
         user1UUID: UUID,
         user2UUID: UUID,
-        callback: (Result<Unit>) -> Unit,
-        context: Context
+        callback: (Result<Unit>) -> Unit
     ) {
       // Remove the message if it matches the UUID and is between the two users
       val removed =
@@ -407,8 +406,7 @@ class ChatEndToEnd {
         message: DataMessage,
         user1UUID: UUID,
         user2UUID: UUID,
-        callback: (Result<Unit>) -> Unit,
-        context: Context
+        callback: (Result<Unit>) -> Unit
     ) {
       val index = messages.indexOfFirst { it.uuid == message.uuid }
       if (index != -1 &&

--- a/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.performTextClearance
@@ -392,7 +393,6 @@ class ChatScreenTest {
     val messageNode =
         composeTestRule.onNodeWithTag(
             "${message.uuid}_" + C.Tag.ChatScreen.messages, useUnmergedTree = true)
-    messageNode.assertExists("Message item not found")
 
     messageNode.performSemanticsAction(SemanticsActions.OnLongClick)
 

--- a/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.performTextClearance

--- a/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
@@ -533,8 +533,18 @@ class ChatScreenTest {
       return mockNewUUID
     }
 
-    override fun getMessages(callback: (Result<List<DataMessage>>) -> Unit) {
-      callback(Result.success(messages))
+    override fun getMessages(
+        user1UUID: UUID,
+        user2UUID: UUID,
+        callback: (Result<List<DataMessage>>) -> Unit
+    ) {
+      // Filter messages to only include those between user1 and user2
+      val filteredMessages =
+          messages.filter { message ->
+            (message.senderUUID == user1UUID && message.receiverUUID == user2UUID) ||
+                (message.senderUUID == user2UUID && message.receiverUUID == user1UUID)
+          }
+      callback(Result.success(filteredMessages))
     }
 
     override fun sendMessage(message: DataMessage, callback: (Result<Unit>) -> Unit) {
@@ -544,11 +554,23 @@ class ChatScreenTest {
 
     override fun deleteMessage(
         messageUUID: UUID,
+        user1UUID: UUID,
+        user2UUID: UUID,
         callback: (Result<Unit>) -> Unit,
         context: Context
     ) {
-      messages.removeIf { it.uuid == messageUUID }
-      callback(Result.success(Unit))
+      // Remove the message if it matches the UUID and is between the two users
+      val removed =
+          messages.removeIf { message ->
+            message.uuid == messageUUID &&
+                ((message.senderUUID == user1UUID && message.receiverUUID == user2UUID) ||
+                    (message.senderUUID == user2UUID && message.receiverUUID == user1UUID))
+          }
+      if (removed) {
+        callback(Result.success(Unit))
+      } else {
+        callback(Result.failure(Exception("Message not found")))
+      }
     }
 
     override fun deleteAllMessages(
@@ -556,20 +578,29 @@ class ChatScreenTest {
         user2UUID: UUID,
         callback: (Result<Unit>) -> Unit
     ) {
-      messages.removeIf { it.senderUUID == user1UUID && it.receiverUUID == user2UUID }
-      messages.removeIf { it.senderUUID == user2UUID && it.receiverUUID == user1UUID }
+      // Remove all messages between the two users
+      messages.removeIf { message ->
+        (message.senderUUID == user1UUID && message.receiverUUID == user2UUID) ||
+            (message.senderUUID == user2UUID && message.receiverUUID == user1UUID)
+      }
       callback(Result.success(Unit))
     }
 
     override fun updateMessage(
         message: DataMessage,
+        user1UUID: UUID,
+        user2UUID: UUID,
         callback: (Result<Unit>) -> Unit,
         context: Context
     ) {
       val index = messages.indexOfFirst { it.uuid == message.uuid }
-      if (index != -1) {
-        messages[index] = message.copy(text = message.text) // Update the message text
-        callback(Result.success(Unit)) // Simulate success
+      if (index != -1 &&
+          ((messages[index].senderUUID == user1UUID && messages[index].receiverUUID == user2UUID) ||
+              (messages[index].senderUUID == user2UUID &&
+                  messages[index].receiverUUID == user1UUID))) {
+        // Update the message text and timestamp
+        messages[index] = message.copy(text = message.text, timestamp = System.currentTimeMillis())
+        callback(Result.success(Unit))
       } else {
         callback(Result.failure(Exception("Message not found")))
       }
@@ -583,7 +614,14 @@ class ChatScreenTest {
       requireNotNull(otherUserUUID) { "otherUserId must not be null" }
       requireNotNull(currentUserUUID) { "currentUserId must not be null" }
 
-      callback(Result.success(messages)) // Or whatever logic you'd like to simulate
+      // Return messages between the two users
+      val filteredMessages =
+          messages.filter { message ->
+            (message.senderUUID == currentUserUUID && message.receiverUUID == otherUserUUID) ||
+                (message.senderUUID == otherUserUUID && message.receiverUUID == currentUserUUID)
+          }
+      callback(Result.success(filteredMessages))
+
       return mockk()
     }
   }

--- a/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
@@ -557,8 +557,7 @@ class ChatScreenTest {
         messageUUID: UUID,
         user1UUID: UUID,
         user2UUID: UUID,
-        callback: (Result<Unit>) -> Unit,
-        context: Context
+        callback: (Result<Unit>) -> Unit
     ) {
       // Remove the message if it matches the UUID and is between the two users
       val removed =
@@ -591,8 +590,7 @@ class ChatScreenTest {
         message: DataMessage,
         user1UUID: UUID,
         user2UUID: UUID,
-        callback: (Result<Unit>) -> Unit,
-        context: Context
+        callback: (Result<Unit>) -> Unit
     ) {
       val index = messages.indexOfFirst { it.uuid == message.uuid }
       if (index != -1 &&

--- a/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
@@ -389,6 +389,12 @@ class ChatScreenTest {
     val message = placeHolderData.first()
     val newText = "Updated message text"
 
+    composeTestRule.waitUntil(timeoutMillis = 5000) {
+      composeTestRule
+          .onAllNodesWithTag("${message.uuid}_" + C.Tag.ChatScreen.messages, useUnmergedTree = true)
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+    }
     val messageNode =
         composeTestRule.onNodeWithTag(
             "${message.uuid}_" + C.Tag.ChatScreen.messages, useUnmergedTree = true)

--- a/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
@@ -2,8 +2,6 @@ package com.android.bookswap.ui.chat
 
 import android.content.Context
 import androidx.compose.ui.semantics.SemanticsActions
-import androidx.compose.ui.semantics.SemanticsProperties
-import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
@@ -389,12 +387,6 @@ class ChatScreenTest {
     val message = placeHolderData.first()
     val newText = "Updated message text"
 
-    composeTestRule.waitUntil(timeoutMillis = 5000) {
-      composeTestRule
-          .onAllNodesWithTag("${message.uuid}_" + C.Tag.ChatScreen.messages, useUnmergedTree = true)
-          .fetchSemanticsNodes()
-          .isNotEmpty()
-    }
     val messageNode =
         composeTestRule.onNodeWithTag(
             "${message.uuid}_" + C.Tag.ChatScreen.messages, useUnmergedTree = true)
@@ -432,19 +424,6 @@ class ChatScreenTest {
     assert(updatedMessage != null && updatedMessage.text == newText) {
       "Message was not updated correctly"
     }
-
-    composeTestRule.waitUntil(timeoutMillis = 5399) {
-      composeTestRule
-          .onNodeWithTag("${message.uuid}_" + C.Tag.ChatScreen.content, useUnmergedTree = true)
-          .fetchSemanticsNode()
-          .config
-          .getOrNull(SemanticsProperties.Text)
-          ?.joinToString() == newText
-    }
-
-    composeTestRule
-        .onNodeWithTag("${message.uuid}_" + C.Tag.ChatScreen.content, useUnmergedTree = true)
-        .assertTextEquals(newText)
 
     composeTestRule
         .onNodeWithTag(C.Tag.ChatScreen.message, useUnmergedTree = true)

--- a/app/src/main/java/com/android/bookswap/data/repository/MessageRepository.kt
+++ b/app/src/main/java/com/android/bookswap/data/repository/MessageRepository.kt
@@ -21,9 +21,13 @@ interface MessageRepository {
   /**
    * Get all messages as a list
    *
+   * @param user1UUID uuid of the first user
+   * @param user2UUID uuid of the second user
    * @param callback callback function that receives list of messages if success
    */
   fun getMessages(
+      user1UUID: UUID,
+      user2UUID: UUID,
       callback: (Result<List<DataMessage>>) -> Unit,
   )
 
@@ -40,10 +44,19 @@ interface MessageRepository {
    * Delete a message from the repository
    *
    * @param messageUUID UUID of message to be deleted
+   * @param user1UUID uuid of the first user
+   * @param user2UUID uuid of the second user
    * @param callback callback function that receives Result.success() when operation succeed of
    *   Result.failure(exception) if error
+   * @param context context of the application
    */
-  fun deleteMessage(messageUUID: UUID, callback: (Result<Unit>) -> Unit, context: Context)
+  fun deleteMessage(
+      messageUUID: UUID,
+      user1UUID: UUID,
+      user2UUID: UUID,
+      callback: (Result<Unit>) -> Unit,
+      context: Context
+  )
 
   /**
    * Delete all messages of this chat from the repository
@@ -59,10 +72,19 @@ interface MessageRepository {
    * Update a message in the repository
    *
    * @param message message to be updated
+   * @param user1UUID uuid of the first user
+   * @param user2UUID uuid of the second user
    * @param callback callback function that receives Result.success() when operation succeed of
    *   Result.failure(exception) if error
+   * @param context context of the application
    */
-  fun updateMessage(message: DataMessage, callback: (Result<Unit>) -> Unit, context: Context)
+  fun updateMessage(
+      message: DataMessage,
+      user1UUID: UUID,
+      user2UUID: UUID,
+      callback: (Result<Unit>) -> Unit,
+      context: Context
+  )
 
   /**
    * Add a listener to the repository to get messages in real-time

--- a/app/src/main/java/com/android/bookswap/data/repository/MessageRepository.kt
+++ b/app/src/main/java/com/android/bookswap/data/repository/MessageRepository.kt
@@ -1,6 +1,5 @@
 package com.android.bookswap.data.repository
 
-import android.content.Context
 import com.android.bookswap.data.DataMessage
 import com.google.firebase.firestore.ListenerRegistration
 import java.util.UUID
@@ -48,14 +47,12 @@ interface MessageRepository {
    * @param user2UUID uuid of the second user
    * @param callback callback function that receives Result.success() when operation succeed of
    *   Result.failure(exception) if error
-   * @param context context of the application
    */
   fun deleteMessage(
       messageUUID: UUID,
       user1UUID: UUID,
       user2UUID: UUID,
       callback: (Result<Unit>) -> Unit,
-      context: Context
   )
 
   /**
@@ -76,14 +73,12 @@ interface MessageRepository {
    * @param user2UUID uuid of the second user
    * @param callback callback function that receives Result.success() when operation succeed of
    *   Result.failure(exception) if error
-   * @param context context of the application
    */
   fun updateMessage(
       message: DataMessage,
       user1UUID: UUID,
       user2UUID: UUID,
-      callback: (Result<Unit>) -> Unit,
-      context: Context
+      callback: (Result<Unit>) -> Unit
   )
 
   /**

--- a/app/src/main/java/com/android/bookswap/data/source/network/MessageFirestoreSource.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/network/MessageFirestoreSource.kt
@@ -11,13 +11,14 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ListenerRegistration
 import java.util.UUID
 
-const val COLLECTION_PATH = "messages"
+const val COLLECTION_PATH = "chats"
 /**
  * Firestore source for managing messages.
  *
  * @param db The Firestore database instance.
  */
 class MessageFirestoreSource(private val db: FirebaseFirestore) : MessageRepository {
+
   /**
    * Generates a new UUID.
    *
@@ -26,6 +27,7 @@ class MessageFirestoreSource(private val db: FirebaseFirestore) : MessageReposit
   override fun getNewUUID(): UUID {
     return UUID.randomUUID()
   }
+
   /**
    * Firestore source for managing messages.
    *
@@ -39,27 +41,37 @@ class MessageFirestoreSource(private val db: FirebaseFirestore) : MessageReposit
       callback(Result.failure(e))
     }
   }
+
   /**
    * Fetches all messages from the Firestore database.
    *
+   * @param user1UUID UUID of the first user.
+   * @param user2UUID UUID of the second user.
    * @param callback Callback to be invoked with the result of the operation. The result is a list
    *   of DataMessage objects on success, or an exception on failure.
+   * @return A list of messages between the two users.
    */
-  override fun getMessages(callback: (Result<List<DataMessage>>) -> Unit) {
-    db.collection(COLLECTION_PATH).get().addOnCompleteListener { task ->
-      if (task.isSuccessful) {
-        val documents = task.result?.documents
-        if (!documents.isNullOrEmpty()) {
-          val messages = documents.mapNotNull { documentToMessage(it).getOrNull() }
-          callback(Result.success(messages))
-        } else {
-          callback(Result.success(emptyList()))
+  override fun getMessages(
+      user1UUID: UUID,
+      user2UUID: UUID,
+      callback: (Result<List<DataMessage>>) -> Unit
+  ) {
+    val chatPath = mergeUUIDs(user1UUID, user2UUID)
+
+    db.collection(COLLECTION_PATH)
+        .document(chatPath)
+        .collection("messages")
+        .get()
+        .addOnCompleteListener { task ->
+          if (task.isSuccessful && task.result != null) {
+            val messages = task.result!!.documents.mapNotNull { documentToMessage(it).getOrNull() }
+            callback(Result.success(messages))
+          } else {
+            callback(Result.failure(task.exception ?: Exception("Error fetching messages")))
+          }
         }
-      } else {
-        callback(Result.failure(task.exception ?: Exception("Unknown error fetching messages")))
-      }
-    }
   }
+
   /**
    * Sends a message to the Firestore database.
    *
@@ -68,6 +80,10 @@ class MessageFirestoreSource(private val db: FirebaseFirestore) : MessageReposit
    *   success if the message is sent successfully, or an exception on failure.
    */
   override fun sendMessage(message: DataMessage, callback: (Result<Unit>) -> Unit) {
+    // Generate the chat path using the consistent `mergeUUIDs` order
+    val chatPath = mergeUUIDs(message.senderUUID, message.receiverUUID)
+
+    // Map the message to a Firestore-compatible structure
     val messageMap =
         mapOf(
             "uuid" to message.uuid.toString(),
@@ -77,14 +93,17 @@ class MessageFirestoreSource(private val db: FirebaseFirestore) : MessageReposit
             "timestamp" to message.timestamp,
             "messageType" to message.messageType.name)
 
+    // Store the message in the correct chat subdivision
     db.collection(COLLECTION_PATH)
+        .document(chatPath)
+        .collection("messages")
         .document(message.uuid.toString())
         .set(messageMap)
-        .addOnCompleteListener { result ->
-          if (result.isSuccessful) {
+        .addOnCompleteListener { task ->
+          if (task.isSuccessful) {
             callback(Result.success(Unit))
           } else {
-            callback(Result.failure(result.exception ?: Exception("Unknown error sending message")))
+            callback(Result.failure(task.exception ?: Exception("Error sending message")))
           }
         }
   }
@@ -92,58 +111,75 @@ class MessageFirestoreSource(private val db: FirebaseFirestore) : MessageReposit
    * Deletes a message from the Firestore database.
    *
    * @param messageUUID The UUID of the message to be deleted.
+   * @param user1UUID The UUID of the first user.
+   * @param user2UUID The UUID of the second user.
    * @param callback Callback to be invoked with the result of the operation. The result is a
    *   success if the message is deleted successfully, or an exception on failure.
+   * @param context The context for displaying Toast messages.
    */
   override fun deleteMessage(
       messageUUID: UUID,
+      user1UUID: UUID,
+      user2UUID: UUID,
       callback: (Result<Unit>) -> Unit,
       context: Context
   ) {
-    val fifteenMinutesInMillis = 15 * 60 * 1000
-    val currentTime = System.currentTimeMillis()
+    // Generate the chat path using the consistent `mergeUUIDs` order
+    val chatPath = mergeUUIDs(user1UUID, user2UUID)
 
-    db.collection(COLLECTION_PATH).document(messageUUID.toString()).get().addOnCompleteListener {
-        task ->
-      if (task.isSuccessful) {
-        val document = task.result
-        if (document != null && document.exists()) {
-          val existingMessage = documentToMessage(document).getOrNull()
-          if (existingMessage != null) {
-            if (currentTime - existingMessage.timestamp <= fifteenMinutesInMillis) {
-              db.collection(COLLECTION_PATH)
-                  .document(messageUUID.toString())
-                  .delete()
-                  .addOnCompleteListener { deleteTask ->
-                    if (deleteTask.isSuccessful) {
-                      callback(Result.success(Unit))
-                    } else {
-                      callback(
-                          Result.failure(
-                              deleteTask.exception ?: Exception("Unknown error deleting message")))
+    // Fetch the message to check the deletion time window
+    db.collection(COLLECTION_PATH)
+        .document(chatPath)
+        .collection("messages")
+        .document(messageUUID.toString())
+        .get()
+        .addOnCompleteListener { task ->
+          if (task.isSuccessful && task.result != null && task.result!!.exists()) {
+            val document = task.result!!
+            val existingMessage = documentToMessage(document).getOrNull()
+
+            if (existingMessage != null) {
+              val currentTime = System.currentTimeMillis()
+              val fifteenMinutesInMillis = 15 * 60 * 1000
+
+              // Check if the message is within the 15-minute deletion window
+              if (currentTime - existingMessage.timestamp <= fifteenMinutesInMillis) {
+                // Delete the message
+                db.collection(COLLECTION_PATH)
+                    .document(chatPath)
+                    .collection("messages")
+                    .document(messageUUID.toString())
+                    .delete()
+                    .addOnCompleteListener { deleteTask ->
+                      if (deleteTask.isSuccessful) {
+                        callback(Result.success(Unit))
+                      } else {
+                        callback(
+                            Result.failure(
+                                deleteTask.exception ?: Exception("Error deleting message")))
+                      }
                     }
-                  }
+              } else {
+                // Notify the user that the deletion window has passed
+                Toast.makeText(
+                        context,
+                        "Message can only be deleted within 15 minutes of being sent",
+                        Toast.LENGTH_LONG)
+                    .show()
+                callback(
+                    Result.failure(
+                        Exception("Message can only be deleted within 15 minutes of being sent")))
+              }
             } else {
-              Toast.makeText(
-                      context,
-                      "Message can only be deleted within 15 minutes of being sent",
-                      Toast.LENGTH_LONG)
-                  .show()
-              callback(
-                  Result.failure(
-                      Exception("Message can only be deleted within 15 minutes of being sent")))
+              callback(Result.failure(Exception("Message not found")))
             }
           } else {
-            callback(Result.failure(Exception("Message not found")))
+            callback(
+                Result.failure(task.exception ?: Exception("Error fetching message for deletion")))
           }
-        } else {
-          callback(Result.failure(Exception("Message not found")))
         }
-      } else {
-        callback(Result.failure(task.exception ?: Exception("Unknown error fetching message")))
-      }
-    }
   }
+
   /**
    * Deletes all messages between two users from the Firestore database.
    *
@@ -157,31 +193,36 @@ class MessageFirestoreSource(private val db: FirebaseFirestore) : MessageReposit
       user2UUID: UUID,
       callback: (Result<Unit>) -> Unit
   ) {
+    // Generate the chat path using the consistent `mergeUUIDs` order
+    val chatPath = mergeUUIDs(user1UUID, user2UUID)
+
+    // Fetch all messages in the chat subdivision
     db.collection(COLLECTION_PATH)
-        .whereIn("senderUUID", listOf(user1UUID, user2UUID))
-        .whereIn("receiverUUID", listOf(user1UUID, user2UUID))
-        .whereNotEqualTo("senderUUID", "receiverUUID")
+        .document(chatPath)
+        .collection("messages")
         .get()
         .addOnCompleteListener { task ->
-          if (task.isSuccessful) {
-            val documents = task.result
-            if (documents != null && !documents.isEmpty) {
-              val batch = db.batch()
-              documents.documents.forEach { document -> batch.delete(document.reference) }
-              batch.commit().addOnCompleteListener { deleteTask ->
-                if (deleteTask.isSuccessful) {
-                  callback(Result.success(Unit))
-                } else {
-                  callback(
-                      Result.failure(
-                          deleteTask.exception ?: Exception("Unknown error deleting messages")))
-                }
+          if (task.isSuccessful && task.result != null) {
+            val batch = db.batch()
+            val documents = task.result!!.documents
+
+            // Add each document to the batch for deletion
+            for (document in documents) {
+              batch.delete(document.reference)
+            }
+
+            // Commit the batch
+            batch.commit().addOnCompleteListener { deleteTask ->
+              if (deleteTask.isSuccessful) {
+                callback(Result.success(Unit))
+              } else {
+                callback(
+                    Result.failure(deleteTask.exception ?: Exception("Error deleting messages")))
               }
-            } else {
-              callback(Result.success(Unit))
             }
           } else {
-            callback(Result.failure(task.exception ?: Exception("Unknown error fetching messages")))
+            callback(
+                Result.failure(task.exception ?: Exception("Error fetching messages for deletion")))
           }
         }
   }
@@ -189,63 +230,80 @@ class MessageFirestoreSource(private val db: FirebaseFirestore) : MessageReposit
    * Updates a message in the Firestore database.
    *
    * @param message The message to be updated.
+   * @param user1UUID The UUID of the first user.
+   * @param user2UUID The UUID of the second user.
    * @param callback Callback to be invoked with the result of the operation. The result is a
    *   success if the message is updated successfully, or an exception on failure.
    * @param context The context for displaying Toast messages.
    */
   override fun updateMessage(
       message: DataMessage,
+      user1UUID: UUID,
+      user2UUID: UUID,
       callback: (Result<Unit>) -> Unit,
       context: Context
   ) {
-    val fifteenMinutesInMillis = 15 * 60 * 1000
-    val currentTime = System.currentTimeMillis()
+    // Generate the chat path using the consistent `mergeUUIDs` order
+    val chatPath = mergeUUIDs(user1UUID, user2UUID)
 
-    db.collection(COLLECTION_PATH).document(message.uuid.toString()).get().addOnCompleteListener {
-        task ->
-      if (task.isSuccessful) {
-        val document = task.result
-        if (document != null && document.exists()) {
-          val existingMessage = documentToMessage(document).getOrNull()
-          if (existingMessage != null) {
-            if (currentTime - existingMessage.timestamp <= fifteenMinutesInMillis) {
-              val messageMap =
-                  mapOf(
-                      "text" to message.text,
-                      "timestamp" to currentTime,
-                      "messageType" to message.messageType.name)
-              db.collection(COLLECTION_PATH)
-                  .document(message.uuid.toString())
-                  .update(messageMap)
-                  .addOnCompleteListener { updateTask ->
-                    if (updateTask.isSuccessful) {
-                      callback(Result.success(Unit))
-                    } else {
-                      callback(
-                          Result.failure(
-                              updateTask.exception ?: Exception("Unknown error updating message")))
+    // Fetch the existing message to validate it exists and check the update window
+    db.collection(COLLECTION_PATH)
+        .document(chatPath)
+        .collection("messages")
+        .document(message.uuid.toString())
+        .get()
+        .addOnCompleteListener { task ->
+          if (task.isSuccessful && task.result != null && task.result!!.exists()) {
+            val document = task.result!!
+            val existingMessage = documentToMessage(document).getOrNull()
+
+            if (existingMessage != null) {
+              val currentTime = System.currentTimeMillis()
+              val fifteenMinutesInMillis = 15 * 60 * 1000
+
+              // Check if the message is within the 15-minute update window
+              if (currentTime - existingMessage.timestamp <= fifteenMinutesInMillis) {
+                // Prepare the updated fields
+                val updatedFields =
+                    mapOf(
+                        "text" to message.text,
+                        "timestamp" to currentTime,
+                        "messageType" to message.messageType.name)
+
+                // Perform the update
+                db.collection(COLLECTION_PATH)
+                    .document(chatPath)
+                    .collection("messages")
+                    .document(message.uuid.toString())
+                    .update(updatedFields)
+                    .addOnCompleteListener { updateTask ->
+                      if (updateTask.isSuccessful) {
+                        callback(Result.success(Unit))
+                      } else {
+                        callback(
+                            Result.failure(
+                                updateTask.exception ?: Exception("Error updating message")))
+                      }
                     }
-                  }
+              } else {
+                // Notify the user that the update window has passed
+                Toast.makeText(
+                        context,
+                        "Message can only be updated within 15 minutes of being sent",
+                        Toast.LENGTH_LONG)
+                    .show()
+                callback(
+                    Result.failure(
+                        Exception("Message can only be updated within 15 minutes of being sent")))
+              }
             } else {
-              Toast.makeText(
-                      context,
-                      "Message can only be updated within 15 minutes of being sent",
-                      Toast.LENGTH_LONG)
-                  .show()
-              callback(
-                  Result.failure(
-                      Exception("Message can only be updated within 15 minutes of being sent")))
+              callback(Result.failure(Exception("Message not found")))
             }
           } else {
-            callback(Result.failure(Exception("Message not found")))
+            callback(
+                Result.failure(task.exception ?: Exception("Error fetching message for update")))
           }
-        } else {
-          callback(Result.failure(Exception("Message not found")))
         }
-      } else {
-        callback(Result.failure(task.exception ?: Exception("Unknown error fetching message")))
-      }
-    }
   }
   /**
    * Adds a listener for real-time updates to messages between two users.
@@ -310,5 +368,20 @@ fun documentToMessage(document: DocumentSnapshot): Result<DataMessage> {
   } catch (e: Exception) {
     Log.e("MessageSource", "Error converting document to Message: ${e.message}")
     Result.failure(e)
+  }
+}
+
+/**
+ * Merges two UUIDs into a single string.
+ *
+ * @param uuid1 The first UUID.
+ * @param uuid2 The second UUID.
+ * @return A string containing both UUIDs.
+ */
+private fun mergeUUIDs(uuid1: UUID, uuid2: UUID): String {
+  return if (uuid1.toString() < uuid2.toString()) {
+    "${uuid1}_$uuid2"
+  } else {
+    "${uuid2}_$uuid1"
   }
 }

--- a/app/src/main/java/com/android/bookswap/data/source/network/MessageFirestoreSource.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/network/MessageFirestoreSource.kt
@@ -1,8 +1,6 @@
 package com.android.bookswap.data.source.network
 
-import android.content.Context
 import android.util.Log
-import android.widget.Toast
 import com.android.bookswap.data.DataMessage
 import com.android.bookswap.data.MessageType
 import com.android.bookswap.data.repository.MessageRepository
@@ -12,6 +10,7 @@ import com.google.firebase.firestore.ListenerRegistration
 import java.util.UUID
 
 const val COLLECTION_PATH = "chats"
+const val fifteenMinutesInMillis = 15 * 60 * 1000
 /**
  * Firestore source for managing messages.
  *
@@ -121,8 +120,7 @@ class MessageFirestoreSource(private val db: FirebaseFirestore) : MessageReposit
       messageUUID: UUID,
       user1UUID: UUID,
       user2UUID: UUID,
-      callback: (Result<Unit>) -> Unit,
-      context: Context
+      callback: (Result<Unit>) -> Unit
   ) {
     // Generate the chat path using the consistent `mergeUUIDs` order
     val chatPath = mergeUUIDs(user1UUID, user2UUID)
@@ -140,7 +138,6 @@ class MessageFirestoreSource(private val db: FirebaseFirestore) : MessageReposit
 
             if (existingMessage != null) {
               val currentTime = System.currentTimeMillis()
-              val fifteenMinutesInMillis = 15 * 60 * 1000
 
               // Check if the message is within the 15-minute deletion window
               if (currentTime - existingMessage.timestamp <= fifteenMinutesInMillis) {
@@ -161,11 +158,6 @@ class MessageFirestoreSource(private val db: FirebaseFirestore) : MessageReposit
                     }
               } else {
                 // Notify the user that the deletion window has passed
-                Toast.makeText(
-                        context,
-                        "Message can only be deleted within 15 minutes of being sent",
-                        Toast.LENGTH_LONG)
-                    .show()
                 callback(
                     Result.failure(
                         Exception("Message can only be deleted within 15 minutes of being sent")))
@@ -240,8 +232,7 @@ class MessageFirestoreSource(private val db: FirebaseFirestore) : MessageReposit
       message: DataMessage,
       user1UUID: UUID,
       user2UUID: UUID,
-      callback: (Result<Unit>) -> Unit,
-      context: Context
+      callback: (Result<Unit>) -> Unit
   ) {
     // Generate the chat path using the consistent `mergeUUIDs` order
     val chatPath = mergeUUIDs(user1UUID, user2UUID)
@@ -259,7 +250,6 @@ class MessageFirestoreSource(private val db: FirebaseFirestore) : MessageReposit
 
             if (existingMessage != null) {
               val currentTime = System.currentTimeMillis()
-              val fifteenMinutesInMillis = 15 * 60 * 1000
 
               // Check if the message is within the 15-minute update window
               if (currentTime - existingMessage.timestamp <= fifteenMinutesInMillis) {
@@ -287,11 +277,6 @@ class MessageFirestoreSource(private val db: FirebaseFirestore) : MessageReposit
                     }
               } else {
                 // Notify the user that the update window has passed
-                Toast.makeText(
-                        context,
-                        "Message can only be updated within 15 minutes of being sent",
-                        Toast.LENGTH_LONG)
-                    .show()
                 callback(
                     Result.failure(
                         Exception("Message can only be updated within 15 minutes of being sent")))

--- a/app/src/main/java/com/android/bookswap/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/chat/ChatScreen.kt
@@ -305,14 +305,18 @@ fun ChatScreen(
                       messageRepository.updateMessage(
                           selectedMessage!!.copy(text = newMessageText.text),
                           currentUser.userUUID,
-                          otherUser.userUUID,
-                          { result: Result<Unit> ->
+                          otherUser.userUUID) { result: Result<Unit> ->
                             if (result.isSuccess) {
                               Log.d("ChatScreen", "Message updated successfully")
                               selectedMessage = null
                               newMessageText = TextFieldValue("")
                               updateActive = false
                             } else {
+                              Toast.makeText(
+                                      context,
+                                      "Message can only be updated within 15 minutes of being sent",
+                                      Toast.LENGTH_LONG)
+                                  .show()
                               Log.e(
                                   "ChatScreen",
                                   "Failed to update message: ${result.exceptionOrNull()?.message}")
@@ -320,8 +324,7 @@ fun ChatScreen(
                               newMessageText = TextFieldValue("")
                               updateActive = false
                             }
-                          },
-                          context)
+                          }
                     } else {
                       // Send a new message
                       val messageId = messageRepository.getNewUUID()
@@ -397,20 +400,21 @@ fun ChatScreen(
                           // Handle delete
                           selectedMessage?.let { message ->
                             messageRepository.deleteMessage(
-                                message.uuid,
-                                currentUser.userUUID,
-                                otherUser.userUUID,
-                                { result ->
+                                message.uuid, currentUser.userUUID, otherUser.userUUID) { result ->
                                   if (result.isSuccess) {
                                     Log.d("ChatScreen", "Message deleted successfully")
                                     selectedMessage = null
                                   } else {
+                                    Toast.makeText(
+                                            context,
+                                            "Message can only be deleted within 15 minutes of being sent",
+                                            Toast.LENGTH_LONG)
+                                        .show()
                                     Log.e(
                                         "ChatScreen",
                                         "Failed to delete message: ${result.exceptionOrNull()?.message}")
                                   }
-                                },
-                                context)
+                                }
                           }
                         },
                         modifier =

--- a/app/src/main/java/com/android/bookswap/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/chat/ChatScreen.kt
@@ -154,7 +154,7 @@ fun ChatScreen(
         messageStorage.addMessage(message)
       }
       messageStorage.setMessages()
-      messageRepository.getMessages { result ->
+      messageRepository.getMessages(currentUser.userUUID, otherUser.userUUID) { result ->
         if (result.isSuccess) {
           messages =
               result
@@ -252,6 +252,8 @@ fun ChatScreen(
                       // Update the message
                       messageRepository.updateMessage(
                           selectedMessage!!.copy(text = newMessageText.text),
+                          currentUser.userUUID,
+                          otherUser.userUUID,
                           { result: Result<Unit> ->
                             if (result.isSuccess) {
                               Log.d("ChatScreen", "Message updated successfully")
@@ -344,6 +346,8 @@ fun ChatScreen(
                           selectedMessage?.let { message ->
                             messageRepository.deleteMessage(
                                 message.uuid,
+                                currentUser.userUUID,
+                                otherUser.userUUID,
                                 { result ->
                                   if (result.isSuccess) {
                                     Log.d("ChatScreen", "Message deleted successfully")

--- a/app/src/test/java/com/android/bookswap/model/chat/DataMessageFirestoreSourceTest.kt
+++ b/app/src/test/java/com/android/bookswap/model/chat/DataMessageFirestoreSourceTest.kt
@@ -1,6 +1,5 @@
 package com.android.bookswap.model.chat
 
-import android.content.Context
 import android.os.Looper
 import com.android.bookswap.data.DataMessage
 import com.android.bookswap.data.MessageType
@@ -34,7 +33,6 @@ class DataMessageFirestoreSourceTest {
   private val mockDocumentReference: DocumentReference = mockk()
   private val mockDocumentSnapshot: DocumentSnapshot = mockk()
   private val mockQuerySnapshot: QuerySnapshot = mockk()
-  private val mockContext: Context = mockk()
 
   private lateinit var messageRepository: MessageFirestoreSource
   private lateinit var messageFirestoreSource: MessageFirestoreSource
@@ -232,11 +230,9 @@ class DataMessageFirestoreSourceTest {
     } returns Tasks.forResult(null)
 
     messageFirestoreSource.deleteMessage(
-        testMessage.uuid,
-        testMessage.senderUUID,
-        testMessage.receiverUUID,
-        { result -> assert(result.isSuccess) },
-        mockContext)
+        testMessage.uuid, testMessage.senderUUID, testMessage.receiverUUID) { result ->
+          assert(result.isSuccess)
+        }
 
     shadowOf(Looper.getMainLooper()).idle()
     verify {
@@ -262,14 +258,10 @@ class DataMessageFirestoreSourceTest {
     every { mockDocumentSnapshot.exists() } returns false // Message does not exist
 
     messageFirestoreSource.deleteMessage(
-        testMessage.uuid,
-        testMessage.senderUUID,
-        testMessage.receiverUUID,
-        { result ->
+        testMessage.uuid, testMessage.senderUUID, testMessage.receiverUUID) { result ->
           assert(result.isFailure)
           assert(result.exceptionOrNull()?.message == "Message not found")
-        },
-        mockContext)
+        }
   }
 
   @Test
@@ -288,16 +280,12 @@ class DataMessageFirestoreSourceTest {
     every { mockDocumentSnapshot.getLong("timestamp") } returns oldTimestamp
 
     messageFirestoreSource.deleteMessage(
-        testMessage.uuid,
-        testMessage.senderUUID,
-        testMessage.receiverUUID,
-        { result ->
+        testMessage.uuid, testMessage.senderUUID, testMessage.receiverUUID) { result ->
           assert(result.isFailure)
           assert(
               result.exceptionOrNull()?.message ==
                   "Message can only be deleted within 15 minutes of being sent")
-        },
-        mockContext)
+        }
   }
 
   @Test
@@ -314,14 +302,10 @@ class DataMessageFirestoreSourceTest {
     } returns Tasks.forException(exception)
 
     messageFirestoreSource.deleteMessage(
-        testMessage.uuid,
-        testMessage.senderUUID,
-        testMessage.receiverUUID,
-        { result ->
+        testMessage.uuid, testMessage.senderUUID, testMessage.receiverUUID) { result ->
           assert(result.isFailure)
           assert(result.exceptionOrNull() == exception)
-        },
-        mockContext)
+        }
   }
 
   @Test
@@ -348,14 +332,10 @@ class DataMessageFirestoreSourceTest {
     } returns Tasks.forException(exception)
 
     messageFirestoreSource.deleteMessage(
-        testMessage.uuid,
-        testMessage.senderUUID,
-        testMessage.receiverUUID,
-        { result ->
+        testMessage.uuid, testMessage.senderUUID, testMessage.receiverUUID) { result ->
           assert(result.isFailure)
           assert(result.exceptionOrNull() == exception)
-        },
-        mockContext)
+        }
   }
 
   @Test
@@ -373,14 +353,10 @@ class DataMessageFirestoreSourceTest {
         null // Missing field causes conversion failure
 
     messageFirestoreSource.deleteMessage(
-        testMessage.uuid,
-        testMessage.senderUUID,
-        testMessage.receiverUUID,
-        { result ->
+        testMessage.uuid, testMessage.senderUUID, testMessage.receiverUUID) { result ->
           assert(result.isFailure)
           assert(result.exceptionOrNull()?.message == "Message not found")
-        },
-        mockContext)
+        }
   }
 
   // DeleteAllMessages Tests
@@ -472,14 +448,10 @@ class DataMessageFirestoreSourceTest {
     every { mockDocumentSnapshot.exists() } returns false
 
     messageFirestoreSource.updateMessage(
-        testMessage,
-        testMessage.senderUUID,
-        testMessage.receiverUUID,
-        { result ->
+        testMessage, testMessage.senderUUID, testMessage.receiverUUID) { result ->
           assert(result.isFailure)
           assert(result.exceptionOrNull()?.message == "Message not found")
-        },
-        mockContext)
+        }
   }
 
   @Test
@@ -501,16 +473,12 @@ class DataMessageFirestoreSourceTest {
     every { mockDocumentSnapshot.getLong("timestamp") } returns oldMessage.timestamp
 
     messageFirestoreSource.updateMessage(
-        oldMessage,
-        testMessage.senderUUID,
-        testMessage.receiverUUID,
-        { result ->
+        oldMessage, testMessage.senderUUID, testMessage.receiverUUID) { result ->
           assert(result.isFailure)
           assert(
               result.exceptionOrNull()?.message ==
                   "Message can only be updated within 15 minutes of being sent")
-        },
-        mockContext)
+        }
   }
 
   @Test
@@ -527,14 +495,10 @@ class DataMessageFirestoreSourceTest {
     } returns Tasks.forException(exception)
 
     messageFirestoreSource.updateMessage(
-        testMessage,
-        testMessage.senderUUID,
-        testMessage.receiverUUID,
-        { result ->
+        testMessage, testMessage.senderUUID, testMessage.receiverUUID) { result ->
           assert(result.isFailure)
           assert(result.exceptionOrNull() == exception)
-        },
-        mockContext)
+        }
   }
 
   @Test
@@ -569,14 +533,10 @@ class DataMessageFirestoreSourceTest {
     } returns Tasks.forException(exception)
 
     messageFirestoreSource.updateMessage(
-        recentMessage,
-        testMessage.senderUUID,
-        testMessage.receiverUUID,
-        { result ->
+        recentMessage, testMessage.senderUUID, testMessage.receiverUUID) { result ->
           assert(result.isFailure)
           assert(result.exceptionOrNull() == exception)
-        },
-        mockContext)
+        }
   }
 
   @Test
@@ -593,14 +553,10 @@ class DataMessageFirestoreSourceTest {
         null // Missing field causes conversion failure
 
     messageFirestoreSource.updateMessage(
-        testMessage,
-        testMessage.senderUUID,
-        testMessage.receiverUUID,
-        { result ->
+        testMessage, testMessage.senderUUID, testMessage.receiverUUID) { result ->
           assert(result.isFailure)
           assert(result.exceptionOrNull()?.message == "Message not found")
-        },
-        mockContext)
+        }
   }
 
   @Test


### PR DESCRIPTION
# Changes to How Messages Are Stored in Firebase
This pull request seeks to update the methods and structure by which the messages are stored in the Firestore Database

## Previous Storage Method
Previously, all messages were stored in a single collection (messages) without subdivision. Each message was represented as a document, as can be seen below:
``` css
messages/
  <message_uuid>: {
    DataMessage
  }
``` 
## Updated Storage Method
Messages are now subdivided into conversation-specific subcollections based on the participants' UUIDs. The subcollections are identified by the concatenation of the sender's and receiver's UUIDs in size order. The new structure can be seen below:
``` css
chats/
  <sorted_uuid_1>_<sorted_uuid_2>/
    messages/
      <message_uuid>: {
        DataMessage
      }
``` 
## Changes to files
Of course, the file by which all of these interactions with firebase are performed has been updated in its entirety along with all relevant tests. Most notably `getMessages` is the function that has changed the most, as now it has to search for a particular set of messages and not all messages at once. The function `sendMessage` has also seen significant conceptual changes to ensure the new structure is always maintained. All other functions include minor fixes to adapt to the new structure.

Additionally, there has also been changes to `updateMessageBoxMap`, which has not only been changed to use the new `getMessages` function, but as an added bonus, also filters out all `IMAGE` type messages to ensure only `TEXT` messages are displayed in the message box.

`ChatScreen` has also seen changes to adapt to the new functions which could at time require additional parameters.