### PR TITLE
Add Button to Other User Profile that Goes to Chat

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/ui/profile/OthersUserProfileTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/profile/OthersUserProfileTest.kt
@@ -1,6 +1,7 @@
 package com.android.bookswap.ui.profile
 
 import androidx.compose.ui.test.assertAll
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasText
@@ -148,6 +149,12 @@ class OthersUserProfileTest : TestCase() {
         .onNodeWithTag(C.Tag.OtherUserProfile.address + C.Tag.LabeledText.text)
         .assertIsDisplayed()
         .assertTextEquals("45.0, 50.0")
+
+    composeTestRule
+        .onNodeWithTag(C.Tag.OtherUserProfile.chatButton)
+        .assertIsDisplayed()
+        .assertHasClickAction()
+        .assertTextEquals("Message with John")
   }
 
   @Test

--- a/app/src/main/java/com/android/bookswap/resources/C.kt
+++ b/app/src/main/java/com/android/bookswap/resources/C.kt
@@ -140,6 +140,7 @@ object C {
       const val email = "email"
       const val phone = "phoneNumber"
       const val address = "address"
+      const val chatButton = "chatButton"
     }
 
     // Edit User Profile Screen specific tags (EditProfile.kt)

--- a/app/src/main/java/com/android/bookswap/ui/profile/OthersUserProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/profile/OthersUserProfile.kt
@@ -37,6 +37,11 @@ private val PROFILE_PICTURE_BORDER_WIDTH = 3.dp
 private val ICON_SIZE = 80.dp
 private val PADDING = 16.dp
 private val ITEM_SPACING = 8.dp
+private const val LABEL_WEIGHT = 0.5f
+private const val VALUE_WEIGHT = 2f
+private val BORDER_WIDTH = 1.dp
+private val PADDING_SMALL = 4.dp
+private val HALF_WIDTH = 0.5f
 
 /**
  * Composable function to display the user profile screen.
@@ -155,14 +160,14 @@ fun OthersUserProfileScreen(
                     modifier =
                         Modifier.testTag(C.Tag.OtherUserProfile.chatButton)
                             .align(Alignment.CenterHorizontally)
-                            .fillMaxWidth(0.5f),
+                            .fillMaxWidth(HALF_WIDTH),
                     colors =
                         ButtonColors(
                             ColorVariable.Secondary,
                             ColorVariable.Accent,
                             ColorVariable.Secondary,
                             ColorVariable.Accent),
-                    border = BorderStroke(1.dp, ColorVariable.Accent),
+                    border = BorderStroke(BORDER_WIDTH, ColorVariable.Accent),
                     onClick = {
                       navigationActions.navigateTo(C.Screen.CHAT, user.userUUID.toString())
                     }) {
@@ -189,12 +194,6 @@ fun OthersUserProfileScreen(
         }
       }
 }
-
-/** Constant * */
-private const val LABEL_WEIGHT = 0.5f
-private const val VALUE_WEIGHT = 2f
-private val BORDER_WIDTH = 1.dp
-private val PADDING_SMALL = 4.dp
 
 /**
  * A composable function to display a labeled text field.

--- a/app/src/main/java/com/android/bookswap/ui/profile/OthersUserProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/profile/OthersUserProfile.kt
@@ -150,6 +150,25 @@ fun OthersUserProfileScreen(
                     label = "Address:",
                     value = "${user.latitude}, ${user.longitude}")
 
+                // Chat Button
+                Button(
+                    modifier =
+                        Modifier.testTag(C.Tag.OtherUserProfile.chatButton)
+                            .align(Alignment.CenterHorizontally)
+                            .fillMaxWidth(0.5f),
+                    colors =
+                        ButtonColors(
+                            ColorVariable.Secondary,
+                            ColorVariable.Accent,
+                            ColorVariable.Secondary,
+                            ColorVariable.Accent),
+                    border = BorderStroke(1.dp, ColorVariable.Accent),
+                    onClick = {
+                      navigationActions.navigateTo(C.Screen.CHAT, user.userUUID.toString())
+                    }) {
+                      Text("Message with ${user.firstName}")
+                    }
+
                 // Book List
                 if (isBooksLoading) {
                   Log.e("OtherUserProfileScreen", "Books are loading")


### PR DESCRIPTION
## Add Button to Other User Profile that Goes to Chat
This pull request is quite simple but necessary, it adds a button to the other user profile such that when pressed it sends you directly to a chat with said user. Whether or not the user is in your contacts already makes little difference as that is handled by the `ChatScreen`. There is not much more to say other than a small test was modified to add a verification that the button exists and is clickable.