### PR TITLE
Add Delete Functionality with URL and Photo ID Support

### DIFF
--- a/app/src/main/java/com/android/bookswap/data/repository/PhotoFirebaseStorageRepository.kt
+++ b/app/src/main/java/com/android/bookswap/data/repository/PhotoFirebaseStorageRepository.kt
@@ -8,4 +8,7 @@ interface PhotoFirebaseStorageRepository {
 
   fun addPhotoToStorage(photoId: String, bitmap: Bitmap, callback: (Result<String>) -> Unit)
   // getphoto is useless (as we can use the url to directly retrieve the picture and show it )
+  fun deletePhotoFromStorage(photoId: String, callback: (Result<Unit>) -> Unit)
+
+  fun deletePhotoFromStorageWithUrl(photoUrl: String, callback: (Result<Unit>) -> Unit)
 }

--- a/app/src/main/java/com/android/bookswap/data/source/network/PhotoFirebaseStorageSource.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/network/PhotoFirebaseStorageSource.kt
@@ -67,4 +67,32 @@ class PhotoFirebaseStorageSource(private val storage: FirebaseStorage) :
         }
         .addOnFailureListener { e -> callback(Result.failure(e)) }
   }
+
+  /**
+   * Deletes a photo from Firebase Storage.
+   *
+   * @param photoId The ID of the photo to delete.
+   * @param callback A callback function that receives Result.success(Unit) on success or
+   *   Result.failure(exception) on failure.
+   */
+  override fun deletePhotoFromStorage(photoId: String, callback: (Result<Unit>) -> Unit) {
+    val storageRef = storage.reference.child("images/$photoId.jpg")
+    storageRef
+        .delete()
+        .addOnSuccessListener { callback(Result.success(Unit)) }
+        .addOnFailureListener { e -> callback(Result.failure(e)) }
+  }
+
+  /**
+   * Deletes a photo from Firebase Storage using the photo URL.
+   *
+   * @param photoUrl The URL of the photo to delete.
+   * @param callback A callback function that receives Result.success(Unit) on success or
+   *   Result.failure(exception) on failure.
+   */
+  override fun deletePhotoFromStorageWithUrl(photoUrl: String, callback: (Result<Unit>) -> Unit) {
+    val regex = Regex("""images%2F([a-zA-Z0-9\-]+)""")
+    val matchResult = regex.find(photoUrl)
+    deletePhotoFromStorage(matchResult?.groups?.get(1)?.value.toString(), callback)
+  }
 }

--- a/app/src/test/java/com/android/bookswap/data/source/network/PhotoFirebaseStorageSourceTest.kt
+++ b/app/src/test/java/com/android/bookswap/data/source/network/PhotoFirebaseStorageSourceTest.kt
@@ -31,7 +31,9 @@ class PhotoFirebaseStorageSourceTest {
   @MockK private lateinit var mockStorageReference: StorageReference
 
   private lateinit var photoStorageSource: PhotoFirebaseStorageSource
-  private val photoId = "etranger_test"
+  private val photoId = "etranger-test"
+  private val photoUrl =
+      "https://firebasestorage.googleapis.com/v0/b/app.appspot.com/o/images%2F$photoId.jpg?alt=media&token=someToken"
 
   @Before
   fun setup() {
@@ -128,5 +130,91 @@ class PhotoFirebaseStorageSourceTest {
     photoStorageSource.init(callback)
 
     verify { callback(Result.success(Unit)) }
+  }
+
+  @Test
+  fun `deletePhotoFromStorage deletes photo and calls callback with success`() {
+    val callback = mockk<(Result<Unit>) -> Unit>(relaxed = true)
+
+    // Mock the storage reference behavior
+    val photoStorageReference = mockk<StorageReference>()
+    every { mockStorageReference.child("images/$photoId.jpg") } returns photoStorageReference
+
+    // Mock successful delete behavior
+    every { photoStorageReference.delete() } returns Tasks.forResult(null)
+
+    // Call the method
+    photoStorageSource.deletePhotoFromStorage(photoId, callback)
+
+    // Process pending tasks
+    shadowOf(Looper.getMainLooper()).idle()
+
+    // Verify the callback is called with success
+    verify { callback(Result.success(Unit)) }
+  }
+
+  @Test
+  fun `deletePhotoFromStorage calls callback with failure when delete fails`() {
+    val callback = mockk<(Result<Unit>) -> Unit>(relaxed = true)
+    val exception = Exception("Delete failed")
+
+    // Mock the storage reference behavior
+    val photoStorageReference = mockk<StorageReference>()
+    every { mockStorageReference.child("images/$photoId.jpg") } returns photoStorageReference
+
+    // Mock delete failure
+    every { photoStorageReference.delete() } returns Tasks.forException(exception)
+
+    // Call the method
+    photoStorageSource.deletePhotoFromStorage(photoId, callback)
+
+    // Process pending tasks
+    shadowOf(Looper.getMainLooper()).idle()
+
+    // Verify the callback is called with failure
+    verify { callback(Result.failure(exception)) }
+  }
+
+  @Test
+  fun `deletePhotoFromStorageWithUrl deletes photo and calls callback with success`() {
+    val callback = mockk<(Result<Unit>) -> Unit>(relaxed = true)
+
+    // Mock the storage reference behavior
+    val photoStorageReference = mockk<StorageReference>()
+    every { mockStorageReference.child("images/$photoId.jpg") } returns photoStorageReference
+
+    // Mock successful delete behavior
+    every { photoStorageReference.delete() } returns Tasks.forResult(null)
+
+    // Call the method
+    photoStorageSource.deletePhotoFromStorageWithUrl(photoUrl, callback)
+
+    // Process pending tasks
+    shadowOf(Looper.getMainLooper()).idle()
+
+    // Verify the callback is called with success
+    verify { callback(Result.success(Unit)) }
+  }
+
+  @Test
+  fun `deletePhotoFromStorageWithUrl calls callback with failure when delete fails`() {
+    val callback = mockk<(Result<Unit>) -> Unit>(relaxed = true)
+    val exception = Exception("Delete failed")
+
+    // Mock the storage reference behavior
+    val photoStorageReference = mockk<StorageReference>()
+    every { mockStorageReference.child("images/$photoId.jpg") } returns photoStorageReference
+
+    // Mock delete failure
+    every { photoStorageReference.delete() } returns Tasks.forException(exception)
+
+    // Call the method
+    photoStorageSource.deletePhotoFromStorageWithUrl(photoUrl, callback)
+
+    // Process pending tasks
+    shadowOf(Looper.getMainLooper()).idle()
+
+    // Verify the callback is called with failure
+    verify { callback(Result.failure(exception)) }
   }
 }


### PR DESCRIPTION

This PR enhances the `PhotoFirebaseStorageSource` by introducing improved deletion capabilities and tests.

#### Summary of Changes
- Added `deletePhotoFromStorage` function to delete a photo using its `photoId`.
- Added `deletePhotoFromStorageWithUrl` function to delete a photo using its URL.
- Extracted the `photoId` from URLs using regex to support deletion via URL.
- Included unit tests to verify both successful and failure scenarios for both deletion methods.

The addition of these methods provides flexibility to delete photos either by their unique ID or directly via their URL. This improves usability and makes the photo deletion API more robust and versatile.