### PR TITLE
Fix Listener for Chat

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/chat/ChatScreenTest.kt
@@ -19,6 +19,7 @@ import com.android.bookswap.data.MessageType
 import com.android.bookswap.data.repository.MessageRepository
 import com.android.bookswap.data.repository.PhotoFirebaseStorageRepository
 import com.android.bookswap.data.source.network.UserFirestoreSource
+import com.android.bookswap.model.chat.ChatScreenViewModel
 import com.android.bookswap.model.chat.OfflineMessageStorage
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.navigation.NavigationActions
@@ -28,9 +29,6 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 import java.util.UUID
 import org.junit.Before
 import org.junit.Rule
@@ -43,6 +41,7 @@ class ChatScreenTest {
   private lateinit var mockPhotoStorage: PhotoFirebaseStorageRepository
   private lateinit var mockMessageStorage: OfflineMessageStorage
   private lateinit var mockUserRepository: UserFirestoreSource
+  private lateinit var chatScreenViewModel: ChatScreenViewModel
   private val currentUserUUID = UUID.randomUUID()
   private val otherUserUUID = UUID.randomUUID()
   private lateinit var mockNavigationActions: NavigationActions
@@ -60,6 +59,8 @@ class ChatScreenTest {
     mockMessageStorage = mockk()
     mockContext = mockk()
     mockUserRepository = mockk()
+
+    chatScreenViewModel = ChatScreenViewModel()
 
     placeHolderData =
         List(6) {
@@ -99,14 +100,6 @@ class ChatScreenTest {
           ColorVariable.Accent,
           ColorVariable.AccentSecondary,
           ColorVariable.BackGround)
-
-  @Test
-  fun testFormatTimeStamps() {
-    val timestamp = System.currentTimeMillis()
-    val formattedTimestamp = formatTimestamp(timestamp)
-    val expectedTimestamp = SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date(timestamp))
-    assert(formattedTimestamp == expectedTimestamp)
-  }
 
   @Test
   fun hasRequiredComponentsWithoutMessage() {
@@ -166,7 +159,7 @@ class ChatScreenTest {
             .assertIsDisplayed()
         composeTestRule
             .onNodeWithTag("${message.uuid}_" + C.Tag.ChatScreen.timestamp, useUnmergedTree = true)
-            .assertTextEquals(formatTimestamp(message.timestamp))
+            .assertTextEquals(chatScreenViewModel.formatTimestamp(message.timestamp))
       }
     }
   }

--- a/app/src/main/java/com/android/bookswap/data/source/network/MessageFirestoreSource.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/network/MessageFirestoreSource.kt
@@ -304,29 +304,24 @@ class MessageFirestoreSource(private val db: FirebaseFirestore) : MessageReposit
       currentUserUUID: UUID,
       callback: (Result<List<DataMessage>>) -> Unit
   ): ListenerRegistration {
-    return db.collection("messages")
-        .whereIn("senderId", listOf(currentUserUUID, otherUserUUID))
-        .whereIn("receiverId", listOf(currentUserUUID, otherUserUUID))
-        .whereNotEqualTo("senderId", "receiverId")
+    val chatPath = mergeUUIDs(currentUserUUID, otherUserUUID)
+
+    // Attach listener to the specific chat's "messages" subcollection
+    return db.collection(COLLECTION_PATH)
+        .document(chatPath)
+        .collection("messages")
         .addSnapshotListener { snapshot, e ->
           if (e != null) {
             callback(Result.failure(e))
             return@addSnapshotListener
           }
 
-          if (snapshot != null && !snapshot.isEmpty) {
+          if (snapshot != null) {
             val messages =
                 snapshot.documents
-                    .mapNotNull { document ->
-                      try {
-                        document.toObject(DataMessage::class.java)
-                      } catch (ex: Exception) {
-                        Log.e(
-                            "MessageSource", "Error converting document to Message: ${ex.message}")
-                        null
-                      }
-                    }
+                    .mapNotNull { document -> documentToMessage(document).getOrNull() }
                     .sortedBy { it.timestamp } // Sort messages by timestamp
+
             callback(Result.success(messages))
           } else {
             callback(Result.success(emptyList()))

--- a/app/src/main/java/com/android/bookswap/model/chat/ChatScreenViewModel.kt
+++ b/app/src/main/java/com/android/bookswap/model/chat/ChatScreenViewModel.kt
@@ -1,0 +1,85 @@
+package com.android.bookswap.model.chat
+
+import android.util.Log
+import com.android.bookswap.data.DataUser
+import com.android.bookswap.data.repository.UsersRepository
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class ChatScreenViewModel {
+
+  /**
+   * Formats a timestamp into a readable string.
+   *
+   * @param timestamp The timestamp to format.
+   * @return A formatted string representing the timestamp. If the timestamp is from today, it
+   *   returns the time in "HH:mm" format. Otherwise, it returns the date in "MMM dd, yyyy" format.
+   */
+  fun formatTimestamp(timestamp: Long): String {
+    val messageDate = Date(timestamp)
+    val currentDate = Date()
+    val dateFormat = SimpleDateFormat("yyyyMMdd", Locale.getDefault())
+    val timeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
+    val dateTimeFormat = SimpleDateFormat("dd MMM, yyyy", Locale.getDefault())
+
+    return if (dateFormat.format(messageDate) == dateFormat.format(currentDate)) {
+      timeFormat.format(messageDate)
+    } else {
+      dateTimeFormat.format(messageDate)
+    }
+  }
+
+  /**
+   * Adds the other user to the current user's contacts and vice versa.
+   *
+   * @param userSource The repository to fetch and update user data.
+   * @param currentUser The current user.
+   * @param otherUser The other user to add to the current user's contacts.
+   */
+  fun addContacts(userSource: UsersRepository, currentUser: DataUser, otherUser: DataUser) {
+    // Add otherUser to currentUser's contacts
+    userSource.getUser(currentUser.userUUID) { result ->
+      if (result.isSuccess) {
+        val updatedUser = result.getOrThrow()
+        if (!updatedUser.contactList.contains(otherUser.userUUID.toString())) {
+          userSource.addContact(currentUser.userUUID, otherUser.userUUID.toString()) { contactResult
+            ->
+            if (contactResult.isSuccess) {
+              Log.d(
+                  "ChatScreen", "Added ${otherUser.userUUID} to ${currentUser.userUUID}'s contacts")
+            } else {
+              Log.e(
+                  "ChatScreen",
+                  "Failed to add contact: ${contactResult.exceptionOrNull()?.message}")
+            }
+          }
+        }
+      } else {
+        Log.e("ChatScreen", "Failed to fetch current user: ${result.exceptionOrNull()?.message}")
+      }
+    }
+
+    // Add currentUser to otherUser's contacts
+    userSource.getUser(otherUser.userUUID) { result ->
+      if (result.isSuccess) {
+        val updatedOtherUser = result.getOrThrow()
+        if (!updatedOtherUser.contactList.contains(currentUser.userUUID.toString())) {
+          userSource.addContact(otherUser.userUUID, currentUser.userUUID.toString()) { contactResult
+            ->
+            if (contactResult.isSuccess) {
+              Log.d(
+                  "ChatScreen", "Added ${currentUser.userUUID} to ${otherUser.userUUID}'s contacts")
+            } else {
+              Log.e(
+                  "ChatScreen",
+                  "Failed to add contact: ${contactResult.exceptionOrNull()?.message}")
+            }
+          }
+        }
+      } else {
+        Log.e("ChatScreen", "Failed to fetch other user: ${result.exceptionOrNull()?.message}")
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/android/bookswap/model/chat/ContactViewModel.kt
+++ b/app/src/main/java/com/android/bookswap/model/chat/ContactViewModel.kt
@@ -30,6 +30,7 @@ class ContactViewModel(
         MessageFirestoreSource(FirebaseFirestore.getInstance())
 ) : ViewModel() {
 
+  private val chatScreenViewModel = ChatScreenViewModel()
   private val _messageBoxMap = MutableStateFlow<Map<UUID, MessageBox>>(emptyMap())
 
   val messageBoxMap: StateFlow<Map<UUID, MessageBox>> = _messageBoxMap
@@ -62,7 +63,8 @@ class ContactViewModel(
                         // Extract the last message details
                         val lastMessage = filteredMessages.lastOrNull()
                         val lastMessageText = lastMessage?.text ?: ""
-                        val lastMessageTimestamp = lastMessage?.timestamp?.toString() ?: ""
+                        val lastMessageTimestamp =
+                            chatScreenViewModel.formatTimestamp(lastMessage?.timestamp ?: 0)
 
                         // Update the message box map
                         _messageBoxMap.value =

--- a/app/src/main/java/com/android/bookswap/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/chat/ChatScreen.kt
@@ -68,15 +68,13 @@ import com.android.bookswap.data.repository.MessageRepository
 import com.android.bookswap.data.repository.PhotoFirebaseStorageRepository
 import com.android.bookswap.data.repository.UsersRepository
 import com.android.bookswap.model.PhotoRequester
+import com.android.bookswap.model.chat.ChatScreenViewModel
 import com.android.bookswap.model.chat.OfflineMessageStorage
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.MAXLENGTHMESSAGE
 import com.android.bookswap.ui.components.BackButtonComponent
 import com.android.bookswap.ui.navigation.NavigationActions
 import com.android.bookswap.ui.theme.ColorVariable
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 import java.util.UUID
 
 /**
@@ -100,6 +98,7 @@ fun ChatScreen(
     messageStorage: OfflineMessageStorage,
     context: Context
 ) {
+  val chatScreenViewModel = ChatScreenViewModel()
   var messages by remember { mutableStateOf(emptyList<DataMessage>()) }
   var newMessageText by remember { mutableStateOf(TextFieldValue("")) }
   var selectedMessage by remember { mutableStateOf<DataMessage?>(null) }
@@ -178,51 +177,10 @@ fun ChatScreen(
   }
 
   LaunchedEffect(Unit) {
-    if (messages.isNotEmpty()) {
-      // Add otherUser to currentUser's contacts
-      userSource.getUser(currentUser.userUUID) { result ->
-        if (result.isSuccess) {
-          val updatedUser = result.getOrThrow()
-          if (!updatedUser.contactList.contains(otherUser.userUUID.toString())) {
-            userSource.addContact(currentUser.userUUID, otherUser.userUUID.toString()) {
-                contactResult ->
-              if (contactResult.isSuccess) {
-                Log.d(
-                    "ChatScreen",
-                    "Added ${otherUser.userUUID} to ${currentUser.userUUID}'s contacts")
-              } else {
-                Log.e(
-                    "ChatScreen",
-                    "Failed to add contact: ${contactResult.exceptionOrNull()?.message}")
-              }
-            }
-          }
-        } else {
-          Log.e("ChatScreen", "Failed to fetch current user: ${result.exceptionOrNull()?.message}")
-        }
-      }
-
-      // Add currentUser to otherUser's contacts
-      userSource.getUser(otherUser.userUUID) { result ->
-        if (result.isSuccess) {
-          val updatedOtherUser = result.getOrThrow()
-          if (!updatedOtherUser.contactList.contains(currentUser.userUUID.toString())) {
-            userSource.addContact(otherUser.userUUID, currentUser.userUUID.toString()) {
-                contactResult ->
-              if (contactResult.isSuccess) {
-                Log.d(
-                    "ChatScreen",
-                    "Added ${currentUser.userUUID} to ${otherUser.userUUID}'s contacts")
-              } else {
-                Log.e(
-                    "ChatScreen",
-                    "Failed to add contact: ${contactResult.exceptionOrNull()?.message}")
-              }
-            }
-          }
-        } else {
-          Log.e("ChatScreen", "Failed to fetch other user: ${result.exceptionOrNull()?.message}")
-        }
+    while (true) {
+      if (messages.isNotEmpty()) {
+        chatScreenViewModel.addContacts(userSource, currentUser, otherUser)
+        break
       }
     }
   }
@@ -263,6 +221,7 @@ fun ChatScreen(
                 MessageItem(
                     message = message,
                     currentUserUUID = currentUser.userUUID,
+                    chatScreenViewModel = chatScreenViewModel,
                     onLongPress = { selectedMessage = message })
               }
             }
@@ -438,7 +397,12 @@ fun ChatScreen(
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun MessageItem(message: DataMessage, currentUserUUID: UUID, onLongPress: () -> Unit) {
+fun MessageItem(
+    message: DataMessage,
+    currentUserUUID: UUID,
+    chatScreenViewModel: ChatScreenViewModel,
+    onLongPress: () -> Unit
+) {
   val isCurrentUser = message.senderUUID == currentUserUUID
   val cornerRadius = 25.dp
   val padding8 = 8.dp
@@ -518,7 +482,7 @@ fun MessageItem(message: DataMessage, currentUserUUID: UUID, onLongPress: () -> 
                           color = ColorVariable.Accent)
                     }
                     Text(
-                        text = formatTimestamp(message.timestamp),
+                        text = chatScreenViewModel.formatTimestamp(message.timestamp),
                         color = ColorVariable.AccentSecondary,
                         style = MaterialTheme.typography.bodySmall,
                         modifier =
@@ -580,26 +544,6 @@ fun MessageItem(message: DataMessage, currentUserUUID: UUID, onLongPress: () -> 
                     }
               }
         }
-  }
-}
-/**
- * Formats a timestamp into a readable string.
- *
- * @param timestamp The timestamp to format.
- * @return A formatted string representing the timestamp. If the timestamp is from today, it returns
- *   the time in "HH:mm" format. Otherwise, it returns the date in "MMM dd, yyyy" format.
- */
-fun formatTimestamp(timestamp: Long): String {
-  val messageDate = Date(timestamp)
-  val currentDate = Date()
-  val dateFormat = SimpleDateFormat("yyyyMMdd", Locale.getDefault())
-  val timeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
-  val dateTimeFormat = SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
-
-  return if (dateFormat.format(messageDate) == dateFormat.format(currentDate)) {
-    timeFormat.format(messageDate)
-  } else {
-    dateTimeFormat.format(messageDate)
   }
 }
 

--- a/app/src/test/java/com/android/bookswap/model/chat/ChatScreenViewModelTest.kt
+++ b/app/src/test/java/com/android/bookswap/model/chat/ChatScreenViewModelTest.kt
@@ -1,0 +1,120 @@
+package com.android.bookswap.model.chat
+
+import com.android.bookswap.data.DataUser
+import com.android.bookswap.data.repository.UsersRepository
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.UUID
+import org.junit.Before
+import org.junit.Test
+
+class ChatScreenViewModelTest {
+
+  private lateinit var chatScreenViewModel: ChatScreenViewModel
+  private val currentUser =
+      DataUser(
+          UUID.randomUUID(),
+          "Hello",
+          "Jaime",
+          "Oliver Pastor",
+          "",
+          "",
+          0.0,
+          0.0,
+          "",
+          emptyList(),
+          "")
+  private val otherUser =
+      DataUser(UUID.randomUUID(), "Hey", "Matias", "Salvade", "", "", 0.0, 0.0, "", emptyList(), "")
+
+  @MockK lateinit var mockUsersRepository: UsersRepository
+
+  @Before
+  fun setup() {
+    chatScreenViewModel = ChatScreenViewModel()
+    MockKAnnotations.init(this)
+  }
+
+  @Test
+  fun testFormatTimeStamps() {
+    val timestamp = System.currentTimeMillis()
+    val formattedTimestamp = chatScreenViewModel.formatTimestamp(timestamp)
+    val expectedTimestamp = SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date(timestamp))
+    assert(formattedTimestamp == expectedTimestamp)
+  }
+
+  @Test
+  fun `addContacts adds users to each other's contact lists on success`() {
+    every { mockUsersRepository.getUser(currentUser.userUUID, any()) } answers
+        {
+          val callback = secondArg<(Result<DataUser>) -> Unit>()
+          callback(Result.success(currentUser))
+        }
+
+    every { mockUsersRepository.getUser(otherUser.userUUID, any()) } answers
+        {
+          val callback = secondArg<(Result<DataUser>) -> Unit>()
+          callback(Result.success(otherUser))
+        }
+
+    every { mockUsersRepository.addContact(any(), any(), any()) } answers
+        {
+          val callback = thirdArg<(Result<Unit>) -> Unit>()
+          callback(Result.success(Unit))
+        }
+
+    chatScreenViewModel.addContacts(mockUsersRepository, currentUser, otherUser)
+
+    verify {
+      mockUsersRepository.addContact(currentUser.userUUID, otherUser.userUUID.toString(), any())
+    }
+    verify {
+      mockUsersRepository.addContact(otherUser.userUUID, currentUser.userUUID.toString(), any())
+    }
+  }
+
+  @Test
+  fun `addContacts fails when adding to other user's contacts`() {
+    every { mockUsersRepository.getUser(currentUser.userUUID, any()) } answers
+        {
+          val callback = secondArg<(Result<DataUser>) -> Unit>()
+          callback(Result.success(currentUser))
+        }
+
+    every { mockUsersRepository.getUser(otherUser.userUUID, any()) } answers
+        {
+          val callback = secondArg<(Result<DataUser>) -> Unit>()
+          callback(Result.success(otherUser))
+        }
+
+    every {
+      mockUsersRepository.addContact(currentUser.userUUID, otherUser.userUUID.toString(), any())
+    } answers
+        {
+          val callback = thirdArg<(Result<Unit>) -> Unit>()
+          callback(Result.success(Unit))
+        }
+
+    every {
+      mockUsersRepository.addContact(otherUser.userUUID, currentUser.userUUID.toString(), any())
+    } answers
+        {
+          val callback = thirdArg<(Result<Unit>) -> Unit>()
+          callback(Result.failure(Exception("Add contact failed for other user")))
+        }
+
+    chatScreenViewModel.addContacts(mockUsersRepository, currentUser, otherUser)
+
+    verify {
+      mockUsersRepository.addContact(currentUser.userUUID, otherUser.userUUID.toString(), any())
+    }
+    verify {
+      mockUsersRepository.addContact(otherUser.userUUID, currentUser.userUUID.toString(), any())
+    }
+  }
+}


### PR DESCRIPTION
# Fix Listener for Chat
## Fix the Listener
In this pull request the Listener has officially and finally been corrected and is in full working fashion, given the change of structure to how the messages were stored in the firebase, it made the function to add the listener much easier to do. Now there is in `ChatScreen` a `DisposableEffect` in which the function is called with an appropriate callback, in this case storing the messages for offline usage.
## Convert to MVVM structure
Additionally, in this pull request all functionality which could have been moved to a different MVVM file has been moved. There is now a new file, `ChatScreenViewModel`, and its respective tests. It includes the functionality of adding both users to each other's contact list whenever the first message is sent as well as the timestamp formatting. This means that there is no more call to firebase directly from `ChatScreen`, it is now in `ChatScreenViewModel`. All of this is then called in the `LaunchedEffect`.