### PR TITLE
Fix adding book from ChatGPT and directly moves it to EditScreen

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/ui/books/edit/EditBookTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/books/edit/EditBookTest.kt
@@ -10,22 +10,25 @@ import androidx.compose.ui.test.performScrollToNode
 import com.android.bookswap.data.BookGenres
 import com.android.bookswap.data.BookLanguages
 import com.android.bookswap.data.DataBook
+import com.android.bookswap.data.repository.BooksRepository
 import com.android.bookswap.data.source.network.BooksFirestoreSource
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.navigation.NavigationActions
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
 import java.util.UUID
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.mock
 
 class EditBookScreenTest {
 
-  @MockK private lateinit var booksRepository: BooksFirestoreSource
+  private val booksRepository: BooksRepository = mockk()
 
-  @MockK private lateinit var navigationActions: NavigationActions
+  private val navigationActions: NavigationActions = mockk()
 
   @get:Rule val composeTestRule = createComposeRule()
 
@@ -46,41 +49,42 @@ class EditBookScreenTest {
 
   @Before
   fun setUp() {
-    MockKAnnotations.init(this)
-
     every { navigationActions.currentRoute() } returns "EDIT_BOOK"
+      every { booksRepository.getBook(any(), any(), any()) } answers {
+          secondArg<(DataBook) -> Unit>()(sampleBook)
+      }
   }
 
   @Test
   fun displayEditScreenComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook) }
+    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
 
     composeTestRule.onNodeWithTag(C.Tag.edit_book_screen_container).assertIsDisplayed()
   }
 
   @Test
   fun displayEditTitleComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook) }
+    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
 
     composeTestRule.onNodeWithTag(C.Tag.TopAppBar.screen_title).assertIsDisplayed()
   }
 
   @Test
   fun displayEditTitleValueComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook) }
+    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
 
     composeTestRule.onNodeWithTag(C.Tag.TopAppBar.screen_title).assertTextEquals("Edit your Book")
   }
 
   @Test
   fun displayEditButtonComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook) }
+    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
     composeTestRule.onNodeWithTag(C.Tag.TopAppBar.back_button).assertIsDisplayed()
   }
 
   @Test
   fun displayEditSaveValueComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook) }
+    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
     composeTestRule
         .onNodeWithTag(C.Tag.EditBook.scrollable)
         .performScrollToNode(hasTestTag(C.Tag.EditBook.save))
@@ -90,7 +94,7 @@ class EditBookScreenTest {
 
   @Test
   fun displayEditDeleteValueComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook) }
+    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
     composeTestRule
         .onNodeWithTag(C.Tag.EditBook.scrollable)
         .performScrollToNode(hasTestTag(C.Tag.EditBook.delete))
@@ -100,44 +104,44 @@ class EditBookScreenTest {
 
   @Test
   fun displayEditBookTitleComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook) }
+    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
 
     composeTestRule.onNodeWithTag(C.Tag.EditBook.title).assertIsDisplayed()
   }
 
   @Test
   fun displayEditBookAuthorComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook) }
+    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
     composeTestRule.onNodeWithTag(C.Tag.EditBook.author).assertIsDisplayed()
   }
 
   @Test
   fun displayEditBookDescriptionComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook) }
+    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
     composeTestRule.onNodeWithTag(C.Tag.EditBook.synopsis).assertIsDisplayed()
   }
 
   @Test
   fun displayEditBookRatingComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook) }
+    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
     composeTestRule.onNodeWithTag(C.Tag.EditBook.rating).assertIsDisplayed()
   }
 
   @Test
   fun displayEditBookPhotoComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook) }
+    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
     composeTestRule.onNodeWithTag(C.Tag.EditBook.image).assertIsDisplayed()
   }
 
   @Test
   fun displayEditBookLanguageComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook) }
+    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
     composeTestRule.onNodeWithTag(C.Tag.EditBook.language).assertIsDisplayed()
   }
 
   @Test
   fun inputsHaveInitialValue() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook) }
+    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
 
     composeTestRule.onNodeWithTag(C.Tag.EditBook.title).assertTextContains(sampleBook.title)
     composeTestRule.onNodeWithTag(C.Tag.EditBook.author).assertTextContains(sampleBook.author ?: "")

--- a/app/src/androidTest/java/com/android/bookswap/ui/books/edit/EditBookTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/books/edit/EditBookTest.kt
@@ -11,18 +11,14 @@ import com.android.bookswap.data.BookGenres
 import com.android.bookswap.data.BookLanguages
 import com.android.bookswap.data.DataBook
 import com.android.bookswap.data.repository.BooksRepository
-import com.android.bookswap.data.source.network.BooksFirestoreSource
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.navigation.NavigationActions
-import io.mockk.MockKAnnotations
 import io.mockk.every
-import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import java.util.UUID
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.kotlin.mock
 
 class EditBookScreenTest {
 
@@ -50,41 +46,52 @@ class EditBookScreenTest {
   @Before
   fun setUp() {
     every { navigationActions.currentRoute() } returns "EDIT_BOOK"
-      every { booksRepository.getBook(any(), any(), any()) } answers {
+    every { booksRepository.getBook(any(), any(), any()) } answers
+        {
           secondArg<(DataBook) -> Unit>()(sampleBook)
-      }
+        }
   }
 
   @Test
   fun displayEditScreenComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
+    composeTestRule.setContent {
+      EditBookScreen(booksRepository, navigationActions, sampleBook.uuid)
+    }
 
     composeTestRule.onNodeWithTag(C.Tag.edit_book_screen_container).assertIsDisplayed()
   }
 
   @Test
   fun displayEditTitleComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
+    composeTestRule.setContent {
+      EditBookScreen(booksRepository, navigationActions, sampleBook.uuid)
+    }
 
     composeTestRule.onNodeWithTag(C.Tag.TopAppBar.screen_title).assertIsDisplayed()
   }
 
   @Test
   fun displayEditTitleValueComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
+    composeTestRule.setContent {
+      EditBookScreen(booksRepository, navigationActions, sampleBook.uuid)
+    }
 
     composeTestRule.onNodeWithTag(C.Tag.TopAppBar.screen_title).assertTextEquals("Edit your Book")
   }
 
   @Test
   fun displayEditButtonComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
+    composeTestRule.setContent {
+      EditBookScreen(booksRepository, navigationActions, sampleBook.uuid)
+    }
     composeTestRule.onNodeWithTag(C.Tag.TopAppBar.back_button).assertIsDisplayed()
   }
 
   @Test
   fun displayEditSaveValueComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
+    composeTestRule.setContent {
+      EditBookScreen(booksRepository, navigationActions, sampleBook.uuid)
+    }
     composeTestRule
         .onNodeWithTag(C.Tag.EditBook.scrollable)
         .performScrollToNode(hasTestTag(C.Tag.EditBook.save))
@@ -94,7 +101,9 @@ class EditBookScreenTest {
 
   @Test
   fun displayEditDeleteValueComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
+    composeTestRule.setContent {
+      EditBookScreen(booksRepository, navigationActions, sampleBook.uuid)
+    }
     composeTestRule
         .onNodeWithTag(C.Tag.EditBook.scrollable)
         .performScrollToNode(hasTestTag(C.Tag.EditBook.delete))
@@ -104,44 +113,58 @@ class EditBookScreenTest {
 
   @Test
   fun displayEditBookTitleComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
+    composeTestRule.setContent {
+      EditBookScreen(booksRepository, navigationActions, sampleBook.uuid)
+    }
 
     composeTestRule.onNodeWithTag(C.Tag.EditBook.title).assertIsDisplayed()
   }
 
   @Test
   fun displayEditBookAuthorComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
+    composeTestRule.setContent {
+      EditBookScreen(booksRepository, navigationActions, sampleBook.uuid)
+    }
     composeTestRule.onNodeWithTag(C.Tag.EditBook.author).assertIsDisplayed()
   }
 
   @Test
   fun displayEditBookDescriptionComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
+    composeTestRule.setContent {
+      EditBookScreen(booksRepository, navigationActions, sampleBook.uuid)
+    }
     composeTestRule.onNodeWithTag(C.Tag.EditBook.synopsis).assertIsDisplayed()
   }
 
   @Test
   fun displayEditBookRatingComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
+    composeTestRule.setContent {
+      EditBookScreen(booksRepository, navigationActions, sampleBook.uuid)
+    }
     composeTestRule.onNodeWithTag(C.Tag.EditBook.rating).assertIsDisplayed()
   }
 
   @Test
   fun displayEditBookPhotoComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
+    composeTestRule.setContent {
+      EditBookScreen(booksRepository, navigationActions, sampleBook.uuid)
+    }
     composeTestRule.onNodeWithTag(C.Tag.EditBook.image).assertIsDisplayed()
   }
 
   @Test
   fun displayEditBookLanguageComponent() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
+    composeTestRule.setContent {
+      EditBookScreen(booksRepository, navigationActions, sampleBook.uuid)
+    }
     composeTestRule.onNodeWithTag(C.Tag.EditBook.language).assertIsDisplayed()
   }
 
   @Test
   fun inputsHaveInitialValue() {
-    composeTestRule.setContent { EditBookScreen(booksRepository, navigationActions, sampleBook.uuid) }
+    composeTestRule.setContent {
+      EditBookScreen(booksRepository, navigationActions, sampleBook.uuid)
+    }
 
     composeTestRule.onNodeWithTag(C.Tag.EditBook.title).assertTextContains(sampleBook.title)
     composeTestRule.onNodeWithTag(C.Tag.EditBook.author).assertTextContains(sampleBook.author ?: "")

--- a/app/src/androidTest/java/com/android/bookswap/ui/navigation/NavigationFromBookProfileToEditBookTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/navigation/NavigationFromBookProfileToEditBookTest.kt
@@ -78,8 +78,7 @@ class NavigationFromBookProfileToEditBookTest {
                 val bookUUID =
                     backStackEntry.arguments?.getString("bookUUID")?.let { UUID.fromString(it) }
                 if (bookUUID != null) {
-                  EditBookScreen(
-                      mockBookRepo, NavigationActions(navController), bookUUID)
+                  EditBookScreen(mockBookRepo, NavigationActions(navController), bookUUID)
                 }
               }
             }

--- a/app/src/androidTest/java/com/android/bookswap/ui/navigation/NavigationFromBookProfileToEditBookTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/navigation/NavigationFromBookProfileToEditBookTest.kt
@@ -74,12 +74,12 @@ class NavigationFromBookProfileToEditBookTest {
               composable(C.Screen.BOOK_PROFILE) {
                 BookProfileScreen(testBookId, mockBookRepo, NavigationActions(navController))
               }
-              composable("${C.Screen.EDIT_BOOK}/{bookId}") { backStackEntry ->
-                val bookId =
-                    backStackEntry.arguments?.getString("bookId")?.let { UUID.fromString(it) }
-                if (bookId != null) {
+              composable("${C.Screen.EDIT_BOOK}/{bookUUID}") { backStackEntry ->
+                val bookUUID =
+                    backStackEntry.arguments?.getString("bookUUID")?.let { UUID.fromString(it) }
+                if (bookUUID != null) {
                   EditBookScreen(
-                      mockBookRepo, NavigationActions(navController), testBook.copy(uuid = bookId))
+                      mockBookRepo, NavigationActions(navController), bookUUID)
                 }
               }
             }

--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -18,7 +18,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navigation
-import com.android.bookswap.data.DataBook
 import com.android.bookswap.data.DataUser
 import com.android.bookswap.data.repository.BooksRepository
 import com.android.bookswap.data.repository.MessageRepository
@@ -239,23 +238,13 @@ class MainActivity : ComponentActivity() {
               Log.e("Navigation", "Invalid bookId passed to BookProfileScreen")
             }
           }
-          composable("${C.Screen.EDIT_BOOK}/{bookId}") { backStackEntry ->
-            val bookId = backStackEntry.arguments?.getString("bookId")?.let { UUID.fromString(it) }
-            var book: DataBook? = null // How to create a book that will be assigned after ?
-            // Fetch book data
-            if (bookId != null) {
-
-              bookRepository.getBook(
-                  uuid = bookId,
-                  OnSucess = { fetchedbook -> book = fetchedbook },
-                  onFailure = { Log.e("EditScreen", "Error while loading the book") })
+          composable("${C.Screen.EDIT_BOOK}/{bookUUID}") { backStackEntry ->
+            val bookUUID = backStackEntry.arguments?.getString("bookUUID")?.let { UUID.fromString(it) }
               EditBookScreen(
                   booksRepository = bookRepository,
                   navigationActions = NavigationActions(navController),
-                  book = book!!)
-            } else {
-              Log.e("Navigation", "Invalid bookId passed to EditBookScreen")
-            }
+                  bookUUID = bookUUID!!
+              )
           }
         }
         navigation(

--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -239,12 +239,12 @@ class MainActivity : ComponentActivity() {
             }
           }
           composable("${C.Screen.EDIT_BOOK}/{bookUUID}") { backStackEntry ->
-            val bookUUID = backStackEntry.arguments?.getString("bookUUID")?.let { UUID.fromString(it) }
-              EditBookScreen(
-                  booksRepository = bookRepository,
-                  navigationActions = NavigationActions(navController),
-                  bookUUID = bookUUID!!
-              )
+            val bookUUID =
+                backStackEntry.arguments?.getString("bookUUID")?.let { UUID.fromString(it) }
+            EditBookScreen(
+                booksRepository = bookRepository,
+                navigationActions = NavigationActions(navController),
+                bookUUID = bookUUID!!)
           }
         }
         navigation(

--- a/app/src/main/java/com/android/bookswap/model/BookFromChatGPT.kt
+++ b/app/src/main/java/com/android/bookswap/model/BookFromChatGPT.kt
@@ -42,8 +42,10 @@ class BookFromChatGPT(
                 return@getBookFromISBN
               }
 
+              val dataBook = dataBookResult.getOrThrow().copy(photo = urlResult.getOrThrow())
+
               // Add book
-              booksRepository.addBook(dataBookResult.getOrThrow()) { bookResult ->
+              booksRepository.addBook(dataBook) { bookResult ->
                 if (bookResult.isFailure) {
                   callback(ErrorType.BOOK_ADD_ERROR, null)
                 } else {

--- a/app/src/main/java/com/android/bookswap/model/BookFromChatGPT.kt
+++ b/app/src/main/java/com/android/bookswap/model/BookFromChatGPT.kt
@@ -28,7 +28,7 @@ class BookFromChatGPT(
       imageToData.analyzeImage(
           urlResult.getOrThrow(),
           onSuccess = { map ->
-            // Get isbn from result
+            // Get isbn from result and removes the '-' characters
             val isbn = map["isbn"]?.replace("-", "")
             if (isbn == null || isbn == ImageToDataSource.UNDEFINED_ATTRIBUTE) {
               callback(ErrorType.CHATGPT_ANALYZER_ERROR, null)
@@ -42,6 +42,7 @@ class BookFromChatGPT(
                 return@getBookFromISBN
               }
 
+              // Add photo url to dataBook
               val dataBook = dataBookResult.getOrThrow().copy(photo = urlResult.getOrThrow())
 
               // Add book

--- a/app/src/main/java/com/android/bookswap/ui/books/add/BookAdditionChoiceScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/add/BookAdditionChoiceScreen.kt
@@ -46,7 +46,6 @@ import com.android.bookswap.ui.theme.ColorVariable
  * @param bottomAppBar A composable function to display the bottom app bar.
  * @param photoFirebaseStorageRepository a repository allowing to upload photo as url
  * @param booksRepository book where to add the book
- * @param userUUID to which user add the book
  */
 @Composable
 fun BookAdditionChoiceScreen(
@@ -111,7 +110,9 @@ fun BookAdditionChoiceScreen(
                   text = "From Photo",
                   leftIcon = null,
                   leftIconPainter = painterResource(id = R.drawable.photoicon),
-                  onClick = { photoRequester.requestPhoto() },
+                  onClick = { //photoRequester.requestPhoto()
+                      navController.navigateTo(C.Screen.EDIT_BOOK, "6e15d9af-ed34-4b28-9b64-5cdc69c25c76")
+                       },
                   buttonWidth = buttonWidth,
               )
             }

--- a/app/src/main/java/com/android/bookswap/ui/books/add/BookAdditionChoiceScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/add/BookAdditionChoiceScreen.kt
@@ -69,11 +69,16 @@ fun BookAdditionChoiceScreen(
         BookFromChatGPT(context, photoFirebaseStorageRepository, booksRepository).addBookFromImage(
             // Display error message in a toast.
             result.getOrThrow().asAndroidBitmap(),
-            appConfig.userViewModel.uuid) { error ->
-              Toast.makeText(
-                      context, context.resources.getString(error.message), Toast.LENGTH_SHORT)
-                  .show()
+            appConfig.userViewModel.uuid,
+        ) {
+            error, uuid ->
+            Toast.makeText(
+                context, context.resources.getString(error.message), Toast.LENGTH_SHORT)
+                .show()
+            if(error == BookFromChatGPT.Companion.ErrorType.NONE ) {
+                navController.navigateTo(C.Screen.EDIT_BOOK, uuid!!.toString())
             }
+        }
       }
   photoRequester.Init()
   Scaffold(

--- a/app/src/main/java/com/android/bookswap/ui/books/add/BookAdditionChoiceScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/add/BookAdditionChoiceScreen.kt
@@ -108,10 +108,7 @@ fun BookAdditionChoiceScreen(
                   text = "From Photo",
                   leftIcon = null,
                   leftIconPainter = painterResource(id = R.drawable.photoicon),
-                  onClick = { // photoRequester.requestPhoto()
-                    navController.navigateTo(
-                        C.Screen.EDIT_BOOK, "6e15d9af-ed34-4b28-9b64-5cdc69c25c76")
-                  },
+                  onClick = { photoRequester.requestPhoto() },
                   buttonWidth = buttonWidth,
               )
             }

--- a/app/src/main/java/com/android/bookswap/ui/books/add/BookAdditionChoiceScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/add/BookAdditionChoiceScreen.kt
@@ -69,14 +69,12 @@ fun BookAdditionChoiceScreen(
             // Display error message in a toast.
             result.getOrThrow().asAndroidBitmap(),
             appConfig.userViewModel.uuid,
-        ) {
-            error, uuid ->
-            Toast.makeText(
-                context, context.resources.getString(error.message), Toast.LENGTH_SHORT)
-                .show()
-            if(error == BookFromChatGPT.Companion.ErrorType.NONE ) {
-                navController.navigateTo(C.Screen.EDIT_BOOK, uuid!!.toString())
-            }
+        ) { error, uuid ->
+          Toast.makeText(context, context.resources.getString(error.message), Toast.LENGTH_SHORT)
+              .show()
+          if (error == BookFromChatGPT.Companion.ErrorType.NONE) {
+            navController.navigateTo(C.Screen.EDIT_BOOK, uuid!!.toString())
+          }
         }
       }
   photoRequester.Init()
@@ -110,9 +108,10 @@ fun BookAdditionChoiceScreen(
                   text = "From Photo",
                   leftIcon = null,
                   leftIconPainter = painterResource(id = R.drawable.photoicon),
-                  onClick = { //photoRequester.requestPhoto()
-                      navController.navigateTo(C.Screen.EDIT_BOOK, "6e15d9af-ed34-4b28-9b64-5cdc69c25c76")
-                       },
+                  onClick = { // photoRequester.requestPhoto()
+                    navController.navigateTo(
+                        C.Screen.EDIT_BOOK, "6e15d9af-ed34-4b28-9b64-5cdc69c25c76")
+                  },
                   buttonWidth = buttonWidth,
               )
             }

--- a/app/src/main/java/com/android/bookswap/ui/books/edit/EditBookScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/edit/EditBookScreen.kt
@@ -74,15 +74,18 @@ fun EditBookScreen(
 
   var bookMutable by remember { mutableStateOf<DataBook?>(null) }
 
+  // Request book when screen load
   LaunchedEffect(Unit) {
     booksRepository.getBook(
         uuid = bookUUID,
         OnSucess = { resultBook -> bookMutable = resultBook },
         onFailure = { Log.e("EditScreen", "Error while loading the book") })
   }
+
   when (bookMutable) {
-    null -> CircularProgressIndicator()
+    null -> CircularProgressIndicator() // If the book has not loaded, show circular loading
     else -> {
+      // Get book when book has been successfully been requested
       val book = bookMutable!!
       var title by remember { mutableStateOf(book.title) }
       var author by remember { mutableStateOf(book.author ?: "") }

--- a/app/src/main/java/com/android/bookswap/ui/books/edit/EditBookScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/edit/EditBookScreen.kt
@@ -1,5 +1,6 @@
 package com.android.bookswap.ui.books.edit
 
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -13,6 +14,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
@@ -26,6 +28,7 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -43,6 +46,7 @@ import com.android.bookswap.resources.C
 import com.android.bookswap.ui.books.add.createDataBook
 import com.android.bookswap.ui.navigation.NavigationActions
 import com.android.bookswap.ui.theme.ColorVariable
+import java.util.UUID
 
 /** Constants * */
 private val SCREEN_PADDING = 16.dp
@@ -54,284 +58,297 @@ private const val COLUMN_WIDTH_RATIO = 0.9f // Column width as 90% of screen wid
  *
  * @param booksRepository The repository to interact with the book data.
  * @param navigationActions The navigation actions to handle navigation events.
- * @param book The book data to be edited.
+ * @param bookUUID The uuid of the book data to be edited.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EditBookScreen(
     booksRepository: BooksRepository,
     navigationActions: NavigationActions,
-    book: DataBook
+    bookUUID: UUID
 ) {
 
   val configuration = LocalConfiguration.current
   val screenWidth = configuration.screenWidthDp.dp
   val columnMaxWidth = screenWidth * COLUMN_WIDTH_RATIO
-  /*val book =
-      booksRepository.selectedBook.collectAsState().value
-          ?: return Text(text = "No Book selected. Should not happen", color = Color.Red)
-  */
-  // Use this and modify the editBookScreen structure if needed when incorporating in the app
-  // navigation
 
-  var title by remember { mutableStateOf(book.title) }
-  var author by remember { mutableStateOf(book.author ?: "") }
-  var description by remember { mutableStateOf(book.description ?: "") }
-  var rating by remember { mutableStateOf(book.rating?.toString() ?: "") }
-  var photo by remember { mutableStateOf(book.photo ?: "") }
-  var language by remember { mutableStateOf(book.language.toString()) }
-  var genres by remember { mutableStateOf(book.genres) }
-  var selectedGenre by remember { mutableStateOf<BookGenres?>(null) } // Genre selection state
-  var expanded by remember { mutableStateOf(false) } // State for dropdown menu
+    var bookMutable by remember { mutableStateOf<DataBook?>(null) }
 
-  val maxLengthTitle = 50
-  val maxLengthAuthor = 50
-  val maxLengthDescription = 10000
-  val maxLengthRating = 1
-  val maxLengthPhoto = 50
+    LaunchedEffect(Unit) {
 
-  val context = LocalContext.current
+        booksRepository.getBook(
+            uuid = bookUUID,
+            OnSucess = { resultBook -> bookMutable = resultBook  },
+            onFailure = { Log.e("EditScreen", "Error while loading the book") })
+    }
+    when(bookMutable) {
+        null -> CircularProgressIndicator()
+        else -> {
+            val book = bookMutable!!
+            var title by remember { mutableStateOf(book.title) }
+            var author by remember { mutableStateOf(book.author ?: "") }
+            var description by remember { mutableStateOf(book.description ?: "") }
+            var rating by remember { mutableStateOf(book.rating?.toString() ?: "") }
+            var photo by remember { mutableStateOf(book.photo ?: "") }
+            var language by remember { mutableStateOf(book.language.toString()) }
+            var genres by remember { mutableStateOf(book.genres) }
+            var selectedGenre by remember { mutableStateOf<BookGenres?>(null) } // Genre selection state
+            var expanded by remember { mutableStateOf(false) } // State for dropdown menu
 
-  Scaffold(
-      modifier =
-          Modifier.testTag(C.Tag.edit_book_screen_container).background(ColorVariable.BackGround),
-      containerColor = ColorVariable.BackGround, // Sets entire Scaffold background color
-      topBar = {
-        TopAppBar(
-            title = {
-              Text("Edit your Book", modifier = Modifier.testTag(C.Tag.TopAppBar.screen_title))
-            },
-            navigationIcon = {
-              IconButton(
-                  modifier = Modifier.testTag(C.Tag.TopAppBar.back_button),
-                  onClick = { navigationActions.goBack() }) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = "Back")
-                  }
-            },
-            colors = TopAppBarDefaults.topAppBarColors(containerColor = ColorVariable.BackGround))
-      },
-      content = { paddingValues ->
-        LazyColumn(
-            modifier =
-                Modifier.fillMaxWidth()
-                    .padding(paddingValues)
-                    .padding(SCREEN_PADDING)
-                    .widthIn(max = columnMaxWidth)
-                    .background(ColorVariable.BackGround)
-                    .testTag(C.Tag.EditBook.scrollable),
-            verticalArrangement = Arrangement.spacedBy(ELEMENT_SPACING)) {
-              // Title Edit Field
-              item {
-                OutlinedTextField(
-                    value = title,
-                    onValueChange = { if (it.length <= maxLengthTitle) title = it },
-                    label = { Text("Title") },
-                    placeholder = { Text("Enter the book title") },
-                    modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.title),
-                    colors =
-                        TextFieldDefaults.outlinedTextFieldColors(
-                            containerColor = ColorVariable.Secondary,
-                            focusedBorderColor = Color.Black,
-                            unfocusedBorderColor = Color.Black))
-              }
+            val maxLengthTitle = 50
+            val maxLengthAuthor = 50
+            val maxLengthDescription = 10000
+            val maxLengthRating = 1
+            val maxLengthPhoto = 50
 
-              item {
-                // Genre Dropdown Edit Field
-                ExposedDropdownMenuBox(
-                    expanded = expanded,
-                    onExpandedChange = { expanded = !expanded },
-                    modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.genres)) {
-                      OutlinedTextField(
-                          value = selectedGenre?.Genre ?: "Select Genre",
-                          onValueChange = {},
-                          label = { Text("Genre") },
-                          readOnly = true,
-                          trailingIcon = {
-                            ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
-                          },
-                          modifier =
-                              Modifier.menuAnchor().testTag("selected" + C.Tag.EditBook.genre),
-                          colors =
-                              TextFieldDefaults.outlinedTextFieldColors(
-                                  containerColor = ColorVariable.Secondary,
-                                  focusedBorderColor = Color.Black,
-                                  unfocusedBorderColor = Color.Black))
-                      ExposedDropdownMenu(
-                          expanded = expanded, onDismissRequest = { expanded = false }) {
-                            BookGenres.values().forEach { genre ->
-                              DropdownMenuItem(
-                                  text = { Text(text = genre.Genre) },
-                                  modifier = Modifier.testTag(genre.Genre + C.Tag.EditBook.genre),
-                                  onClick = {
-                                    selectedGenre = genre
-                                    genres = listOf(genre) // Update genres list with selected genre
-                                    expanded = false
-                                  })
+            val context = LocalContext.current
+
+            Scaffold(
+                modifier =
+                Modifier.testTag(C.Tag.edit_book_screen_container).background(ColorVariable.BackGround),
+                containerColor = ColorVariable.BackGround, // Sets entire Scaffold background color
+                topBar = {
+                    TopAppBar(
+                        title = {
+                            Text("Edit your Book", modifier = Modifier.testTag(C.Tag.TopAppBar.screen_title))
+                        },
+                        navigationIcon = {
+                            IconButton(
+                                modifier = Modifier.testTag(C.Tag.TopAppBar.back_button),
+                                onClick = { navigationActions.goBack() }) {
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                    contentDescription = "Back")
                             }
-                          }
-                    }
-              }
+                        },
+                        colors = TopAppBarDefaults.topAppBarColors(containerColor = ColorVariable.BackGround))
+                },
+                content = { paddingValues ->
+                    LazyColumn(
+                        modifier =
+                        Modifier.fillMaxWidth()
+                            .padding(paddingValues)
+                            .padding(SCREEN_PADDING)
+                            .widthIn(max = columnMaxWidth)
+                            .background(ColorVariable.BackGround)
+                            .testTag(C.Tag.EditBook.scrollable),
+                        verticalArrangement = Arrangement.spacedBy(ELEMENT_SPACING)) {
+                        // Title Edit Field
+                        item {
+                            OutlinedTextField(
+                                value = title,
+                                onValueChange = { if (it.length <= maxLengthTitle) title = it },
+                                label = { Text("Title") },
+                                placeholder = { Text("Enter the book title") },
+                                modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.title),
+                                colors =
+                                TextFieldDefaults.outlinedTextFieldColors(
+                                    containerColor = ColorVariable.Secondary,
+                                    focusedBorderColor = Color.Black,
+                                    unfocusedBorderColor = Color.Black))
+                        }
 
-              item {
-                // Author Edit Field
-                OutlinedTextField(
-                    value = author,
-                    onValueChange = { if (it.length <= maxLengthAuthor) author = it },
-                    label = { Text("Author") },
-                    placeholder = { Text("Enter the author's name") },
-                    modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.author),
-                    colors =
-                        TextFieldDefaults.outlinedTextFieldColors(
-                            containerColor = ColorVariable.Secondary,
-                            focusedBorderColor = Color.Black,
-                            unfocusedBorderColor = Color.Black))
-              }
-
-              item {
-                // Description Edit Field
-                OutlinedTextField(
-                    value = description,
-                    onValueChange = { if (it.length <= maxLengthDescription) description = it },
-                    label = { Text("Description") },
-                    placeholder = { Text("Provide a description of the book") },
-                    modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.synopsis),
-                    colors =
-                        TextFieldDefaults.outlinedTextFieldColors(
-                            containerColor = ColorVariable.Secondary,
-                            focusedBorderColor = Color.Black,
-                            unfocusedBorderColor = Color.Black))
-              }
-
-              item {
-                // Rating Edit Field
-                OutlinedTextField(
-                    value = rating,
-                    onValueChange = { if (it.length <= maxLengthRating) rating = it },
-                    label = { Text("Rating") },
-                    placeholder = { Text("Rate the book (e.g. 4.5)") },
-                    modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.rating),
-                    colors =
-                        TextFieldDefaults.outlinedTextFieldColors(
-                            containerColor = ColorVariable.Secondary,
-                            focusedBorderColor = Color.Black,
-                            unfocusedBorderColor = Color.Black))
-              }
-
-              item {
-                // Photo Edit Field
-                OutlinedTextField(
-                    value = photo,
-                    onValueChange = { if (it.length <= maxLengthPhoto) photo = it },
-                    label = { Text("Photo ") },
-                    placeholder = { Text("Enter a photo of the books") },
-                    modifier = Modifier.testTag(C.Tag.EditBook.image),
-                    colors =
-                        TextFieldDefaults.outlinedTextFieldColors(
-                            containerColor = ColorVariable.Secondary,
-                            focusedBorderColor = Color.Black,
-                            unfocusedBorderColor = Color.Black))
-              }
-
-              item {
-                // Language Edit Field
-                OutlinedTextField(
-                    value = language,
-                    onValueChange = { language = it },
-                    label = { Text("Language ") },
-                    placeholder = { Text("In which language are the book") },
-                    modifier = Modifier.testTag(C.Tag.EditBook.language),
-                    colors =
-                        TextFieldDefaults.outlinedTextFieldColors(
-                            containerColor = ColorVariable.Secondary,
-                            focusedBorderColor = Color.Black,
-                            unfocusedBorderColor = Color.Black))
-              }
-              item { Spacer(modifier = Modifier.height(BUTTON_SPACER_HEIGHT)) }
-
-              item {
-                Button(
-                    onClick = {
-                      try {
-                        if (title.isBlank())
-                            throw IllegalArgumentException("Title cannot be null or blank")
-                        if (author.isBlank())
-                            throw IllegalArgumentException("Author cannot be null or blank")
-                        if (description.isBlank())
-                            throw IllegalArgumentException("Description cannot be null or blank")
-                        if (rating.isBlank())
-                            throw IllegalArgumentException("Rating cannot be null or blank")
-                        if (photo.isBlank())
-                            throw IllegalArgumentException("Photo cannot be null or blank")
-                        if (language.isBlank())
-                            throw IllegalArgumentException("Language cannot be null or blank")
-                        if (book.isbn.isNullOrBlank())
-                            throw IllegalArgumentException("ISBN cannot be null or blank")
-                        if (genres.isEmpty())
-                            throw IllegalArgumentException("Genres cannot be empty")
-
-                        val updatedBook =
-                            createDataBook(
-                                context = context,
-                                uuid = book.uuid,
-                                title = title,
-                                author = author,
-                                description = description,
-                                ratingStr = rating,
-                                photo = photo,
-                                bookLanguageStr = language,
-                                isbn = book.isbn,
-                                genres = genres,
-                                userId = book.userId,
-                            )
-
-                        booksRepository.updateBook(
-                            updatedBook!!,
-                            callback = { result ->
-                              if (result.isSuccess) {
-                                // Fetch the updated book data from Firestore
-                                // booksRepository.getBook(updatedBook.uuid) {
-                                // updatedBookFromFirestore ->
-                                // createdBook.value = updatedBookFromFirestore
-                                navigationActions.goBack()
-                              } else {
-                                Toast.makeText(
-                                        context, "Failed to update book.", Toast.LENGTH_SHORT)
-                                    .show()
-                              }
-                            })
-                      } catch (e: Exception) {
-                        Toast.makeText(context, "Error: ${e.message}", Toast.LENGTH_SHORT).show()
-                      }
-                    },
-                    modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.save),
-                    enabled = title.isNotBlank(),
-                    colors = ButtonDefaults.buttonColors(containerColor = ColorVariable.Primary)) {
-                      Text("Save", color = Color.White)
-                    }
-              }
-
-              item {
-                Button(
-                    onClick = {
-                      booksRepository.deleteBooks(
-                          book.uuid,
-                          book,
-                          callback = { result ->
-                            if (result.isSuccess) {
-                              navigationActions.goBack()
-                            } else {
-                              Toast.makeText(context, "Failed to delete book.", Toast.LENGTH_SHORT)
-                                  .show()
+                        item {
+                            // Genre Dropdown Edit Field
+                            ExposedDropdownMenuBox(
+                                expanded = expanded,
+                                onExpandedChange = { expanded = !expanded },
+                                modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.genres)) {
+                                OutlinedTextField(
+                                    value = selectedGenre?.Genre ?: "Select Genre",
+                                    onValueChange = {},
+                                    label = { Text("Genre") },
+                                    readOnly = true,
+                                    trailingIcon = {
+                                        ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+                                    },
+                                    modifier =
+                                    Modifier.menuAnchor().testTag("selected" + C.Tag.EditBook.genre),
+                                    colors =
+                                    TextFieldDefaults.outlinedTextFieldColors(
+                                        containerColor = ColorVariable.Secondary,
+                                        focusedBorderColor = Color.Black,
+                                        unfocusedBorderColor = Color.Black))
+                                ExposedDropdownMenu(
+                                    expanded = expanded, onDismissRequest = { expanded = false }) {
+                                    BookGenres.values().forEach { genre ->
+                                        DropdownMenuItem(
+                                            text = { Text(text = genre.Genre) },
+                                            modifier = Modifier.testTag(genre.Genre + C.Tag.EditBook.genre),
+                                            onClick = {
+                                                selectedGenre = genre
+                                                genres = listOf(genre) // Update genres list with selected genre
+                                                expanded = false
+                                            })
+                                    }
+                                }
                             }
-                          })
-                    },
-                    modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.delete),
-                    colors = ButtonDefaults.buttonColors(containerColor = ColorVariable.Primary)) {
-                      Text("Delete", color = Color.White)
+                        }
+
+                        item {
+                            // Author Edit Field
+                            OutlinedTextField(
+                                value = author,
+                                onValueChange = { if (it.length <= maxLengthAuthor) author = it },
+                                label = { Text("Author") },
+                                placeholder = { Text("Enter the author's name") },
+                                modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.author),
+                                colors =
+                                TextFieldDefaults.outlinedTextFieldColors(
+                                    containerColor = ColorVariable.Secondary,
+                                    focusedBorderColor = Color.Black,
+                                    unfocusedBorderColor = Color.Black))
+                        }
+
+                        item {
+                            // Description Edit Field
+                            OutlinedTextField(
+                                value = description,
+                                onValueChange = { if (it.length <= maxLengthDescription) description = it },
+                                label = { Text("Description") },
+                                placeholder = { Text("Provide a description of the book") },
+                                modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.synopsis),
+                                colors =
+                                TextFieldDefaults.outlinedTextFieldColors(
+                                    containerColor = ColorVariable.Secondary,
+                                    focusedBorderColor = Color.Black,
+                                    unfocusedBorderColor = Color.Black))
+                        }
+
+                        item {
+                            // Rating Edit Field
+                            OutlinedTextField(
+                                value = rating,
+                                onValueChange = { if (it.length <= maxLengthRating) rating = it },
+                                label = { Text("Rating") },
+                                placeholder = { Text("Rate the book (e.g. 4.5)") },
+                                modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.rating),
+                                colors =
+                                TextFieldDefaults.outlinedTextFieldColors(
+                                    containerColor = ColorVariable.Secondary,
+                                    focusedBorderColor = Color.Black,
+                                    unfocusedBorderColor = Color.Black))
+                        }
+
+                        item {
+                            // Photo Edit Field
+                            OutlinedTextField(
+                                value = photo,
+                                onValueChange = { if (it.length <= maxLengthPhoto) photo = it },
+                                label = { Text("Photo ") },
+                                placeholder = { Text("Enter a photo of the books") },
+                                modifier = Modifier.testTag(C.Tag.EditBook.image),
+                                colors =
+                                TextFieldDefaults.outlinedTextFieldColors(
+                                    containerColor = ColorVariable.Secondary,
+                                    focusedBorderColor = Color.Black,
+                                    unfocusedBorderColor = Color.Black))
+                        }
+
+                        item {
+                            // Language Edit Field
+                            OutlinedTextField(
+                                value = language,
+                                onValueChange = { language = it },
+                                label = { Text("Language ") },
+                                placeholder = { Text("In which language are the book") },
+                                modifier = Modifier.testTag(C.Tag.EditBook.language),
+                                colors =
+                                TextFieldDefaults.outlinedTextFieldColors(
+                                    containerColor = ColorVariable.Secondary,
+                                    focusedBorderColor = Color.Black,
+                                    unfocusedBorderColor = Color.Black))
+                        }
+                        item { Spacer(modifier = Modifier.height(BUTTON_SPACER_HEIGHT)) }
+
+                        item {
+                            Button(
+                                onClick = {
+                                    try {
+                                        if (title.isBlank())
+                                            throw IllegalArgumentException("Title cannot be null or blank")
+                                        if (author.isBlank())
+                                            throw IllegalArgumentException("Author cannot be null or blank")
+                                        if (description.isBlank())
+                                            throw IllegalArgumentException("Description cannot be null or blank")
+                                        if (rating.isBlank())
+                                            throw IllegalArgumentException("Rating cannot be null or blank")
+                                        if (photo.isBlank())
+                                            throw IllegalArgumentException("Photo cannot be null or blank")
+                                        if (language.isBlank())
+                                            throw IllegalArgumentException("Language cannot be null or blank")
+                                        if (book.isbn.isNullOrBlank())
+                                            throw IllegalArgumentException("ISBN cannot be null or blank")
+                                        if (genres.isEmpty())
+                                            throw IllegalArgumentException("Genres cannot be empty")
+
+                                        val updatedBook =
+                                            createDataBook(
+                                                context = context,
+                                                uuid = book.uuid,
+                                                title = title,
+                                                author = author,
+                                                description = description,
+                                                ratingStr = rating,
+                                                photo = photo,
+                                                bookLanguageStr = language,
+                                                isbn = book.isbn,
+                                                genres = genres,
+                                                userId = book.userId,
+                                            )
+
+                                        booksRepository.updateBook(
+                                            updatedBook!!,
+                                            callback = { result ->
+                                                if (result.isSuccess) {
+                                                    // Fetch the updated book data from Firestore
+                                                    // booksRepository.getBook(updatedBook.uuid) {
+                                                    // updatedBookFromFirestore ->
+                                                    // createdBook.value = updatedBookFromFirestore
+                                                    navigationActions.goBack()
+                                                } else {
+                                                    Toast.makeText(
+                                                        context, "Failed to update book.", Toast.LENGTH_SHORT)
+                                                        .show()
+                                                }
+                                            })
+                                    } catch (e: Exception) {
+                                        Toast.makeText(context, "Error: ${e.message}", Toast.LENGTH_SHORT).show()
+                                    }
+                                },
+                                modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.save),
+                                enabled = title.isNotBlank(),
+                                colors = ButtonDefaults.buttonColors(containerColor = ColorVariable.Primary)) {
+                                Text("Save", color = Color.White)
+                            }
+                        }
+
+                        item {
+                            Button(
+                                onClick = {
+                                    booksRepository.deleteBooks(
+                                        book.uuid,
+                                        book,
+                                        callback = { result ->
+                                            if (result.isSuccess) {
+                                                navigationActions.goBack()
+                                            } else {
+                                                Toast.makeText(context, "Failed to delete book.", Toast.LENGTH_SHORT)
+                                                    .show()
+                                            }
+                                        })
+                                },
+                                modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.delete),
+                                colors = ButtonDefaults.buttonColors(containerColor = ColorVariable.Primary)) {
+                                Text("Delete", color = Color.White)
+                            }
+                        }
                     }
-              }
-            }
-      })
+                })
+        }
+    }
+
+
+
+
 }

--- a/app/src/main/java/com/android/bookswap/ui/books/edit/EditBookScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/edit/EditBookScreen.kt
@@ -72,283 +72,287 @@ fun EditBookScreen(
   val screenWidth = configuration.screenWidthDp.dp
   val columnMaxWidth = screenWidth * COLUMN_WIDTH_RATIO
 
-    var bookMutable by remember { mutableStateOf<DataBook?>(null) }
+  var bookMutable by remember { mutableStateOf<DataBook?>(null) }
 
-    LaunchedEffect(Unit) {
+  LaunchedEffect(Unit) {
+    booksRepository.getBook(
+        uuid = bookUUID,
+        OnSucess = { resultBook -> bookMutable = resultBook },
+        onFailure = { Log.e("EditScreen", "Error while loading the book") })
+  }
+  when (bookMutable) {
+    null -> CircularProgressIndicator()
+    else -> {
+      val book = bookMutable!!
+      var title by remember { mutableStateOf(book.title) }
+      var author by remember { mutableStateOf(book.author ?: "") }
+      var description by remember { mutableStateOf(book.description ?: "") }
+      var rating by remember { mutableStateOf(book.rating?.toString() ?: "") }
+      var photo by remember { mutableStateOf(book.photo ?: "") }
+      var language by remember { mutableStateOf(book.language.toString()) }
+      var genres by remember { mutableStateOf(book.genres) }
+      var selectedGenre by remember { mutableStateOf<BookGenres?>(null) } // Genre selection state
+      var expanded by remember { mutableStateOf(false) } // State for dropdown menu
 
-        booksRepository.getBook(
-            uuid = bookUUID,
-            OnSucess = { resultBook -> bookMutable = resultBook  },
-            onFailure = { Log.e("EditScreen", "Error while loading the book") })
-    }
-    when(bookMutable) {
-        null -> CircularProgressIndicator()
-        else -> {
-            val book = bookMutable!!
-            var title by remember { mutableStateOf(book.title) }
-            var author by remember { mutableStateOf(book.author ?: "") }
-            var description by remember { mutableStateOf(book.description ?: "") }
-            var rating by remember { mutableStateOf(book.rating?.toString() ?: "") }
-            var photo by remember { mutableStateOf(book.photo ?: "") }
-            var language by remember { mutableStateOf(book.language.toString()) }
-            var genres by remember { mutableStateOf(book.genres) }
-            var selectedGenre by remember { mutableStateOf<BookGenres?>(null) } // Genre selection state
-            var expanded by remember { mutableStateOf(false) } // State for dropdown menu
+      val maxLengthTitle = 50
+      val maxLengthAuthor = 50
+      val maxLengthDescription = 10000
+      val maxLengthRating = 1
+      val maxLengthPhoto = 50
 
-            val maxLengthTitle = 50
-            val maxLengthAuthor = 50
-            val maxLengthDescription = 10000
-            val maxLengthRating = 1
-            val maxLengthPhoto = 50
+      val context = LocalContext.current
 
-            val context = LocalContext.current
-
-            Scaffold(
-                modifier =
-                Modifier.testTag(C.Tag.edit_book_screen_container).background(ColorVariable.BackGround),
-                containerColor = ColorVariable.BackGround, // Sets entire Scaffold background color
-                topBar = {
-                    TopAppBar(
-                        title = {
-                            Text("Edit your Book", modifier = Modifier.testTag(C.Tag.TopAppBar.screen_title))
-                        },
-                        navigationIcon = {
-                            IconButton(
-                                modifier = Modifier.testTag(C.Tag.TopAppBar.back_button),
-                                onClick = { navigationActions.goBack() }) {
-                                Icon(
-                                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                                    contentDescription = "Back")
-                            }
-                        },
-                        colors = TopAppBarDefaults.topAppBarColors(containerColor = ColorVariable.BackGround))
+      Scaffold(
+          modifier =
+              Modifier.testTag(C.Tag.edit_book_screen_container)
+                  .background(ColorVariable.BackGround),
+          containerColor = ColorVariable.BackGround, // Sets entire Scaffold background color
+          topBar = {
+            TopAppBar(
+                title = {
+                  Text("Edit your Book", modifier = Modifier.testTag(C.Tag.TopAppBar.screen_title))
                 },
-                content = { paddingValues ->
-                    LazyColumn(
-                        modifier =
-                        Modifier.fillMaxWidth()
-                            .padding(paddingValues)
-                            .padding(SCREEN_PADDING)
-                            .widthIn(max = columnMaxWidth)
-                            .background(ColorVariable.BackGround)
-                            .testTag(C.Tag.EditBook.scrollable),
-                        verticalArrangement = Arrangement.spacedBy(ELEMENT_SPACING)) {
-                        // Title Edit Field
-                        item {
-                            OutlinedTextField(
-                                value = title,
-                                onValueChange = { if (it.length <= maxLengthTitle) title = it },
-                                label = { Text("Title") },
-                                placeholder = { Text("Enter the book title") },
-                                modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.title),
-                                colors =
-                                TextFieldDefaults.outlinedTextFieldColors(
-                                    containerColor = ColorVariable.Secondary,
-                                    focusedBorderColor = Color.Black,
-                                    unfocusedBorderColor = Color.Black))
-                        }
+                navigationIcon = {
+                  IconButton(
+                      modifier = Modifier.testTag(C.Tag.TopAppBar.back_button),
+                      onClick = { navigationActions.goBack() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back")
+                      }
+                },
+                colors =
+                    TopAppBarDefaults.topAppBarColors(containerColor = ColorVariable.BackGround))
+          },
+          content = { paddingValues ->
+            LazyColumn(
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .padding(paddingValues)
+                        .padding(SCREEN_PADDING)
+                        .widthIn(max = columnMaxWidth)
+                        .background(ColorVariable.BackGround)
+                        .testTag(C.Tag.EditBook.scrollable),
+                verticalArrangement = Arrangement.spacedBy(ELEMENT_SPACING)) {
+                  // Title Edit Field
+                  item {
+                    OutlinedTextField(
+                        value = title,
+                        onValueChange = { if (it.length <= maxLengthTitle) title = it },
+                        label = { Text("Title") },
+                        placeholder = { Text("Enter the book title") },
+                        modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.title),
+                        colors =
+                            TextFieldDefaults.outlinedTextFieldColors(
+                                containerColor = ColorVariable.Secondary,
+                                focusedBorderColor = Color.Black,
+                                unfocusedBorderColor = Color.Black))
+                  }
 
-                        item {
-                            // Genre Dropdown Edit Field
-                            ExposedDropdownMenuBox(
-                                expanded = expanded,
-                                onExpandedChange = { expanded = !expanded },
-                                modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.genres)) {
-                                OutlinedTextField(
-                                    value = selectedGenre?.Genre ?: "Select Genre",
-                                    onValueChange = {},
-                                    label = { Text("Genre") },
-                                    readOnly = true,
-                                    trailingIcon = {
-                                        ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
-                                    },
-                                    modifier =
-                                    Modifier.menuAnchor().testTag("selected" + C.Tag.EditBook.genre),
-                                    colors =
-                                    TextFieldDefaults.outlinedTextFieldColors(
-                                        containerColor = ColorVariable.Secondary,
-                                        focusedBorderColor = Color.Black,
-                                        unfocusedBorderColor = Color.Black))
-                                ExposedDropdownMenu(
-                                    expanded = expanded, onDismissRequest = { expanded = false }) {
-                                    BookGenres.values().forEach { genre ->
-                                        DropdownMenuItem(
-                                            text = { Text(text = genre.Genre) },
-                                            modifier = Modifier.testTag(genre.Genre + C.Tag.EditBook.genre),
-                                            onClick = {
-                                                selectedGenre = genre
-                                                genres = listOf(genre) // Update genres list with selected genre
-                                                expanded = false
-                                            })
-                                    }
+                  item {
+                    // Genre Dropdown Edit Field
+                    ExposedDropdownMenuBox(
+                        expanded = expanded,
+                        onExpandedChange = { expanded = !expanded },
+                        modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.genres)) {
+                          OutlinedTextField(
+                              value = selectedGenre?.Genre ?: "Select Genre",
+                              onValueChange = {},
+                              label = { Text("Genre") },
+                              readOnly = true,
+                              trailingIcon = {
+                                ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+                              },
+                              modifier =
+                                  Modifier.menuAnchor().testTag("selected" + C.Tag.EditBook.genre),
+                              colors =
+                                  TextFieldDefaults.outlinedTextFieldColors(
+                                      containerColor = ColorVariable.Secondary,
+                                      focusedBorderColor = Color.Black,
+                                      unfocusedBorderColor = Color.Black))
+                          ExposedDropdownMenu(
+                              expanded = expanded, onDismissRequest = { expanded = false }) {
+                                BookGenres.values().forEach { genre ->
+                                  DropdownMenuItem(
+                                      text = { Text(text = genre.Genre) },
+                                      modifier =
+                                          Modifier.testTag(genre.Genre + C.Tag.EditBook.genre),
+                                      onClick = {
+                                        selectedGenre = genre
+                                        genres =
+                                            listOf(genre) // Update genres list with selected genre
+                                        expanded = false
+                                      })
                                 }
-                            }
+                              }
                         }
+                  }
 
-                        item {
-                            // Author Edit Field
-                            OutlinedTextField(
-                                value = author,
-                                onValueChange = { if (it.length <= maxLengthAuthor) author = it },
-                                label = { Text("Author") },
-                                placeholder = { Text("Enter the author's name") },
-                                modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.author),
-                                colors =
-                                TextFieldDefaults.outlinedTextFieldColors(
-                                    containerColor = ColorVariable.Secondary,
-                                    focusedBorderColor = Color.Black,
-                                    unfocusedBorderColor = Color.Black))
+                  item {
+                    // Author Edit Field
+                    OutlinedTextField(
+                        value = author,
+                        onValueChange = { if (it.length <= maxLengthAuthor) author = it },
+                        label = { Text("Author") },
+                        placeholder = { Text("Enter the author's name") },
+                        modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.author),
+                        colors =
+                            TextFieldDefaults.outlinedTextFieldColors(
+                                containerColor = ColorVariable.Secondary,
+                                focusedBorderColor = Color.Black,
+                                unfocusedBorderColor = Color.Black))
+                  }
+
+                  item {
+                    // Description Edit Field
+                    OutlinedTextField(
+                        value = description,
+                        onValueChange = { if (it.length <= maxLengthDescription) description = it },
+                        label = { Text("Description") },
+                        placeholder = { Text("Provide a description of the book") },
+                        modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.synopsis),
+                        colors =
+                            TextFieldDefaults.outlinedTextFieldColors(
+                                containerColor = ColorVariable.Secondary,
+                                focusedBorderColor = Color.Black,
+                                unfocusedBorderColor = Color.Black))
+                  }
+
+                  item {
+                    // Rating Edit Field
+                    OutlinedTextField(
+                        value = rating,
+                        onValueChange = { if (it.length <= maxLengthRating) rating = it },
+                        label = { Text("Rating") },
+                        placeholder = { Text("Rate the book (e.g. 4.5)") },
+                        modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.rating),
+                        colors =
+                            TextFieldDefaults.outlinedTextFieldColors(
+                                containerColor = ColorVariable.Secondary,
+                                focusedBorderColor = Color.Black,
+                                unfocusedBorderColor = Color.Black))
+                  }
+
+                  item {
+                    // Photo Edit Field
+                    OutlinedTextField(
+                        value = photo,
+                        onValueChange = { if (it.length <= maxLengthPhoto) photo = it },
+                        label = { Text("Photo ") },
+                        placeholder = { Text("Enter a photo of the books") },
+                        modifier = Modifier.testTag(C.Tag.EditBook.image),
+                        colors =
+                            TextFieldDefaults.outlinedTextFieldColors(
+                                containerColor = ColorVariable.Secondary,
+                                focusedBorderColor = Color.Black,
+                                unfocusedBorderColor = Color.Black))
+                  }
+
+                  item {
+                    // Language Edit Field
+                    OutlinedTextField(
+                        value = language,
+                        onValueChange = { language = it },
+                        label = { Text("Language ") },
+                        placeholder = { Text("In which language are the book") },
+                        modifier = Modifier.testTag(C.Tag.EditBook.language),
+                        colors =
+                            TextFieldDefaults.outlinedTextFieldColors(
+                                containerColor = ColorVariable.Secondary,
+                                focusedBorderColor = Color.Black,
+                                unfocusedBorderColor = Color.Black))
+                  }
+                  item { Spacer(modifier = Modifier.height(BUTTON_SPACER_HEIGHT)) }
+
+                  item {
+                    Button(
+                        onClick = {
+                          try {
+                            if (title.isBlank())
+                                throw IllegalArgumentException("Title cannot be null or blank")
+                            if (author.isBlank())
+                                throw IllegalArgumentException("Author cannot be null or blank")
+                            if (description.isBlank())
+                                throw IllegalArgumentException(
+                                    "Description cannot be null or blank")
+                            if (rating.isBlank())
+                                throw IllegalArgumentException("Rating cannot be null or blank")
+                            if (photo.isBlank())
+                                throw IllegalArgumentException("Photo cannot be null or blank")
+                            if (language.isBlank())
+                                throw IllegalArgumentException("Language cannot be null or blank")
+                            if (book.isbn.isNullOrBlank())
+                                throw IllegalArgumentException("ISBN cannot be null or blank")
+                            if (genres.isEmpty())
+                                throw IllegalArgumentException("Genres cannot be empty")
+
+                            val updatedBook =
+                                createDataBook(
+                                    context = context,
+                                    uuid = book.uuid,
+                                    title = title,
+                                    author = author,
+                                    description = description,
+                                    ratingStr = rating,
+                                    photo = photo,
+                                    bookLanguageStr = language,
+                                    isbn = book.isbn,
+                                    genres = genres,
+                                    userId = book.userId,
+                                )
+
+                            booksRepository.updateBook(
+                                updatedBook!!,
+                                callback = { result ->
+                                  if (result.isSuccess) {
+                                    // Fetch the updated book data from Firestore
+                                    // booksRepository.getBook(updatedBook.uuid) {
+                                    // updatedBookFromFirestore ->
+                                    // createdBook.value = updatedBookFromFirestore
+                                    navigationActions.goBack()
+                                  } else {
+                                    Toast.makeText(
+                                            context, "Failed to update book.", Toast.LENGTH_SHORT)
+                                        .show()
+                                  }
+                                })
+                          } catch (e: Exception) {
+                            Toast.makeText(context, "Error: ${e.message}", Toast.LENGTH_SHORT)
+                                .show()
+                          }
+                        },
+                        modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.save),
+                        enabled = title.isNotBlank(),
+                        colors =
+                            ButtonDefaults.buttonColors(containerColor = ColorVariable.Primary)) {
+                          Text("Save", color = Color.White)
                         }
+                  }
 
-                        item {
-                            // Description Edit Field
-                            OutlinedTextField(
-                                value = description,
-                                onValueChange = { if (it.length <= maxLengthDescription) description = it },
-                                label = { Text("Description") },
-                                placeholder = { Text("Provide a description of the book") },
-                                modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.synopsis),
-                                colors =
-                                TextFieldDefaults.outlinedTextFieldColors(
-                                    containerColor = ColorVariable.Secondary,
-                                    focusedBorderColor = Color.Black,
-                                    unfocusedBorderColor = Color.Black))
+                  item {
+                    Button(
+                        onClick = {
+                          booksRepository.deleteBooks(
+                              book.uuid,
+                              book,
+                              callback = { result ->
+                                if (result.isSuccess) {
+                                  navigationActions.goBack()
+                                } else {
+                                  Toast.makeText(
+                                          context, "Failed to delete book.", Toast.LENGTH_SHORT)
+                                      .show()
+                                }
+                              })
+                        },
+                        modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.delete),
+                        colors =
+                            ButtonDefaults.buttonColors(containerColor = ColorVariable.Primary)) {
+                          Text("Delete", color = Color.White)
                         }
-
-                        item {
-                            // Rating Edit Field
-                            OutlinedTextField(
-                                value = rating,
-                                onValueChange = { if (it.length <= maxLengthRating) rating = it },
-                                label = { Text("Rating") },
-                                placeholder = { Text("Rate the book (e.g. 4.5)") },
-                                modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.rating),
-                                colors =
-                                TextFieldDefaults.outlinedTextFieldColors(
-                                    containerColor = ColorVariable.Secondary,
-                                    focusedBorderColor = Color.Black,
-                                    unfocusedBorderColor = Color.Black))
-                        }
-
-                        item {
-                            // Photo Edit Field
-                            OutlinedTextField(
-                                value = photo,
-                                onValueChange = { if (it.length <= maxLengthPhoto) photo = it },
-                                label = { Text("Photo ") },
-                                placeholder = { Text("Enter a photo of the books") },
-                                modifier = Modifier.testTag(C.Tag.EditBook.image),
-                                colors =
-                                TextFieldDefaults.outlinedTextFieldColors(
-                                    containerColor = ColorVariable.Secondary,
-                                    focusedBorderColor = Color.Black,
-                                    unfocusedBorderColor = Color.Black))
-                        }
-
-                        item {
-                            // Language Edit Field
-                            OutlinedTextField(
-                                value = language,
-                                onValueChange = { language = it },
-                                label = { Text("Language ") },
-                                placeholder = { Text("In which language are the book") },
-                                modifier = Modifier.testTag(C.Tag.EditBook.language),
-                                colors =
-                                TextFieldDefaults.outlinedTextFieldColors(
-                                    containerColor = ColorVariable.Secondary,
-                                    focusedBorderColor = Color.Black,
-                                    unfocusedBorderColor = Color.Black))
-                        }
-                        item { Spacer(modifier = Modifier.height(BUTTON_SPACER_HEIGHT)) }
-
-                        item {
-                            Button(
-                                onClick = {
-                                    try {
-                                        if (title.isBlank())
-                                            throw IllegalArgumentException("Title cannot be null or blank")
-                                        if (author.isBlank())
-                                            throw IllegalArgumentException("Author cannot be null or blank")
-                                        if (description.isBlank())
-                                            throw IllegalArgumentException("Description cannot be null or blank")
-                                        if (rating.isBlank())
-                                            throw IllegalArgumentException("Rating cannot be null or blank")
-                                        if (photo.isBlank())
-                                            throw IllegalArgumentException("Photo cannot be null or blank")
-                                        if (language.isBlank())
-                                            throw IllegalArgumentException("Language cannot be null or blank")
-                                        if (book.isbn.isNullOrBlank())
-                                            throw IllegalArgumentException("ISBN cannot be null or blank")
-                                        if (genres.isEmpty())
-                                            throw IllegalArgumentException("Genres cannot be empty")
-
-                                        val updatedBook =
-                                            createDataBook(
-                                                context = context,
-                                                uuid = book.uuid,
-                                                title = title,
-                                                author = author,
-                                                description = description,
-                                                ratingStr = rating,
-                                                photo = photo,
-                                                bookLanguageStr = language,
-                                                isbn = book.isbn,
-                                                genres = genres,
-                                                userId = book.userId,
-                                            )
-
-                                        booksRepository.updateBook(
-                                            updatedBook!!,
-                                            callback = { result ->
-                                                if (result.isSuccess) {
-                                                    // Fetch the updated book data from Firestore
-                                                    // booksRepository.getBook(updatedBook.uuid) {
-                                                    // updatedBookFromFirestore ->
-                                                    // createdBook.value = updatedBookFromFirestore
-                                                    navigationActions.goBack()
-                                                } else {
-                                                    Toast.makeText(
-                                                        context, "Failed to update book.", Toast.LENGTH_SHORT)
-                                                        .show()
-                                                }
-                                            })
-                                    } catch (e: Exception) {
-                                        Toast.makeText(context, "Error: ${e.message}", Toast.LENGTH_SHORT).show()
-                                    }
-                                },
-                                modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.save),
-                                enabled = title.isNotBlank(),
-                                colors = ButtonDefaults.buttonColors(containerColor = ColorVariable.Primary)) {
-                                Text("Save", color = Color.White)
-                            }
-                        }
-
-                        item {
-                            Button(
-                                onClick = {
-                                    booksRepository.deleteBooks(
-                                        book.uuid,
-                                        book,
-                                        callback = { result ->
-                                            if (result.isSuccess) {
-                                                navigationActions.goBack()
-                                            } else {
-                                                Toast.makeText(context, "Failed to delete book.", Toast.LENGTH_SHORT)
-                                                    .show()
-                                            }
-                                        })
-                                },
-                                modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.delete),
-                                colors = ButtonDefaults.buttonColors(containerColor = ColorVariable.Primary)) {
-                                Text("Delete", color = Color.White)
-                            }
-                        }
-                    }
-                })
-        }
+                  }
+                }
+          })
     }
-
-
-
-
+  }
 }

--- a/app/src/test/java/com/android/bookswap/model/BookFromChatGPTTest.kt
+++ b/app/src/test/java/com/android/bookswap/model/BookFromChatGPTTest.kt
@@ -52,7 +52,9 @@ class BookFromChatGPTTest {
     every { anyConstructed<GoogleBookDataSource>().getBookFromISBN(testISBN, any(), any()) } answers
         {
           val dataBook: DataBook = mockk()
-          thirdArg<(Result<DataBook>) -> Unit>()(Result.success(dataBook))
+            every { dataBook.copy(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns dataBook
+          every { dataBook.uuid } returns UUID.randomUUID()
+            thirdArg<(Result<DataBook>) -> Unit>()(Result.success(dataBook))
         }
 
     every { booksRepository.addBook(any(), any()) } answers
@@ -69,11 +71,11 @@ class BookFromChatGPTTest {
         }
 
     val bookFromChatGPT = BookFromChatGPT(context, photoFirebaseStorageRepository, booksRepository)
-    val callback = mockk<(BookFromChatGPT.Companion.ErrorType) -> Unit>(relaxed = true)
+    val callback = mockk<(BookFromChatGPT.Companion.ErrorType, UUID?) -> Unit>(relaxed = true)
     bookFromChatGPT.addBookFromImage(bitmap, uuid, callback)
 
     verify(exactly = 1, timeout = 500) {
-      callback.invoke(BookFromChatGPT.Companion.ErrorType.FIREBASE_STORAGE_ERROR)
+      callback.invoke(BookFromChatGPT.Companion.ErrorType.FIREBASE_STORAGE_ERROR, null)
     }
   }
 
@@ -85,11 +87,11 @@ class BookFromChatGPTTest {
         }
 
     val bookFromChatGPT = BookFromChatGPT(context, photoFirebaseStorageRepository, booksRepository)
-    val callback = mockk<(BookFromChatGPT.Companion.ErrorType) -> Unit>(relaxed = true)
+    val callback = mockk<(BookFromChatGPT.Companion.ErrorType, UUID?) -> Unit>(relaxed = true)
     bookFromChatGPT.addBookFromImage(bitmap, uuid, callback)
 
     verify(exactly = 1, timeout = 500) {
-      callback.invoke(BookFromChatGPT.Companion.ErrorType.CHATGPT_ANALYZER_ERROR)
+      callback.invoke(BookFromChatGPT.Companion.ErrorType.CHATGPT_ANALYZER_ERROR, null)
     }
   }
 
@@ -102,11 +104,11 @@ class BookFromChatGPTTest {
         }
 
     val bookFromChatGPT = BookFromChatGPT(context, photoFirebaseStorageRepository, booksRepository)
-    val callback = mockk<(BookFromChatGPT.Companion.ErrorType) -> Unit>(relaxed = true)
+    val callback = mockk<(BookFromChatGPT.Companion.ErrorType, UUID?) -> Unit>(relaxed = true)
     bookFromChatGPT.addBookFromImage(bitmap, uuid, callback)
 
     verify(exactly = 1, timeout = 500) {
-      callback.invoke(BookFromChatGPT.Companion.ErrorType.CHATGPT_ANALYZER_ERROR)
+      callback.invoke(BookFromChatGPT.Companion.ErrorType.CHATGPT_ANALYZER_ERROR, null)
     }
   }
 
@@ -118,11 +120,11 @@ class BookFromChatGPTTest {
         }
 
     val bookFromChatGPT = BookFromChatGPT(context, photoFirebaseStorageRepository, booksRepository)
-    val callback = mockk<(BookFromChatGPT.Companion.ErrorType) -> Unit>(relaxed = true)
+    val callback = mockk<(BookFromChatGPT.Companion.ErrorType, UUID?) -> Unit>(relaxed = true)
     bookFromChatGPT.addBookFromImage(bitmap, uuid, callback)
 
     verify(exactly = 1, timeout = 500) {
-      callback.invoke(BookFromChatGPT.Companion.ErrorType.ISBN_ERROR)
+      callback.invoke(BookFromChatGPT.Companion.ErrorType.ISBN_ERROR, null)
     }
   }
 
@@ -134,20 +136,20 @@ class BookFromChatGPTTest {
         }
 
     val bookFromChatGPT = BookFromChatGPT(context, photoFirebaseStorageRepository, booksRepository)
-    val callback = mockk<(BookFromChatGPT.Companion.ErrorType) -> Unit>(relaxed = true)
+    val callback = mockk<(BookFromChatGPT.Companion.ErrorType, UUID?) -> Unit>(relaxed = true)
     bookFromChatGPT.addBookFromImage(bitmap, uuid, callback)
 
     verify(exactly = 1, timeout = 500) {
-      callback.invoke(BookFromChatGPT.Companion.ErrorType.BOOK_ADD_ERROR)
+      callback.invoke(BookFromChatGPT.Companion.ErrorType.BOOK_ADD_ERROR, null)
     }
   }
 
   @Test
   fun `book is added correctly`() {
     val bookFromChatGPT = BookFromChatGPT(context, photoFirebaseStorageRepository, booksRepository)
-    val callback = mockk<(BookFromChatGPT.Companion.ErrorType) -> Unit>(relaxed = true)
+    val callback = mockk<(BookFromChatGPT.Companion.ErrorType, UUID?) -> Unit>(relaxed = true)
     bookFromChatGPT.addBookFromImage(bitmap, uuid, callback)
 
-    verify(exactly = 1, timeout = 500) { callback.invoke(BookFromChatGPT.Companion.ErrorType.NONE) }
+    verify(exactly = 1, timeout = 500) { callback.invoke(BookFromChatGPT.Companion.ErrorType.NONE, any()) }
   }
 }

--- a/app/src/test/java/com/android/bookswap/model/BookFromChatGPTTest.kt
+++ b/app/src/test/java/com/android/bookswap/model/BookFromChatGPTTest.kt
@@ -52,9 +52,12 @@ class BookFromChatGPTTest {
     every { anyConstructed<GoogleBookDataSource>().getBookFromISBN(testISBN, any(), any()) } answers
         {
           val dataBook: DataBook = mockk()
-            every { dataBook.copy(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns dataBook
+          every {
+            dataBook.copy(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+          } returns dataBook
           every { dataBook.uuid } returns UUID.randomUUID()
-            thirdArg<(Result<DataBook>) -> Unit>()(Result.success(dataBook))
+          thirdArg<(Result<DataBook>) -> Unit>()(Result.success(dataBook))
         }
 
     every { booksRepository.addBook(any(), any()) } answers
@@ -150,6 +153,8 @@ class BookFromChatGPTTest {
     val callback = mockk<(BookFromChatGPT.Companion.ErrorType, UUID?) -> Unit>(relaxed = true)
     bookFromChatGPT.addBookFromImage(bitmap, uuid, callback)
 
-    verify(exactly = 1, timeout = 500) { callback.invoke(BookFromChatGPT.Companion.ErrorType.NONE, any()) }
+    verify(exactly = 1, timeout = 500) {
+      callback.invoke(BookFromChatGPT.Companion.ErrorType.NONE, any())
+    }
   }
 }


### PR DESCRIPTION
Adding a book using a photo and sending it to ChatGPT was not working.
This was mainly due to the API KEY name change and the ISBN containing '-' characters.

Additionally, once the photo is retrieved, it should be sent to the EditScreen instead of just getting added. This necessitated to move the simple Book retrieval logic inside the screen instead of in the navigation (where it shouldn't be).

For sonarcloud : https://github.com/BookswapEPFL/Bookswap/pull/303#issuecomment-2522034830
