### PR TITLE
Add profile picture handling in the Others User profile screen

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/ui/profile/OthersUserProfileTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/profile/OthersUserProfileTest.kt
@@ -216,7 +216,9 @@ class OthersUserProfileTest : TestCase() {
           navigationActions = mockNavigationActions)
     }
     // Verify the container is displayed
-    composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profilePictureContainer).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(C.Tag.OtherUserProfile.profilePictureContainer)
+        .assertIsDisplayed()
 
     // Verify the picture is displayed inside the container
     composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profile_image_picture).assertIsDisplayed()
@@ -257,7 +259,9 @@ class OthersUserProfileTest : TestCase() {
           navigationActions = mockNavigationActions)
     }
     // Verify the container is displayed
-    composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profilePictureContainer).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(C.Tag.OtherUserProfile.profilePictureContainer)
+        .assertIsDisplayed()
 
     // Verify the icon is displayed inside the container
     composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profile_image_icon).assertIsDisplayed()

--- a/app/src/androidTest/java/com/android/bookswap/ui/profile/OthersUserProfileTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/profile/OthersUserProfileTest.kt
@@ -209,7 +209,7 @@ class OthersUserProfileTest : TestCase() {
           navigationActions = mockNavigationActions)
     }
     // Verify the container is displayed
-    composeTestRule.onNodeWithTag(C.Tag.BookDisplayComp.image).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.image_container).assertIsDisplayed()
 
     // Verify the picture is displayed inside the container
     composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profile_image_picture).assertIsDisplayed()
@@ -250,7 +250,7 @@ class OthersUserProfileTest : TestCase() {
           navigationActions = mockNavigationActions)
     }
     // Verify the container is displayed
-    composeTestRule.onNodeWithTag(C.Tag.BookDisplayComp.image).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.image_container).assertIsDisplayed()
 
     // Verify the icon is displayed inside the container
     composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profile_image_icon).assertIsDisplayed()

--- a/app/src/androidTest/java/com/android/bookswap/ui/profile/OthersUserProfileTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/profile/OthersUserProfileTest.kt
@@ -216,7 +216,7 @@ class OthersUserProfileTest : TestCase() {
           navigationActions = mockNavigationActions)
     }
     // Verify the container is displayed
-    composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.image_container).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profilePictureContainer).assertIsDisplayed()
 
     // Verify the picture is displayed inside the container
     composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profile_image_picture).assertIsDisplayed()
@@ -257,7 +257,7 @@ class OthersUserProfileTest : TestCase() {
           navigationActions = mockNavigationActions)
     }
     // Verify the container is displayed
-    composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.image_container).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profilePictureContainer).assertIsDisplayed()
 
     // Verify the icon is displayed inside the container
     composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profile_image_icon).assertIsDisplayed()

--- a/app/src/androidTest/java/com/android/bookswap/ui/profile/OthersUserProfileTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/profile/OthersUserProfileTest.kt
@@ -61,7 +61,7 @@ class OthersUserProfileTest : TestCase() {
               description =
                   "Recuento de la historia de España desde los primeros pobladores hasta la actualidad.",
               rating = 3,
-              photo = null,
+              photo = "https://example.com/photo.jpg",
               language = BookLanguages.SPANISH,
               isbn = "978-84-09025-23-5",
               genres = listOf(BookGenres.HISTORICAL, BookGenres.NONFICTION, BookGenres.BIOGRAPHY),
@@ -176,4 +176,86 @@ class OthersUserProfileTest : TestCase() {
         .onAllNodesWithTag(C.Tag.BookDisplayComp.author)
         .assertAll(hasText("Author 1").or(hasText("Author 2")))
   }
+
+    @Test
+    fun displaysImage_whenPhotoUrlIsNotEmpty() {
+        val imageTestUserId = UUID.randomUUID()
+        val imageTestUser =
+            DataUser(
+                userUUID = imageTestUserId,
+                greeting = "Mr.",
+                firstName = "John",
+                lastName = "Doe",
+                email = "john.doe@example.com",
+                phoneNumber = "1234567890",
+                latitude = 45.0,
+                longitude = 50.0,
+                profilePictureUrl = "https://test_profile_pic.jpg",
+                bookList = listOf(UUID.randomUUID(), UUID.randomUUID()))
+
+        // Mock the user data fetching
+        every { mockOthersUserViewModel.getUserByUUID(imageTestUserId, any()) } answers
+                {
+                    val callback = secondArg<(DataUser?) -> Unit>()
+                    callback(imageTestUser)
+                }
+
+        composeTestRule.setContent {
+            OthersUserProfileScreen(
+                userId = imageTestUserId,
+                otherUserVM = mockOthersUserViewModel,
+                booksRepository = mockBooksRepository,
+                userBookViewModel = mockUserBookViewModel,
+                navigationActions = mockNavigationActions)
+        }
+        // Verify the container is displayed
+        composeTestRule.onNodeWithTag(C.Tag.BookDisplayComp.image).assertIsDisplayed()
+
+        // Verify the picture is displayed inside the container
+        composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profile_image_picture).assertIsDisplayed()
+
+        // Ensure the icon is not displayed
+        composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profile_image_icon).assertDoesNotExist()
+    }
+
+    @Test
+    fun displaysIcon_whenPhotoUrlIsEmpty() {
+        val imageTestUserId = UUID.randomUUID()
+        val imageTestUser =
+            DataUser(
+                userUUID = imageTestUserId,
+                greeting = "Mr.",
+                firstName = "John",
+                lastName = "Doe",
+                email = "john.doe@example.com",
+                phoneNumber = "1234567890",
+                latitude = 45.0,
+                longitude = 50.0,
+                profilePictureUrl = "",
+                bookList = listOf(UUID.randomUUID(), UUID.randomUUID()))
+
+        // Mock the user data fetching
+        every { mockOthersUserViewModel.getUserByUUID(imageTestUserId, any()) } answers
+                {
+                    val callback = secondArg<(DataUser?) -> Unit>()
+                    callback(imageTestUser)
+                }
+
+        composeTestRule.setContent {
+            OthersUserProfileScreen(
+                userId = imageTestUserId,
+                otherUserVM = mockOthersUserViewModel,
+                booksRepository = mockBooksRepository,
+                userBookViewModel = mockUserBookViewModel,
+                navigationActions = mockNavigationActions)
+        }
+        // Verify the container is displayed
+        composeTestRule.onNodeWithTag(C.Tag.BookDisplayComp.image).assertIsDisplayed()
+
+        // Verify the icon is displayed inside the container
+        composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profile_image_icon).assertIsDisplayed()
+
+        // Ensure the picture is not displayed
+        composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profile_image_picture).assertDoesNotExist()
+    }
 }

--- a/app/src/androidTest/java/com/android/bookswap/ui/profile/OthersUserProfileTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/profile/OthersUserProfileTest.kt
@@ -177,85 +177,85 @@ class OthersUserProfileTest : TestCase() {
         .assertAll(hasText("Author 1").or(hasText("Author 2")))
   }
 
-    @Test
-    fun displaysImage_whenPhotoUrlIsNotEmpty() {
-        val imageTestUserId = UUID.randomUUID()
-        val imageTestUser =
-            DataUser(
-                userUUID = imageTestUserId,
-                greeting = "Mr.",
-                firstName = "John",
-                lastName = "Doe",
-                email = "john.doe@example.com",
-                phoneNumber = "1234567890",
-                latitude = 45.0,
-                longitude = 50.0,
-                profilePictureUrl = "https://test_profile_pic.jpg",
-                bookList = listOf(UUID.randomUUID(), UUID.randomUUID()))
+  @Test
+  fun displaysImage_whenPhotoUrlIsNotEmpty() {
+    val imageTestUserId = UUID.randomUUID()
+    val imageTestUser =
+        DataUser(
+            userUUID = imageTestUserId,
+            greeting = "Mr.",
+            firstName = "John",
+            lastName = "Doe",
+            email = "john.doe@example.com",
+            phoneNumber = "1234567890",
+            latitude = 45.0,
+            longitude = 50.0,
+            profilePictureUrl = "https://test_profile_pic.jpg",
+            bookList = listOf(UUID.randomUUID(), UUID.randomUUID()))
 
-        // Mock the user data fetching
-        every { mockOthersUserViewModel.getUserByUUID(imageTestUserId, any()) } answers
-                {
-                    val callback = secondArg<(DataUser?) -> Unit>()
-                    callback(imageTestUser)
-                }
-
-        composeTestRule.setContent {
-            OthersUserProfileScreen(
-                userId = imageTestUserId,
-                otherUserVM = mockOthersUserViewModel,
-                booksRepository = mockBooksRepository,
-                userBookViewModel = mockUserBookViewModel,
-                navigationActions = mockNavigationActions)
+    // Mock the user data fetching
+    every { mockOthersUserViewModel.getUserByUUID(imageTestUserId, any()) } answers
+        {
+          val callback = secondArg<(DataUser?) -> Unit>()
+          callback(imageTestUser)
         }
-        // Verify the container is displayed
-        composeTestRule.onNodeWithTag(C.Tag.BookDisplayComp.image).assertIsDisplayed()
 
-        // Verify the picture is displayed inside the container
-        composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profile_image_picture).assertIsDisplayed()
-
-        // Ensure the icon is not displayed
-        composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profile_image_icon).assertDoesNotExist()
+    composeTestRule.setContent {
+      OthersUserProfileScreen(
+          userId = imageTestUserId,
+          otherUserVM = mockOthersUserViewModel,
+          booksRepository = mockBooksRepository,
+          userBookViewModel = mockUserBookViewModel,
+          navigationActions = mockNavigationActions)
     }
+    // Verify the container is displayed
+    composeTestRule.onNodeWithTag(C.Tag.BookDisplayComp.image).assertIsDisplayed()
 
-    @Test
-    fun displaysIcon_whenPhotoUrlIsEmpty() {
-        val imageTestUserId = UUID.randomUUID()
-        val imageTestUser =
-            DataUser(
-                userUUID = imageTestUserId,
-                greeting = "Mr.",
-                firstName = "John",
-                lastName = "Doe",
-                email = "john.doe@example.com",
-                phoneNumber = "1234567890",
-                latitude = 45.0,
-                longitude = 50.0,
-                profilePictureUrl = "",
-                bookList = listOf(UUID.randomUUID(), UUID.randomUUID()))
+    // Verify the picture is displayed inside the container
+    composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profile_image_picture).assertIsDisplayed()
 
-        // Mock the user data fetching
-        every { mockOthersUserViewModel.getUserByUUID(imageTestUserId, any()) } answers
-                {
-                    val callback = secondArg<(DataUser?) -> Unit>()
-                    callback(imageTestUser)
-                }
+    // Ensure the icon is not displayed
+    composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profile_image_icon).assertDoesNotExist()
+  }
 
-        composeTestRule.setContent {
-            OthersUserProfileScreen(
-                userId = imageTestUserId,
-                otherUserVM = mockOthersUserViewModel,
-                booksRepository = mockBooksRepository,
-                userBookViewModel = mockUserBookViewModel,
-                navigationActions = mockNavigationActions)
+  @Test
+  fun displaysIcon_whenPhotoUrlIsEmpty() {
+    val imageTestUserId = UUID.randomUUID()
+    val imageTestUser =
+        DataUser(
+            userUUID = imageTestUserId,
+            greeting = "Mr.",
+            firstName = "John",
+            lastName = "Doe",
+            email = "john.doe@example.com",
+            phoneNumber = "1234567890",
+            latitude = 45.0,
+            longitude = 50.0,
+            profilePictureUrl = "",
+            bookList = listOf(UUID.randomUUID(), UUID.randomUUID()))
+
+    // Mock the user data fetching
+    every { mockOthersUserViewModel.getUserByUUID(imageTestUserId, any()) } answers
+        {
+          val callback = secondArg<(DataUser?) -> Unit>()
+          callback(imageTestUser)
         }
-        // Verify the container is displayed
-        composeTestRule.onNodeWithTag(C.Tag.BookDisplayComp.image).assertIsDisplayed()
 
-        // Verify the icon is displayed inside the container
-        composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profile_image_icon).assertIsDisplayed()
-
-        // Ensure the picture is not displayed
-        composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profile_image_picture).assertDoesNotExist()
+    composeTestRule.setContent {
+      OthersUserProfileScreen(
+          userId = imageTestUserId,
+          otherUserVM = mockOthersUserViewModel,
+          booksRepository = mockBooksRepository,
+          userBookViewModel = mockUserBookViewModel,
+          navigationActions = mockNavigationActions)
     }
+    // Verify the container is displayed
+    composeTestRule.onNodeWithTag(C.Tag.BookDisplayComp.image).assertIsDisplayed()
+
+    // Verify the icon is displayed inside the container
+    composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profile_image_icon).assertIsDisplayed()
+
+    // Ensure the picture is not displayed
+    composeTestRule.onNodeWithTag(C.Tag.OtherUserProfile.profile_image_picture).assertDoesNotExist()
+  }
 }

--- a/app/src/main/java/com/android/bookswap/resources/C.kt
+++ b/app/src/main/java/com/android/bookswap/resources/C.kt
@@ -140,9 +140,9 @@ object C {
       const val email = "email"
       const val phone = "phoneNumber"
       const val address = "address"
-      const val image_container = BOOK + UI_T.IMAGE
-      const val profile_image_picture = "profile_image_picture" + UI_T.IMAGE
-      const val profile_image_icon = "profile_image_icon" + UI_T.IMAGE
+      const val profilePictureContainer = S.OTHERS_USER_PROFILE + "_picture" + UI_T.CONTAINER
+      const val profile_image_picture = S.OTHERS_USER_PROFILE + "_picture" + UI_T.IMAGE
+      const val profile_image_icon = S.OTHERS_USER_PROFILE + "_picture" + UI_T.ICON
       const val chatButton = "chatButton"
     }
 

--- a/app/src/main/java/com/android/bookswap/resources/C.kt
+++ b/app/src/main/java/com/android/bookswap/resources/C.kt
@@ -140,6 +140,9 @@ object C {
       const val email = "email"
       const val phone = "phoneNumber"
       const val address = "address"
+      const val image_container = BOOK + UI_T.IMAGE
+      const val profile_image_picture = "profile_image_picture" + UI_T.IMAGE
+      const val profile_image_icon = "profile_image_icon" + UI_T.IMAGE
     }
 
     // Edit User Profile Screen specific tags (EditProfile.kt)

--- a/app/src/main/java/com/android/bookswap/ui/profile/OthersUserProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/profile/OthersUserProfile.kt
@@ -18,8 +18,11 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
 import com.android.bookswap.data.DataBook
 import com.android.bookswap.data.DataUser
 import com.android.bookswap.data.repository.BooksRepository
@@ -36,7 +39,7 @@ private val PROFILE_PICTURE_SIZE = 90.dp
 private val PROFILE_PICTURE_BORDER_WIDTH = 3.dp
 private val ICON_SIZE = 80.dp
 private val PADDING = 16.dp
-private val ITEM_SPACING = 8.dp
+private val ITEM_SPACING = 4.dp
 
 /**
  * Composable function to display the user profile screen.
@@ -114,16 +117,28 @@ fun OthersUserProfileScreen(
                         Modifier.padding(PADDING)
                             .size(PROFILE_PICTURE_SIZE)
                             .border(PROFILE_PICTURE_BORDER_WIDTH, ColorVariable.Accent, CircleShape)
-                            .background(ColorVariable.AccentSecondary, CircleShape),
+                            .background(ColorVariable.AccentSecondary, CircleShape)
+                            .testTag(C.Tag.OtherUserProfile.image_container),
                     contentAlignment = Alignment.Center) {
-                      if (user.profilePictureUrl.isNotEmpty()) {
-                        // Replace with an image loader like Coil or Glide if required
-                        Text("Profile Picture Placeholder")
+
+                      val profilePictureUrl = user.profilePictureUrl
+                      if (profilePictureUrl.isNotEmpty()) {
+                          Log.i("BookDisplayComponent", "Photo URL: ${profilePictureUrl}")
+                          AsyncImage(
+                              model = profilePictureUrl,
+                              contentDescription = "Book Picture",
+                              modifier = Modifier
+                                  .fillMaxSize()
+                                  .clip(CircleShape)
+                                  .testTag(C.Tag.OtherUserProfile.profile_image_picture),
+                              contentScale = ContentScale.Crop)
                       } else {
                         Icon(
                             imageVector = Icons.Default.AccountCircle,
                             contentDescription = null,
-                            modifier = Modifier.size(ICON_SIZE),
+                            modifier = Modifier
+                                .size(ICON_SIZE)
+                                .testTag(C.Tag.OtherUserProfile.profile_image_icon),
                             tint = ColorVariable.Accent)
                       }
                     }
@@ -174,8 +189,9 @@ fun OthersUserProfileScreen(
 /** Constant * */
 private const val LABEL_WEIGHT = 0.5f
 private const val VALUE_WEIGHT = 2f
-private val BORDER_WIDTH = 1.dp
-private val PADDING_SMALL = 4.dp
+private val BORDER_WIDTH = 2.dp
+private val ROW_PADDING = 4.dp
+private val BOX_PADDING = 2.dp
 
 /**
  * A composable function to display a labeled text field.
@@ -188,10 +204,11 @@ fun LabeledText(testTag: String = "LabeledText", label: String, value: String) {
   Box(
       modifier =
           Modifier.fillMaxWidth()
+              .padding(BOX_PADDING)
               .background(ColorVariable.Secondary, shape = MaterialTheme.shapes.small)
               .border(BORDER_WIDTH, ColorVariable.Accent, shape = MaterialTheme.shapes.small)) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(PADDING_SMALL),
+            modifier = Modifier.fillMaxWidth().padding(ROW_PADDING),
             verticalAlignment = Alignment.CenterVertically) {
               Text(
                   text = label,

--- a/app/src/main/java/com/android/bookswap/ui/profile/OthersUserProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/profile/OthersUserProfile.kt
@@ -120,14 +120,14 @@ fun OthersUserProfileScreen(
                             .size(PROFILE_PICTURE_SIZE)
                             .border(PROFILE_PICTURE_BORDER_WIDTH, ColorVariable.Accent, CircleShape)
                             .background(ColorVariable.AccentSecondary, CircleShape)
-                            .testTag(C.Tag.OtherUserProfile.image_container),
+                            .testTag(C.Tag.OtherUserProfile.profilePictureContainer),
                     contentAlignment = Alignment.Center) {
                       val profilePictureUrl = user.profilePictureUrl
                       if (profilePictureUrl.isNotEmpty()) {
                         Log.i("BookDisplayComponent", "Photo URL: ${profilePictureUrl}")
                         AsyncImage(
                             model = profilePictureUrl,
-                            contentDescription = "Book Picture",
+                            contentDescription = "User's Picture",
                             modifier =
                                 Modifier.fillMaxSize()
                                     .clip(CircleShape)

--- a/app/src/main/java/com/android/bookswap/ui/profile/OthersUserProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/profile/OthersUserProfile.kt
@@ -120,25 +120,24 @@ fun OthersUserProfileScreen(
                             .background(ColorVariable.AccentSecondary, CircleShape)
                             .testTag(C.Tag.OtherUserProfile.image_container),
                     contentAlignment = Alignment.Center) {
-
                       val profilePictureUrl = user.profilePictureUrl
                       if (profilePictureUrl.isNotEmpty()) {
-                          Log.i("BookDisplayComponent", "Photo URL: ${profilePictureUrl}")
-                          AsyncImage(
-                              model = profilePictureUrl,
-                              contentDescription = "Book Picture",
-                              modifier = Modifier
-                                  .fillMaxSize()
-                                  .clip(CircleShape)
-                                  .testTag(C.Tag.OtherUserProfile.profile_image_picture),
-                              contentScale = ContentScale.Crop)
+                        Log.i("BookDisplayComponent", "Photo URL: ${profilePictureUrl}")
+                        AsyncImage(
+                            model = profilePictureUrl,
+                            contentDescription = "Book Picture",
+                            modifier =
+                                Modifier.fillMaxSize()
+                                    .clip(CircleShape)
+                                    .testTag(C.Tag.OtherUserProfile.profile_image_picture),
+                            contentScale = ContentScale.Crop)
                       } else {
                         Icon(
                             imageVector = Icons.Default.AccountCircle,
                             contentDescription = null,
-                            modifier = Modifier
-                                .size(ICON_SIZE)
-                                .testTag(C.Tag.OtherUserProfile.profile_image_icon),
+                            modifier =
+                                Modifier.size(ICON_SIZE)
+                                    .testTag(C.Tag.OtherUserProfile.profile_image_icon),
                             tint = ColorVariable.Accent)
                       }
                     }


### PR DESCRIPTION
### Summary
This PR enhances the `OthersUseProfileScreen` to include  handling of profile pictures. User with valid photo URLs will display their images, while those without a photo URL will render an icon for the profile. Tests have been included to ensure the feature works in all scenarios.

### Details
**1. Feature Implementation:**
- Updated Screen: `OthersUserProfileScreen`
  - Uses Coil's AsyncImage to load images dynamically.
  - Displays a profile icon if the photo property in DataUser is null or empty.
  - Tags added for UI testing: image_placeholder, profile_image_picture, and profile_ image_icon.

**2. Testing:**
- New UI Tests: `OthersUserProfileTest`
  -  `displaysImage_whenPhotoUrlIsNotEmpty`:
      - Ensure the place holder for the images is displayed
      - Validates that the component displays the image when a valid photo URL is provided.
      - Ensures the icon is not displayed in this case.
  - `displaysIcon_whenPhotoUrlIsEmpty`:
    - Ensure the place holder for the images is displayed
    - Validates that the profile icon is displayed when the photo URL is missing or null.
    - Ensures the image is not displayed in this case.

**3. Code Adjustments:**
- Resource Constants: Updated C.kt
  - Added new constants for `OthersUserProfile` test tags:
    - image_container
    - profile_image_picture
    - profile_image_icon
- Component Logging: Improved  `OthersUserProfile` with logs to help debugging.

### UI visual representation:
![Screenshot 2024-12-09 144812](https://github.com/user-attachments/assets/04da1a37-8adb-49da-9ad8-1d3ae95430bf)