### PR TITLE
Fix a bug where the selection of a filter with "-" was not selected 

### DIFF
--- a/app/src/main/java/com/android/bookswap/data/DataBook.kt
+++ b/app/src/main/java/com/android/bookswap/data/DataBook.kt
@@ -40,8 +40,7 @@ enum class BookLanguages(val languageCode: String) {
   ENGLISH("English"), // English language
   SPANISH("Spanish"), // Spanish language
   ITALIAN("Italian"), // Italian language
-  ROMANSH("Romansh"),
-  SMALLTEST("Small Test"), // Romansh, a language spoken in Switzerland
+  ROMANSH("Romansh"), // Romansh, a language spoken in Switzerland
   OTHER("Other") // All languages that are not yet implemented
 }
 /** Genre of a book */

--- a/app/src/main/java/com/android/bookswap/data/DataBook.kt
+++ b/app/src/main/java/com/android/bookswap/data/DataBook.kt
@@ -40,7 +40,8 @@ enum class BookLanguages(val languageCode: String) {
   ENGLISH("English"), // English language
   SPANISH("Spanish"), // Spanish language
   ITALIAN("Italian"), // Italian language
-  ROMANSH("Romansh"), // Romansh, a language spoken in Switzerland
+  ROMANSH("Romansh"),
+  SMALLTEST("Small Test"), // Romansh, a language spoken in Switzerland
   OTHER("Other") // All languages that are not yet implemented
 }
 /** Genre of a book */

--- a/app/src/main/java/com/android/bookswap/model/map/BookFilter.kt
+++ b/app/src/main/java/com/android/bookswap/model/map/BookFilter.kt
@@ -64,7 +64,8 @@ class BookFilter {
   fun setLanguages(languages: List<String>) {
     val newLanguagesFilter =
         languages.mapNotNull { language ->
-          runCatching { BookLanguages.valueOf(language.uppercase()) }.getOrNull()
+          // Use the Genre parameter to get the corresponding BookGenres enum
+          BookLanguages.values().firstOrNull { it.languageCode.equals(language, ignoreCase = true) }
         }
     _languagesFilter.value = newLanguagesFilter
   }

--- a/app/src/main/java/com/android/bookswap/model/map/BookFilter.kt
+++ b/app/src/main/java/com/android/bookswap/model/map/BookFilter.kt
@@ -50,8 +50,9 @@ class BookFilter {
   fun setGenres(genres: List<String>) {
     val newGenresFilter =
         genres.mapNotNull { genre ->
-          // Use the Genre parameter to get the corresponding BookGenres enum
-          BookGenres.values().firstOrNull { it.Genre.equals(genre, ignoreCase = true) }
+          BookGenres.values().firstOrNull {
+            it.Genre.replace("-", "").equals(genre.replace("-", ""), ignoreCase = true)
+          }
         }
     _genresFilter.value = newGenresFilter
   }

--- a/app/src/main/java/com/android/bookswap/model/map/BookFilter.kt
+++ b/app/src/main/java/com/android/bookswap/model/map/BookFilter.kt
@@ -64,7 +64,7 @@ class BookFilter {
   fun setLanguages(languages: List<String>) {
     val newLanguagesFilter =
         languages.mapNotNull { language ->
-          // Use the Genre parameter to get the corresponding BookGenres enum
+          // Use the language parameter to get the corresponding BookLanguages enum
           BookLanguages.values().firstOrNull { it.languageCode.equals(language, ignoreCase = true) }
         }
     _languagesFilter.value = newLanguagesFilter

--- a/app/src/main/java/com/android/bookswap/model/map/BookFilter.kt
+++ b/app/src/main/java/com/android/bookswap/model/map/BookFilter.kt
@@ -50,9 +50,8 @@ class BookFilter {
   fun setGenres(genres: List<String>) {
     val newGenresFilter =
         genres.mapNotNull { genre ->
-          BookGenres.values().firstOrNull {
-            it.Genre.replace("-", "").equals(genre.replace("-", ""), ignoreCase = true)
-          }
+          // Use the Genre parameter to get the corresponding BookGenres enum
+          BookGenres.values().firstOrNull { it.Genre.equals(genre, ignoreCase = true) }
         }
     _genresFilter.value = newGenresFilter
   }

--- a/app/src/main/java/com/android/bookswap/ui/map/FilterMap.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/FilterMap.kt
@@ -102,13 +102,8 @@ fun FilterMapScreen(navigationActions: NavigationActions, bookFilter: BookFilter
           }
           item {
             ButtonBlock(
-                buttonTexts =
-                    BookLanguages.values().map {
-                      it.toString().lowercase().replaceFirstChar { c -> c.uppercase() }
-                    },
-                selectedFiltersLanguages.map {
-                  it.name.lowercase().replaceFirstChar { c -> c.uppercase() }
-                }) { newSelection ->
+                buttonTexts = BookLanguages.values().map { it.languageCode },
+                selectedFiltersLanguages.map { it.languageCode }) { newSelection ->
                   bookFilter.setLanguages(
                       newSelection) // Actualize the selected languages as OnClick
             }
@@ -121,7 +116,7 @@ fun FilterMapScreen(navigationActions: NavigationActions, bookFilter: BookFilter
             Button(
                 onClick = {
                   bookFilter.setGenres(selectedFiltersGenres.map { it.Genre })
-                  bookFilter.setLanguages(selectedFiltersLanguages.map { it.name })
+                  bookFilter.setLanguages(selectedFiltersLanguages.map { it.languageCode })
                   Toast.makeText(context, "Filters applied", Toast.LENGTH_SHORT).show()
                   navigationActions.goBack()
                 },

--- a/app/src/main/java/com/android/bookswap/ui/map/FilterMap.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/FilterMap.kt
@@ -120,7 +120,7 @@ fun FilterMapScreen(navigationActions: NavigationActions, bookFilter: BookFilter
           Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
             Button(
                 onClick = {
-                  bookFilter.setGenres(selectedFiltersGenres.map { it.name })
+                  bookFilter.setGenres(selectedFiltersGenres.map { it.Genre })
                   bookFilter.setLanguages(selectedFiltersLanguages.map { it.name })
                   Toast.makeText(context, "Filters applied", Toast.LENGTH_SHORT).show()
                   navigationActions.goBack()


### PR DESCRIPTION
This PR fixes a bug where filters containing a hyphen "-" were no longer selected when returning to the screen. The issue was due to the comparison logic not handling special characters correctly, leading to discrepancies when updating the selected genres.

To address this, the code was updated to normalize the genre strings by removing hyphens and ensuring case-insensitive comparisons. This change ensures that genres such as "Science-Fiction" and "SCIENCEFICTION" are properly recognized and retained.

With this fix, the filter functionality should now work as expected, preserving selected genres, even those with special characters.