### PR TITLE
Book Profile Screen Fix

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/ui/books/BookProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/books/BookProfileScreenTest.kt
@@ -1,11 +1,14 @@
 package com.android.bookswap.ui.books
 
+import android.annotation.SuppressLint
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performTouchInput
 import androidx.navigation.compose.rememberNavController
+import androidx.test.espresso.action.ViewActions.swipeUp
 import com.android.bookswap.data.BookGenres
 import com.android.bookswap.data.BookLanguages
 import com.android.bookswap.data.DataBook
@@ -34,7 +37,30 @@ class BookProfileScreenTest {
           testBookId,
           "Historia de España",
           "Jose Ignacio Pastor Iglesias",
-          "Recuento de la historia de España desde los primeros pobladores hasta la actualidad.",
+          """
+    Recuento de la historia de España desde los primeros pobladores hasta la actualidad. 
+    Este libro abarca desde las antiguas civilizaciones ibéricas y celtas hasta la llegada 
+    de los romanos y la posterior invasión de los visigodos. Se examinan en detalle los 
+    ocho siglos de ocupación musulmana, con especial atención a figuras como Abderramán III 
+    y la esplendorosa época de Al-Ándalus. 
+    
+    También se analizan las cruzadas cristianas para recuperar el territorio, conocidas como 
+    la Reconquista, que culminaron en 1492 con la toma de Granada por los Reyes Católicos. 
+    Este evento marcó el inicio de una nueva era para España, incluyendo el descubrimiento 
+    de América por Cristóbal Colón y el auge del Imperio Español durante los siglos XVI y XVII.
+    
+    El libro continúa con las guerras napoleónicas, el colapso del Antiguo Régimen y la 
+    instauración de la Primera República. Se detallan los turbulentos años de la Guerra Civil 
+    Española (1936-1939) y el posterior régimen franquista. Finalmente, se explora la 
+    Transición Democrática y el ascenso de España como una nación moderna dentro de la 
+    Unión Europea.
+    
+    Cada capítulo incluye ilustraciones, mapas y cronologías detalladas para facilitar 
+    el estudio de los eventos históricos más importantes. Es una lectura obligatoria 
+    para cualquier persona interesada en comprender la rica y compleja historia de España, 
+    llena de conquistas, descubrimientos, conflictos y reformas.
+    """
+              .trimIndent(),
           9,
           null,
           BookLanguages.SPANISH,
@@ -49,7 +75,9 @@ class BookProfileScreenTest {
     mockNavController = mockk()
     mockBookRepo = mockk()
 
-    modTestBook = testBook.copy(uuid = modTestBookId, photo = "new_photo_url")
+    modTestBook =
+        testBook.copy(
+            uuid = modTestBookId, description = "Historia de España", photo = "new_photo_url")
 
     // Mocking the getBook call to return the test book
     coEvery { mockBookRepo.getBook(any(), any(), any()) } answers
@@ -100,5 +128,36 @@ class BookProfileScreenTest {
     }
 
     composeTestRule.onNodeWithTag(C.Tag.BookProfile.image).assertIsDisplayed()
+  }
+
+  @SuppressLint("CheckResult")
+  @Test
+  fun descriptionBoxIsScrollable() {
+    composeTestRule.setContent {
+      val navController = rememberNavController()
+      val navigationActions = NavigationActions(navController)
+      BookProfileScreen(testBookId, mockBookRepo, navigationActions)
+    }
+
+    // Check that the "Synopsis" title is displayed
+    composeTestRule.onNodeWithTag(C.Tag.BookProfile.synopsis_label).assertIsDisplayed()
+
+    composeTestRule
+        .onNodeWithTag(C.Tag.BookProfile.scrollable)
+        .performScrollToNode(hasTestTag(C.Tag.BookProfile.synopsis))
+
+    // Check that the description box is displayed
+    composeTestRule
+        .onNodeWithTag(C.Tag.BookProfile.synopsis, useUnmergedTree = true)
+        .assertIsDisplayed()
+
+    // Check that the description box is scrollable
+    val scrollNode = composeTestRule.onNodeWithTag(C.Tag.BookProfile.synopsis)
+
+    // Assertion to verify scrolling works by interacting with the scrollable area
+    scrollNode.performTouchInput { swipeUp() }
+
+    // Optionally, check that after scrolling, the scroll bar is still visible
+    scrollNode.assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/android/bookswap/ui/navigation/NavigationFromBookProfileToEditBookTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/navigation/NavigationFromBookProfileToEditBookTest.kt
@@ -17,6 +17,7 @@ import com.android.bookswap.data.BookGenres
 import com.android.bookswap.data.BookLanguages
 import com.android.bookswap.data.DataBook
 import com.android.bookswap.data.repository.BooksRepository
+import com.android.bookswap.data.repository.UsersRepository
 import com.android.bookswap.model.AppConfig
 import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.model.UserViewModel
@@ -27,6 +28,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import java.util.UUID
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -35,15 +37,25 @@ import org.junit.runner.RunWith
 class NavigationFromBookProfileToEditBookTest {
 
   @get:Rule val composeTestRule = createComposeRule()
+  private lateinit var mockUserRepository: UsersRepository
+  private lateinit var userVM: UserViewModel
+  private lateinit var mockBookRepo: BooksRepository
+  private val currentUserId: UUID = UUID.randomUUID()
+  private val testBookId: UUID = UUID.randomUUID()
+  private val bookUserId: UUID = UUID.randomUUID()
+  private lateinit var testBookOwner: DataBook
+  private lateinit var testBookOther: DataBook
 
-  @Test
-  fun EditBookScreen_allows_editing_when_currentUser_is_bookUser() {
-    // Arrange
-    val currentUserId = UUID.randomUUID()
-    val mockUserViewModel: UserViewModel = mockk()
-    every { mockUserViewModel.uuid } returns currentUserId
-    val testBookId = UUID.randomUUID()
-    val testBook =
+  @Before
+  fun setUp() {
+    mockUserRepository = mockk()
+    userVM = UserViewModel(currentUserId, mockUserRepository)
+    mockBookRepo = mockk<BooksRepository>(relaxed = true)
+
+    every { mockUserRepository.getUser(currentUserId, any()) } answers { currentUserId }
+    every { userVM.getUser().userUUID } returns currentUserId
+
+    testBookOwner =
         DataBook(
             testBookId,
             "Original Title",
@@ -57,37 +69,36 @@ class NavigationFromBookProfileToEditBookTest {
             currentUserId,
             false,
             false)
+    testBookOther = testBookOwner.copy(userId = bookUserId)
+  }
 
-    val mockBookRepo = mockk<BooksRepository>(relaxed = true)
+  @Test
+  fun EditBookScreen_allows_editing_when_currentUser_is_bookUser() {
+    // Arrange
     coEvery { mockBookRepo.getBook(eq(testBookId), any(), any()) } answers
         {
           val onSuccess = secondArg<(DataBook) -> Unit>()
-          onSuccess(testBook)
+          onSuccess(testBookOwner)
         }
 
     composeTestRule.setContent {
       val navController = rememberNavController()
-      CompositionLocalProvider(
-          LocalAppConfig provides AppConfig(userViewModel = mockUserViewModel)) {
-            // Add a NavHost to handle navigation
-            NavHost(navController, C.Screen.BOOK_PROFILE) {
-              composable(C.Screen.BOOK_PROFILE) {
-                BookProfileScreen(testBookId, mockBookRepo, NavigationActions(navController))
-              }
-              composable("${C.Screen.EDIT_BOOK}/{bookUUID}") { backStackEntry ->
-                val bookUUID =
-                    backStackEntry.arguments?.getString("bookUUID")?.let { UUID.fromString(it) }
-                if (bookUUID != null) {
-                  EditBookScreen(mockBookRepo, NavigationActions(navController), bookUUID)
-                }
-              }
+      CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = userVM)) {
+        // Add a NavHost to handle navigation
+        NavHost(navController, C.Screen.BOOK_PROFILE) {
+          composable(C.Screen.BOOK_PROFILE) {
+            BookProfileScreen(testBookId, mockBookRepo, NavigationActions(navController))
+          }
+          composable("${C.Screen.EDIT_BOOK}/{bookUUID}") { backStackEntry ->
+            val bookUUID =
+                backStackEntry.arguments?.getString("bookUUID")?.let { UUID.fromString(it) }
+            if (bookUUID != null) {
+              EditBookScreen(mockBookRepo, NavigationActions(navController), bookUUID)
             }
           }
+        }
+      }
     }
-    // This is juste temporary as when Matias will do the MainActivity part for the navigation
-    // from the Profile to the BookProfile then I will finish the navigation in the main from the
-    // BookProfile to the EditBook
-
     // Act & Assert
     // Assert that the book title is displayed, i.e. the top of the scrollable column is shown
     composeTestRule.onNodeWithTag(C.Tag.BookProfile.title).assertExists()
@@ -96,18 +107,21 @@ class NavigationFromBookProfileToEditBookTest {
     // Scrolls to the end of the column
     composeTestRule
         .onNodeWithTag(C.Tag.BookProfile.scrollable)
-        .performScrollToNode(hasTestTag(C.Tag.BookProfile.scrollable_end))
+        .performScrollToNode(hasTestTag(C.Tag.BookProfile.edit))
 
     // Assert that the Edit Button is displayed
     composeTestRule.onNodeWithTag(C.Tag.BookProfile.edit).assertExists()
     composeTestRule.onNodeWithTag(C.Tag.BookProfile.edit).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(C.Tag.BookProfile.edit).assertTextEquals("Edit Book")
 
     // Click the Edit Button and navigate to EditBookScreen
     composeTestRule.onNodeWithTag(C.Tag.BookProfile.edit).performClick()
 
     // Verify book information on EditBookScreen
     composeTestRule.onNodeWithTag(C.Tag.EditBook.title).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(C.Tag.EditBook.title).assertTextEquals(testBook.title, "Title")
+    composeTestRule
+        .onNodeWithTag(C.Tag.EditBook.title)
+        .assertTextEquals(testBookOwner.title, "Title")
 
     // composeTestRule.onNodeWithTag("inputBookDescription").assertTextEquals("Original
     // Description")
@@ -124,50 +138,32 @@ class NavigationFromBookProfileToEditBookTest {
     coEvery { mockBookRepo.getBook(eq(testBookId), any(), any()) } answers
         {
           val onSuccess = secondArg<(DataBook) -> Unit>()
-          onSuccess(testBook.copy(title = "Updated Title"))
+          onSuccess(testBookOwner.copy(title = "Updated Title"))
         }
   }
 
   @Test
   fun EditButton_is_not_displayed_when_currentUser_is_different_from_bookUser() {
     // Arrange
-    val currentUserId = UUID.randomUUID()
-    val bookUserId = UUID.randomUUID()
-    val testBookId = UUID.randomUUID()
-    val testBook =
-        DataBook(
-            testBookId,
-            "A Book",
-            "Author",
-            "Description",
-            4,
-            null,
-            BookLanguages.ENGLISH,
-            "1234567890",
-            listOf(BookGenres.FICTION),
-            bookUserId,
-            false,
-            false // Different from currentUserId
-            )
-
-    val mockBookRepo = mockk<BooksRepository>(relaxed = true)
     coEvery { mockBookRepo.getBook(eq(testBookId), any(), any()) } answers
         {
           val onSuccess = secondArg<(DataBook) -> Unit>()
-          onSuccess(testBook)
+          onSuccess(testBookOther)
         }
 
     // Act
     composeTestRule.setContent {
       val navController = rememberNavController()
       val navigationActions = NavigationActions(navController)
-      BookProfileScreen(testBookId, mockBookRepo, navigationActions)
+      CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = userVM)) {
+        BookProfileScreen(testBookId, mockBookRepo, navigationActions)
+      }
     }
 
     composeTestRule
         .onNodeWithTag(C.Tag.BookProfile.scrollable)
-        .performScrollToNode(hasTestTag(C.Tag.BookProfile.scrollable_end))
+        .performScrollToNode(hasTestTag(C.Tag.BookProfile.edit))
     // Assert
-    composeTestRule.onNodeWithTag(C.Tag.BookProfile.edit).assertDoesNotExist()
+    composeTestRule.onNodeWithTag(C.Tag.BookProfile.edit).assertTextEquals("Go to User")
   }
 }

--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -238,6 +238,7 @@ class MainActivity : ComponentActivity() {
             if (bookId != null) {
               BookProfileScreen(
                   bookId = bookId, // Default for testing
+                  topAppBar = { topAppBar("Book Profile") },
                   booksRepository = BooksFirestoreSource(FirebaseFirestore.getInstance()),
                   navController = NavigationActions(navController),
               )

--- a/app/src/main/java/com/android/bookswap/resources/C.kt
+++ b/app/src/main/java/com/android/bookswap/resources/C.kt
@@ -166,9 +166,8 @@ object C {
       const val genre = "_genre" + UI_T.TEXT
       const val isbn = BOOK + "_isbn" + UI_T.TEXT
       const val date = BOOK + "_date" + UI_T.TEXT
+      const val imagePlaceholder = BOOK + "_placeholder" + UI_T.IMAGE
       const val image = BOOK + UI_T.IMAGE
-      const val next_image = BOOK + A.NEXT + UI_T.ICON_BUTTON
-      const val previous_image = BOOK + A.BACK + UI_T.ICON_BUTTON
       const val volume = BOOK + "_volume" + UI_T.TEXT
       const val issue = BOOK + "_issue" + UI_T.TEXT
       const val editorial = BOOK + "_editorial" + UI_T.TEXT

--- a/app/src/main/java/com/android/bookswap/ui/books/BookProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/BookProfile.kt
@@ -1,5 +1,6 @@
 package com.android.bookswap.ui.books
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -16,6 +17,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -41,7 +44,6 @@ import com.android.bookswap.data.DataBook
 import com.android.bookswap.data.repository.BooksRepository
 import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.resources.C
-import com.android.bookswap.ui.components.ButtonComponent
 import com.android.bookswap.ui.components.drawVerticalScrollbar
 import com.android.bookswap.ui.navigation.NavigationActions
 import com.android.bookswap.ui.theme.ColorVariable
@@ -54,6 +56,8 @@ val HORIZONTAL_PADDING = 16.dp
 val TOP_PADDING = 2.dp
 const val SCROLLBAR_PADDING = 12f
 const val MAX_LINES = 15
+const val BORDER_WIDTH = 1f
+const val HALF_WIDTH = 0.5f
 
 /**
  * Composable function to display the profile screen of a book.
@@ -230,19 +234,36 @@ fun BookProfileScreen(
                           }
                         }
                   }
-                  // Conditionally display the "Edit Book" button if the current user owns the book
-                  if (dataBook.userId == appConfig.userViewModel.getUser().userUUID) {
-                    item { Spacer(modifier = Modifier.height(COLUMN_PADDING)) }
-                    item {
-                      ButtonComponent(
-                          onClick = {
+                  // Conditionally display the "Edit Book" or "Go to User" button if the current
+                  // user owns the book or not
+                  item {
+                    Button(
+                        colors =
+                            ButtonColors(
+                                ColorVariable.Secondary,
+                                ColorVariable.Accent,
+                                ColorVariable.Secondary,
+                                ColorVariable.Accent),
+                        border = BorderStroke(BORDER_WIDTH.dp, ColorVariable.Accent),
+                        onClick = {
+                          if (dataBook.userId == appConfig.userViewModel.getUser().userUUID) {
                             navController.navigateTo(C.Screen.EDIT_BOOK, dataBook.uuid.toString())
-                          },
-                          modifier =
-                              Modifier.padding(COLUMN_PADDING).testTag(C.Tag.BookProfile.edit)) {
-                            Text("Edit Book")
+                          } else {
+                            navController.navigateTo(
+                                C.Screen.OTHERS_USER_PROFILE, dataBook.userId.toString())
                           }
-                    }
+                        },
+                        modifier =
+                            Modifier.padding(COLUMN_PADDING)
+                                .testTag(C.Tag.BookProfile.edit)
+                                .fillMaxWidth(HALF_WIDTH)) {
+                          Text(
+                              if (dataBook.userId == appConfig.userViewModel.getUser().userUUID) {
+                                "Edit Book"
+                              } else {
+                                "Go to User"
+                              })
+                        }
                   }
                 }
               }

--- a/app/src/main/java/com/android/bookswap/ui/books/BookProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/BookProfile.kt
@@ -44,6 +44,16 @@ import com.android.bookswap.ui.theme.ColorVariable
 import java.util.UUID
 
 /**
+ * Constant values used in the BookProfileScreen.
+ */
+const val COLUMN_WEIGHT = 1f
+val COLUMN_PADDING = 8.dp
+val HORIZONTAL_PADDING = 16.dp
+val TOP_PADDING = 2.dp
+
+
+
+/**
  * Composable function to display the profile screen of a book.
  *
  * @param DataBook The data object containing book details.
@@ -59,7 +69,7 @@ fun BookProfileScreen(
     topAppBar: @Composable () -> Unit = {},
     bottomAppBar: @Composable () -> Unit = {}
 ) {
-  val columnPadding = 8.dp
+
   val pictureWidth = (LocalConfiguration.current.screenWidthDp.dp * (0.60f))
   val pictureHeight = pictureWidth * 1.41f
   val image = R.drawable.isabellacatolica
@@ -93,7 +103,7 @@ fun BookProfileScreen(
                     .padding(innerPadding)
                     .background(ColorVariable.BackGround)
                     .testTag(C.Tag.BookProfile.scrollable),
-            verticalArrangement = Arrangement.spacedBy(columnPadding),
+            verticalArrangement = Arrangement.spacedBy(COLUMN_PADDING),
             horizontalAlignment = Alignment.CenterHorizontally) {
               when {
                 isLoading -> {
@@ -116,7 +126,7 @@ fun BookProfileScreen(
                   item {
                     Text(
                         text = dataBook.title,
-                        modifier = Modifier.testTag(C.Tag.BookProfile.title).padding(columnPadding),
+                        modifier = Modifier.testTag(C.Tag.BookProfile.title).padding(COLUMN_PADDING),
                         color = ColorVariable.Accent,
                         style = MaterialTheme.typography.titleLarge)
                   }
@@ -127,7 +137,7 @@ fun BookProfileScreen(
                         color = ColorVariable.AccentSecondary,
                         style = MaterialTheme.typography.titleMedium)
                   }
-                  item { Spacer(modifier = Modifier.height(columnPadding)) }
+                  item { Spacer(modifier = Modifier.height(COLUMN_PADDING)) }
                   item {
                     Box(
                         modifier =
@@ -152,26 +162,26 @@ fun BookProfileScreen(
                           }
                         }
                   }
-                  item { Spacer(modifier = Modifier.height(columnPadding)) }
+                  item { Spacer(modifier = Modifier.height(COLUMN_PADDING)) }
                   item {
                     dataBook.rating?.let {
                       Text(
-                          text = "Rating: $it/10",
+                          text = "Rating: $it/5",
                           color = ColorVariable.Accent,
                           style = MaterialTheme.typography.bodyMedium,
                           modifier =
-                              Modifier.padding(vertical = 8.dp).testTag(C.Tag.BookProfile.rating))
+                              Modifier.testTag(C.Tag.BookProfile.rating))
+                      Spacer(modifier = Modifier.height(COLUMN_PADDING))
                     }
                   }
-                  item { Spacer(modifier = Modifier.height(columnPadding)) }
+
                   item {
                     Text(
                         text = "Synopsis",
                         color = ColorVariable.Accent,
                         style = MaterialTheme.typography.titleSmall,
                         modifier =
-                            Modifier.padding(vertical = 8.dp)
-                                .testTag(C.Tag.BookProfile.synopsis_label))
+                            Modifier.testTag(C.Tag.BookProfile.synopsis_label))
                   }
                   item {
                     Text(
@@ -179,13 +189,13 @@ fun BookProfileScreen(
                         color = ColorVariable.Accent,
                         style = MaterialTheme.typography.bodyMedium,
                         modifier =
-                            Modifier.padding(vertical = 8.dp).testTag(C.Tag.BookProfile.synopsis),
+                            Modifier.testTag(C.Tag.BookProfile.synopsis),
                         textAlign = TextAlign.Center)
                   }
-                  item { Spacer(modifier = Modifier.height(columnPadding)) }
+                  item { Spacer(modifier = Modifier.height(COLUMN_PADDING)) }
                   item {
-                    Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
-                      Column(modifier = Modifier.weight(1f)) {
+                    Row(modifier = Modifier.fillMaxWidth().padding(horizontal = HORIZONTAL_PADDING)) {
+                      Column(modifier = Modifier.weight(COLUMN_WEIGHT)) {
                         ProfileText(
                             text = "Language: ${dataBook.language.languageCode}",
                             testTag = C.Tag.BookProfile.language)
@@ -196,7 +206,7 @@ fun BookProfileScreen(
                               color = ColorVariable.AccentSecondary,
                               style = MaterialTheme.typography.bodyMedium,
                               modifier =
-                                  Modifier.padding(top = 2.dp, start = 16.dp)
+                                  Modifier.padding(top = TOP_PADDING, start = HORIZONTAL_PADDING)
                                       .testTag(genre.Genre + C.Tag.BookProfile.genre))
                         }
                         ProfileText(
@@ -205,9 +215,7 @@ fun BookProfileScreen(
                             testTag = C.Tag.BookProfile.isbn)
                       }
 
-                      VerticalDivider(color = ColorVariable.Accent, thickness = 1.dp)
-
-                      Column(modifier = Modifier.weight(1f)) {
+                      Column(modifier = Modifier.weight(COLUMN_WEIGHT)) {
                         ProfileText(
                             text = "Date of Publication: [Temporary Date]",
                             testTag = C.Tag.BookProfile.date)
@@ -226,20 +234,16 @@ fun BookProfileScreen(
                   }
                   // Conditionally display the "Edit Book" button if the current user owns the book
                   if (dataBook.userId == appConfig.userViewModel.uuid) {
-                    item { Spacer(modifier = Modifier.height(columnPadding)) }
+                    item { Spacer(modifier = Modifier.height(COLUMN_PADDING)) }
                     item {
                       ButtonComponent(
                           onClick = {
                             navController.navigateTo(C.Screen.EDIT_BOOK, dataBook.uuid.toString())
                           },
-                          modifier = Modifier.padding(8.dp).testTag(C.Tag.BookProfile.edit)) {
+                          modifier = Modifier.padding(COLUMN_PADDING).testTag(C.Tag.BookProfile.edit)) {
                             Text("Edit Book")
                           }
                     }
-                  }
-                  item {
-                    Spacer(
-                        modifier = Modifier.height(0.dp).testTag(C.Tag.BookProfile.scrollable_end))
                   }
                 }
               }
@@ -258,5 +262,5 @@ fun ProfileText(text: String, testTag: String) {
       text = text,
       color = ColorVariable.Accent,
       style = MaterialTheme.typography.bodyMedium,
-      modifier = Modifier.padding(vertical = 8.dp).testTag(testTag))
+      modifier = Modifier.padding(vertical = COLUMN_PADDING).testTag(testTag))
 }

--- a/app/src/main/java/com/android/bookswap/ui/books/BookProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/BookProfile.kt
@@ -231,7 +231,7 @@ fun BookProfileScreen(
                         }
                   }
                   // Conditionally display the "Edit Book" button if the current user owns the book
-                  if (dataBook.userId == appConfig.userViewModel.uuid) {
+                  if (dataBook.userId == appConfig.userViewModel.getUser().userUUID) {
                     item { Spacer(modifier = Modifier.height(COLUMN_PADDING)) }
                     item {
                       ButtonComponent(

--- a/app/src/main/java/com/android/bookswap/ui/books/BookProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/BookProfile.kt
@@ -13,12 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -26,7 +21,6 @@ import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -38,6 +32,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
 import com.android.bookswap.R
 import com.android.bookswap.data.DataBook
 import com.android.bookswap.data.repository.BooksRepository
@@ -67,10 +62,8 @@ fun BookProfileScreen(
   val columnPadding = 8.dp
   val pictureWidth = (LocalConfiguration.current.screenWidthDp.dp * (0.60f))
   val pictureHeight = pictureWidth * 1.41f
-  val buttonsHeight = pictureHeight / 12.0f
-  val images = listOf(R.drawable.isabellacatolica, R.drawable.felipeii)
-  val imagesDescription = listOf("Isabel La Catolica", "Felipe II")
-  var currentImageIndex by remember { mutableIntStateOf(0) }
+  val image = R.drawable.isabellacatolica
+  val imageDescription = "Isabel La Catolica"
 
   val appConfig = LocalAppConfig.current
   // State to hold the book data and loading status
@@ -140,49 +133,23 @@ fun BookProfileScreen(
                         modifier =
                             Modifier.size(pictureWidth, pictureHeight)
                                 .background(ColorVariable.BackGround)) {
-                          Image(
-                              painter = painterResource(id = images[currentImageIndex]),
-                              contentDescription = imagesDescription[currentImageIndex],
-                              modifier =
-                                  Modifier.height(pictureHeight)
-                                      .fillMaxWidth()
-                                      .testTag("${currentImageIndex}_" + C.Tag.BookProfile.image))
-                        }
-                  }
-                  item {
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.SpaceBetween) {
-                          IconButton(
-                              onClick = {
-                                currentImageIndex =
-                                    (currentImageIndex - 1 + images.size) % images.size
-                              },
-                              modifier =
-                                  Modifier.height(buttonsHeight)
-                                      .testTag(C.Tag.BookProfile.previous_image)) {
-                                Icon(
-                                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                                    contentDescription = "Previous Image",
-                                    tint = ColorVariable.Accent)
-                              }
-                          Text(
-                              text = imagesDescription[currentImageIndex],
-                              color = ColorVariable.AccentSecondary,
-                              modifier = Modifier.padding(horizontal = 8.dp))
-                          IconButton(
-                              onClick = {
-                                currentImageIndex = (currentImageIndex + 1) % images.size
-                              },
-                              modifier =
-                                  Modifier.height(buttonsHeight)
-                                      .testTag(C.Tag.BookProfile.next_image)) {
-                                Icon(
-                                    imageVector = Icons.AutoMirrored.Filled.ArrowForward,
-                                    contentDescription = "Next Image",
-                                    tint = ColorVariable.Accent)
-                              }
+                          if (dataBook.photo?.isNotEmpty() == true) {
+                            AsyncImage(
+                                model = dataBook.photo,
+                                contentDescription = dataBook.title,
+                                modifier =
+                                    Modifier.height(pictureHeight)
+                                        .fillMaxWidth()
+                                        .testTag(C.Tag.BookProfile.image))
+                          } else {
+                            Image(
+                                painter = painterResource(id = image),
+                                contentDescription = imageDescription,
+                                modifier =
+                                    Modifier.height(pictureHeight)
+                                        .fillMaxWidth()
+                                        .testTag(C.Tag.BookProfile.imagePlaceholder))
+                          }
                         }
                   }
                   item { Spacer(modifier = Modifier.height(columnPadding)) }

--- a/app/src/main/java/com/android/bookswap/ui/books/BookProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/BookProfile.kt
@@ -10,14 +10,16 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -28,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
@@ -39,19 +42,18 @@ import com.android.bookswap.data.repository.BooksRepository
 import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.components.ButtonComponent
+import com.android.bookswap.ui.components.drawVerticalScrollbar
 import com.android.bookswap.ui.navigation.NavigationActions
 import com.android.bookswap.ui.theme.ColorVariable
 import java.util.UUID
 
-/**
- * Constant values used in the BookProfileScreen.
- */
+/** Constant values used in the BookProfileScreen. */
 const val COLUMN_WEIGHT = 1f
 val COLUMN_PADDING = 8.dp
 val HORIZONTAL_PADDING = 16.dp
 val TOP_PADDING = 2.dp
-
-
+const val SCROLLBAR_PADDING = 12f
+const val MAX_LINES = 15
 
 /**
  * Composable function to display the profile screen of a book.
@@ -126,7 +128,8 @@ fun BookProfileScreen(
                   item {
                     Text(
                         text = dataBook.title,
-                        modifier = Modifier.testTag(C.Tag.BookProfile.title).padding(COLUMN_PADDING),
+                        modifier =
+                            Modifier.testTag(C.Tag.BookProfile.title).padding(COLUMN_PADDING),
                         color = ColorVariable.Accent,
                         style = MaterialTheme.typography.titleLarge)
                   }
@@ -169,8 +172,7 @@ fun BookProfileScreen(
                           text = "Rating: $it/5",
                           color = ColorVariable.Accent,
                           style = MaterialTheme.typography.bodyMedium,
-                          modifier =
-                              Modifier.testTag(C.Tag.BookProfile.rating))
+                          modifier = Modifier.testTag(C.Tag.BookProfile.rating))
                       Spacer(modifier = Modifier.height(COLUMN_PADDING))
                     }
                   }
@@ -180,57 +182,53 @@ fun BookProfileScreen(
                         text = "Synopsis",
                         color = ColorVariable.Accent,
                         style = MaterialTheme.typography.titleSmall,
-                        modifier =
-                            Modifier.testTag(C.Tag.BookProfile.synopsis_label))
+                        modifier = Modifier.testTag(C.Tag.BookProfile.synopsis_label))
                   }
-                  item {
-                    Text(
-                        text = dataBook.description ?: "No description available",
-                        color = ColorVariable.Accent,
-                        style = MaterialTheme.typography.bodyMedium,
-                        modifier =
-                            Modifier.testTag(C.Tag.BookProfile.synopsis),
-                        textAlign = TextAlign.Center)
-                  }
+                  item { BookSynopsis(description = dataBook.description ?: "") }
                   item { Spacer(modifier = Modifier.height(COLUMN_PADDING)) }
                   item {
-                    Row(modifier = Modifier.fillMaxWidth().padding(horizontal = HORIZONTAL_PADDING)) {
-                      Column(modifier = Modifier.weight(COLUMN_WEIGHT)) {
-                        ProfileText(
-                            text = "Language: ${dataBook.language.languageCode}",
-                            testTag = C.Tag.BookProfile.language)
-                        ProfileText(text = "Genres:", testTag = C.Tag.BookProfile.genres)
-                        dataBook.genres.forEach { genre ->
-                          Text(
-                              text = "- ${genre.Genre}",
-                              color = ColorVariable.AccentSecondary,
-                              style = MaterialTheme.typography.bodyMedium,
-                              modifier =
-                                  Modifier.padding(top = TOP_PADDING, start = HORIZONTAL_PADDING)
-                                      .testTag(genre.Genre + C.Tag.BookProfile.genre))
-                        }
-                        ProfileText(
-                            text =
-                                "ISBN: ${dataBook.isbn ?: "ISBN doesn't exist or is not available"}",
-                            testTag = C.Tag.BookProfile.isbn)
-                      }
+                    Row(
+                        modifier =
+                            Modifier.fillMaxWidth().padding(horizontal = HORIZONTAL_PADDING)) {
+                          Column(modifier = Modifier.weight(COLUMN_WEIGHT)) {
+                            ProfileText(
+                                text = "Language: ${dataBook.language.languageCode}",
+                                testTag = C.Tag.BookProfile.language)
+                            ProfileText(text = "Genres:", testTag = C.Tag.BookProfile.genres)
+                            dataBook.genres.forEach { genre ->
+                              Text(
+                                  text = "- ${genre.Genre}",
+                                  color = ColorVariable.AccentSecondary,
+                                  style = MaterialTheme.typography.bodyMedium,
+                                  modifier =
+                                      Modifier.padding(
+                                              top = TOP_PADDING, start = HORIZONTAL_PADDING)
+                                          .testTag(genre.Genre + C.Tag.BookProfile.genre))
+                            }
+                            ProfileText(
+                                text =
+                                    "ISBN: ${dataBook.isbn ?: "ISBN doesn't exist or is not available"}",
+                                testTag = C.Tag.BookProfile.isbn)
+                          }
 
-                      Column(modifier = Modifier.weight(COLUMN_WEIGHT)) {
-                        ProfileText(
-                            text = "Date of Publication: [Temporary Date]",
-                            testTag = C.Tag.BookProfile.date)
-                        ProfileText(
-                            text = "Volume: [Temporary Volume]", testTag = C.Tag.BookProfile.volume)
-                        ProfileText(
-                            text = "Issue: [Temporary Issue]", testTag = C.Tag.BookProfile.issue)
-                        ProfileText(
-                            text = "Editorial: [Temporary Editorial]",
-                            testTag = C.Tag.BookProfile.editorial)
-                        ProfileText(
-                            text = "Place of Edition: [Temporary Place]",
-                            testTag = C.Tag.BookProfile.location)
-                      }
-                    }
+                          Column(modifier = Modifier.weight(COLUMN_WEIGHT)) {
+                            ProfileText(
+                                text = "Date of Publication: [Temporary Date]",
+                                testTag = C.Tag.BookProfile.date)
+                            ProfileText(
+                                text = "Volume: [Temporary Volume]",
+                                testTag = C.Tag.BookProfile.volume)
+                            ProfileText(
+                                text = "Issue: [Temporary Issue]",
+                                testTag = C.Tag.BookProfile.issue)
+                            ProfileText(
+                                text = "Editorial: [Temporary Editorial]",
+                                testTag = C.Tag.BookProfile.editorial)
+                            ProfileText(
+                                text = "Place of Edition: [Temporary Place]",
+                                testTag = C.Tag.BookProfile.location)
+                          }
+                        }
                   }
                   // Conditionally display the "Edit Book" button if the current user owns the book
                   if (dataBook.userId == appConfig.userViewModel.uuid) {
@@ -240,7 +238,8 @@ fun BookProfileScreen(
                           onClick = {
                             navController.navigateTo(C.Screen.EDIT_BOOK, dataBook.uuid.toString())
                           },
-                          modifier = Modifier.padding(COLUMN_PADDING).testTag(C.Tag.BookProfile.edit)) {
+                          modifier =
+                              Modifier.padding(COLUMN_PADDING).testTag(C.Tag.BookProfile.edit)) {
                             Text("Edit Book")
                           }
                     }
@@ -263,4 +262,33 @@ fun ProfileText(text: String, testTag: String) {
       color = ColorVariable.Accent,
       style = MaterialTheme.typography.bodyMedium,
       modifier = Modifier.padding(vertical = COLUMN_PADDING).testTag(testTag))
+}
+
+/**
+ * Composable function to display the synopsis of a book. The synopsis is scrollable if it exceeds a
+ * certain number of lines.
+ *
+ * @param description The description of the book.
+ */
+@Composable
+fun BookSynopsis(description: String) {
+  val scrollState = rememberScrollState()
+
+  Box(
+      modifier =
+          Modifier.heightIn(
+                  max =
+                      with(LocalDensity.current) {
+                        MaterialTheme.typography.bodyMedium.lineHeight.toDp() * MAX_LINES
+                      })
+              .verticalScroll(scrollState)
+              .drawVerticalScrollbar(scrollState, paddingEnd = SCROLLBAR_PADDING)
+              .padding(start = HORIZONTAL_PADDING, end = HORIZONTAL_PADDING)
+              .testTag(C.Tag.BookProfile.synopsis)) {
+        Text(
+            text = description.ifEmpty { "No description available" },
+            color = ColorVariable.Accent,
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Start)
+      }
 }

--- a/app/src/main/java/com/android/bookswap/ui/components/DrawVerticalScrollBar.kt
+++ b/app/src/main/java/com/android/bookswap/ui/components/DrawVerticalScrollBar.kt
@@ -1,0 +1,43 @@
+package com.android.bookswap.ui.components
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import com.android.bookswap.ui.theme.ColorVariable
+
+const val STANDARD_THICKNESS = 4f
+const val MINIMUM_COERCION = 1f
+const val END_PADDING = 8f
+
+/** Modifier that draws a vertical scrollbar on the right side of the content. */
+fun Modifier.drawVerticalScrollbar(
+    scrollState: ScrollState,
+    color: Color = ColorVariable.Accent,
+    thickness: Float = STANDARD_THICKNESS,
+    paddingEnd: Float = END_PADDING
+): Modifier =
+    this.then(
+        Modifier.drawWithContent {
+          drawContent()
+
+          // Only draw the scroll bar if the content is scrollable
+          if (scrollState.maxValue > 0) {
+            // Height of the scrollbar (fixed proportion of the total height)
+            val scrollBarHeight = size.height * 0.1f
+            // Scrollbar position based on scroll progress
+            val scrollBarY =
+                (size.height - scrollBarHeight) *
+                    (scrollState.value /
+                        scrollState.maxValue.toFloat().coerceAtLeast(MINIMUM_COERCION))
+
+            drawLine(
+                color = color,
+                start = Offset(size.width - paddingEnd, scrollBarY),
+                end = Offset(size.width - paddingEnd, scrollBarY + scrollBarHeight),
+                strokeWidth = thickness,
+                cap = StrokeCap.Round)
+          }
+        })

--- a/app/src/main/java/com/android/bookswap/ui/components/DrawVerticalScrollBar.kt
+++ b/app/src/main/java/com/android/bookswap/ui/components/DrawVerticalScrollBar.kt
@@ -8,11 +8,19 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import com.android.bookswap.ui.theme.ColorVariable
 
+/** Constants for the scrollbar */
 const val STANDARD_THICKNESS = 4f
 const val MINIMUM_COERCION = 1f
 const val END_PADDING = 8f
 
-/** Modifier that draws a vertical scrollbar on the right side of the content. */
+/**
+ * Draw a vertical scrollbar on the right side of the composable that uses this modifier.
+ *
+ * @param scrollState The scroll state of the composable
+ * @param color The color of the scrollbar
+ * @param thickness The thickness of the scrollbar
+ * @param paddingEnd The padding from the right edge of the composable
+ */
 fun Modifier.drawVerticalScrollbar(
     scrollState: ScrollState,
     color: Color = ColorVariable.Accent,


### PR DESCRIPTION
# Book Profile Screen Fix
This pull request seeks to completely fix and finalise the Book Profile Screen as the title indicates, this includes a number of changes which will be described in parts below. Most changes are in `BookProfileScreen.kt`, however other files have been modified and added. Of course all changes come with their necessary tests. Two small fixes that don't deserve a part is adding the top app bar and removing some unnecessary spaces.
## Image Display
The first part to be fixed was the image display. Of old it simply held a placeholder and was prepared to consist of a list of images instead. Now it displays the image belonging to the book being observed so long as it exists, and reverts to a placeholder whenever it does not exist. This can be seen in the first of the images below.
## Synopsis Box Fix
This part is more complex, in order to not allow a particularly long synopsis to eat up the entire screen, it has now been made so it can hold a maximum of 15 lines (subject to change as it is a variable at the top of the file) and any more will allow the box to be scrolled through to reach the rest of the synopsis. This makes it much more visible and is observable in the second image below. To do this a new file was created, `DrawVerticalScrollBar.kt`, this file contains a new modifier that can be called to create a scroll bar to the right of the composable. It can be used as follows:
``` kotlin
val scrollState = rememberScrollState()
//Content
Modifier
  .verticalScroll(scrollState)
  .drawVerticalScrollbar(scrollState)
//Content
```
This is just an example but most parameters of the scroll bar can be modified by passing them as parameters, though they have a default value if a parameter is not passed.
## Edit Button Fix and Other User Button
This part of the pull request seeks to fix the edit button which was done changing the call to obtain the correct UUID as well as adding the Other User Button which allows someone to go to the user profile of the book owner if it is not their own. This was a small and fast change done by changing the `OnClick()` and `Text` of the edit button depending on the owner.
## Images
<div style="display: inline-block;">
  <img src="https://github.com/user-attachments/assets/e8b7a769-0548-41fc-a2d7-ef27c3410069" alt="Screenshot1" width="200"/>
  <img src="https://github.com/user-attachments/assets/d55e2ecc-02b9-4cde-aa4f-ec5056dea7ae" alt="Screenshot2" width="200"/>
  <img src="https://github.com/user-attachments/assets/f5807357-b0ce-4fb8-bc7d-c82bb521255a" alt="Screenshot3" width="200"/>
</div>

