### PR TITLE
Fix app crash on first launch after login

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/endtoend/NavigationBarEndToEnd.kt
+++ b/app/src/androidTest/java/com/android/bookswap/endtoend/NavigationBarEndToEnd.kt
@@ -32,8 +32,7 @@ class NavigationBarEndToEnd {
   @get:Rule
   val grantPermissionRule: GrantPermissionRule =
       GrantPermissionRule.grant(
-          Manifest.permission.ACCESS_FINE_LOCATION,
-          Manifest.permission.ACCESS_COARSE_LOCATION)
+          Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION)
 
   private lateinit var mockBookRepository: BooksRepository
   private lateinit var mockUserRepository: UsersRepository

--- a/app/src/androidTest/java/com/android/bookswap/endtoend/NavigationBarEndToEnd.kt
+++ b/app/src/androidTest/java/com/android/bookswap/endtoend/NavigationBarEndToEnd.kt
@@ -33,8 +33,7 @@ class NavigationBarEndToEnd {
   val grantPermissionRule: GrantPermissionRule =
       GrantPermissionRule.grant(
           Manifest.permission.ACCESS_FINE_LOCATION,
-          Manifest.permission.ACCESS_COARSE_LOCATION,
-          Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+          Manifest.permission.ACCESS_COARSE_LOCATION)
 
   private lateinit var mockBookRepository: BooksRepository
   private lateinit var mockUserRepository: UsersRepository

--- a/app/src/androidTest/java/com/android/bookswap/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/map/MapScreenTest.kt
@@ -1,6 +1,5 @@
 package com.android.bookswap.ui.map
 
-import android.Manifest
 import android.content.Context
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.geometry.Offset
@@ -16,7 +15,6 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipe
 import androidx.compose.ui.test.swipeUp
 import androidx.navigation.compose.rememberNavController
-import androidx.test.rule.GrantPermissionRule
 import com.android.bookswap.data.BookGenres
 import com.android.bookswap.data.BookLanguages
 import com.android.bookswap.data.DataBook
@@ -31,6 +29,8 @@ import com.android.bookswap.model.map.DefaultGeolocation
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.navigation.NavigationActions
 import com.google.maps.android.compose.CameraPositionState
+import com.kaspersky.kaspresso.device.permissions.Permissions
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -89,7 +89,8 @@ val books =
             false,
             false))
 
-class MapScreenTest {
+class MapScreenTest : TestCase() {
+  private val geolocation = DefaultGeolocation()
   private val user = listOf(DataUser(bookList = listOf(UUID(1000, 1000), UUID(2000, 1000))))
   private val userLongList = listOf(DataUser(bookList = listOf(UUID(2000, 2000))))
 
@@ -103,12 +104,6 @@ class MapScreenTest {
   private val userWithoutBooks =
       listOf(UserBooksWithLocation(UUID.randomUUID(), 0.0, 0.0, emptyList()))
   @get:Rule val composeTestRule = createComposeRule()
-  @get:Rule
-  val grantPermissionRule: GrantPermissionRule =
-      GrantPermissionRule.grant(
-          Manifest.permission.ACCESS_FINE_LOCATION,
-          Manifest.permission.ACCESS_COARSE_LOCATION,
-          Manifest.permission.ACCESS_BACKGROUND_LOCATION)
 
   private val mockBookManagerViewModel: BookManagerViewModel = mockk()
   private lateinit var userVM: UserViewModel
@@ -145,224 +140,247 @@ class MapScreenTest {
     every { userVM.updateAddress(any<Double>(), any<Double>(), any<Context>()) } just runs
   }
 
-  @Test
-  fun displayAllComponents() {
+  fun composeMapScreen(selectedUser: Int = -1) {
     composeTestRule.setContent {
       CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = userVM)) {
         val navController = rememberNavController()
         val navigationActions = NavigationActions(navController)
-        MapScreen(mockBookManagerViewModel, navigationActions, 0)
+        MapScreen(mockBookManagerViewModel, navigationActions, selectedUser, geolocation)
       }
     }
-    composeTestRule.onNodeWithTag(C.Tag.map_screen_container).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(C.Tag.Map.google_map).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(C.Tag.Map.Marker.info_window_container).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(C.Tag.Map.Marker.info_window_scrollable).assertIsDisplayed()
-    composeTestRule
-        .onAllNodesWithTag(C.Tag.Map.Marker.info_window_book_container)
-        .assertCountEquals(2)
-    composeTestRule.onAllNodesWithTag(C.Tag.Map.Marker.book_title).assertCountEquals(2)
-    composeTestRule.onAllNodesWithTag(C.Tag.Map.Marker.book_author).assertCountEquals(2)
-    composeTestRule.onAllNodesWithTag(C.Tag.Map.Marker.info_window_divider).assertCountEquals(1)
+  }
 
-    // components of Draggable Menu
-    composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_container).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_layout).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_handle).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_handle_divider).assertIsDisplayed()
-    composeTestRule
-        .onNodeWithTag("0_" + C.Tag.BookDisplayComp.book_display_container)
-        .assertIsDisplayed()
-    composeTestRule
-        .onNodeWithTag("1_" + C.Tag.BookDisplayComp.book_display_container)
-        .assertIsDisplayed()
+  @Test
+  fun displayAllComponents() {
+    run {
+      step("Compose screen") { composeMapScreen(0) }
+      step("Accept Permissions") {
+        flakySafely { device.permissions.clickOn(Permissions.Button.ALLOW_FOREGROUND) }
+      }
+      step("") {
+        composeTestRule.onNodeWithTag(C.Tag.map_screen_container).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(C.Tag.Map.google_map).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(C.Tag.Map.Marker.info_window_container).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(C.Tag.Map.Marker.info_window_scrollable).assertIsDisplayed()
+        composeTestRule
+            .onAllNodesWithTag(C.Tag.Map.Marker.info_window_book_container)
+            .assertCountEquals(2)
+        composeTestRule.onAllNodesWithTag(C.Tag.Map.Marker.book_title).assertCountEquals(2)
+        composeTestRule.onAllNodesWithTag(C.Tag.Map.Marker.book_author).assertCountEquals(2)
+        composeTestRule.onAllNodesWithTag(C.Tag.Map.Marker.info_window_divider).assertCountEquals(1)
 
-    composeTestRule
-        .onAllNodesWithTag(C.Tag.BookDisplayComp.image, useUnmergedTree = true)
-        .assertCountEquals(2)
-    composeTestRule
-        .onAllNodesWithTag(C.Tag.BookDisplayComp.title, useUnmergedTree = true)
-        .assertCountEquals(2)
-    composeTestRule
-        .onAllNodesWithTag(C.Tag.BookDisplayComp.author, useUnmergedTree = true)
-        .assertCountEquals(2)
-    composeTestRule
-        .onAllNodesWithTag(C.Tag.BookDisplayComp.rating, useUnmergedTree = true)
-        .assertCountEquals(2)
-    composeTestRule
-        .onAllNodesWithTag(C.Tag.BookDisplayComp.filled_star, useUnmergedTree = true)
-        .assertCountEquals(9)
-    composeTestRule
-        .onAllNodesWithTag(C.Tag.BookDisplayComp.hollow_star, useUnmergedTree = true)
-        .assertCountEquals(1)
-    composeTestRule
-        .onAllNodesWithTag(C.Tag.BookDisplayComp.genres, useUnmergedTree = true)
-        .assertCountEquals(2)
-    composeTestRule
-        .onAllNodesWithTag(C.Tag.BookListComp.divider, useUnmergedTree = true)
-        .assertCountEquals(books.size - 1)
-    composeTestRule
-        .onNodeWithTag(C.Tag.Map.filter_button, useUnmergedTree = true)
-        .assertIsDisplayed()
+        // components of Draggable Menu
+        composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_container).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_layout).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_handle).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_handle_divider).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag("0_" + C.Tag.BookDisplayComp.book_display_container)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag("1_" + C.Tag.BookDisplayComp.book_display_container)
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onAllNodesWithTag(C.Tag.BookDisplayComp.image, useUnmergedTree = true)
+            .assertCountEquals(2)
+        composeTestRule
+            .onAllNodesWithTag(C.Tag.BookDisplayComp.title, useUnmergedTree = true)
+            .assertCountEquals(2)
+        composeTestRule
+            .onAllNodesWithTag(C.Tag.BookDisplayComp.author, useUnmergedTree = true)
+            .assertCountEquals(2)
+        composeTestRule
+            .onAllNodesWithTag(C.Tag.BookDisplayComp.rating, useUnmergedTree = true)
+            .assertCountEquals(2)
+        composeTestRule
+            .onAllNodesWithTag(C.Tag.BookDisplayComp.filled_star, useUnmergedTree = true)
+            .assertCountEquals(9)
+        composeTestRule
+            .onAllNodesWithTag(C.Tag.BookDisplayComp.hollow_star, useUnmergedTree = true)
+            .assertCountEquals(1)
+        composeTestRule
+            .onAllNodesWithTag(C.Tag.BookDisplayComp.genres, useUnmergedTree = true)
+            .assertCountEquals(2)
+        composeTestRule
+            .onAllNodesWithTag(C.Tag.BookListComp.divider, useUnmergedTree = true)
+            .assertCountEquals(books.size - 1)
+        composeTestRule
+            .onNodeWithTag(C.Tag.Map.filter_button, useUnmergedTree = true)
+            .assertIsDisplayed()
+      }
+    }
   }
 
   @Test
   fun noMarkerDisplayedForUserWithoutBooks() {
     every { mockBookManagerViewModel.filteredBooks } answers { MutableStateFlow(emptyList()) }
     every { mockBookManagerViewModel.filteredUsers } answers { MutableStateFlow(userWithoutBooks) }
-    composeTestRule.setContent {
-      CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = userVM)) {
-        val navController = rememberNavController()
-        val navigationActions = NavigationActions(navController)
-        MapScreen(mockBookManagerViewModel, navigationActions, 0)
+
+    run {
+      step("Compose screen") { composeMapScreen(0) }
+      step("Accept Permissions") {
+        flakySafely { device.permissions.clickOn(Permissions.Button.ALLOW_FOREGROUND) }
+      }
+      step("") {
+        // Assert that the marker info window is displayed, but without book entries
+        composeTestRule.onNodeWithTag(C.Tag.Map.Marker.info_window_container).assertIsNotDisplayed()
+        composeTestRule
+            .onAllNodesWithTag(C.Tag.Map.Marker.info_window_book_container)
+            .assertCountEquals(0) // No books
       }
     }
-
-    // Assert that the marker info window is displayed, but without book entries
-    composeTestRule.onNodeWithTag(C.Tag.Map.Marker.info_window_container).assertIsNotDisplayed()
-    composeTestRule
-        .onAllNodesWithTag(C.Tag.Map.Marker.info_window_book_container)
-        .assertCountEquals(0) // No books
   }
 
   @Test
   fun emptyUserListDoesNotShowMarkers() {
     every { mockBookManagerViewModel.filteredBooks } answers { MutableStateFlow(emptyList()) }
     every { mockBookManagerViewModel.filteredUsers } answers { MutableStateFlow(emptyList()) }
-    composeTestRule.setContent {
-      CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = userVM)) {
-        val navController = rememberNavController()
-        val navigationActions = NavigationActions(navController)
-        MapScreen(mockBookManagerViewModel, navigationActions)
+
+    run {
+      step("Compose screen") { composeMapScreen() }
+      step("Accept Permissions") {
+        flakySafely { device.permissions.clickOn(Permissions.Button.ALLOW_FOREGROUND) }
+      }
+      step("") {
+        // Assert that the map is displayed but no marker and info window is shown
+        composeTestRule.onNodeWithTag(C.Tag.Map.google_map).assertIsDisplayed()
+        composeTestRule
+            .onAllNodesWithTag(C.Tag.Map.Marker.info_window_container)
+            .assertCountEquals(0) // No marker info
       }
     }
-
-    // Assert that the map is displayed but no marker and info window is shown
-    composeTestRule.onNodeWithTag(C.Tag.Map.google_map).assertIsDisplayed()
-    composeTestRule
-        .onAllNodesWithTag(C.Tag.Map.Marker.info_window_container)
-        .assertCountEquals(0) // No marker info
   }
 
   @Test
   fun emptyBooksListGiveEmptyDraggableMenu() {
     every { mockBookManagerViewModel.filteredBooks } answers { MutableStateFlow(emptyList()) }
     every { mockBookManagerViewModel.filteredUsers } answers { MutableStateFlow(emptyList()) }
-    composeTestRule.setContent {
-      CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = userVM)) {
-        val navController = rememberNavController()
-        val navigationActions = NavigationActions(navController)
-        MapScreen(mockBookManagerViewModel, navigationActions)
+
+    run {
+      step("Compose screen") { composeMapScreen() }
+      step("Accept Permissions") {
+        flakySafely { device.permissions.clickOn(Permissions.Button.ALLOW_FOREGROUND) }
+      }
+      step("") {
+        // Assert that the marker info window is displayed, but without book entries
+        composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_container).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag("0_" + C.Tag.BookDisplayComp.book_display_container)
+            .assertIsNotDisplayed()
+        composeTestRule
+            .onNodeWithTag(C.Tag.BookListComp.empty_list_text)
+            .assertIsDisplayed()
+            .assertTextContains("No books to display")
       }
     }
-    // Assert that the marker info window is displayed, but without book entries
-    composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_container).assertIsDisplayed()
-    composeTestRule
-        .onNodeWithTag("0_" + C.Tag.BookDisplayComp.book_display_container)
-        .assertIsNotDisplayed()
-    composeTestRule
-        .onNodeWithTag(C.Tag.BookListComp.empty_list_text)
-        .assertIsDisplayed()
-        .assertTextContains("No books to display")
   }
 
   @Test
   fun noUserSelectedInitially() {
-    composeTestRule.setContent {
-      CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = userVM)) {
-        val navController = rememberNavController()
-        val navigationActions = NavigationActions(navController)
-        MapScreen(mockBookManagerViewModel, navigationActions)
+
+    run {
+      step("Compose screen") { composeMapScreen() }
+      step("Accept Permissions") {
+        flakySafely { device.permissions.clickOn(Permissions.Button.ALLOW_FOREGROUND) }
+      }
+      step("") {
+        // Assert that no info window is displayed when no user is selected
+        composeTestRule.onNodeWithTag(C.Tag.Map.google_map).assertIsDisplayed()
+        composeTestRule
+            .onAllNodesWithTag(C.Tag.Map.Marker.info_window_container)
+            .assertCountEquals(0) // No info window
       }
     }
-
-    // Assert that no info window is displayed when no user is selected
-    composeTestRule.onNodeWithTag(C.Tag.Map.google_map).assertIsDisplayed()
-    composeTestRule
-        .onAllNodesWithTag(C.Tag.Map.Marker.info_window_container)
-        .assertCountEquals(0) // No info window
   }
 
   @Test
   fun draggableMenu_canBeDraggedVertically() {
-    composeTestRule.setContent {
-      CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = userVM)) {
-        val navController = rememberNavController()
-        val navigationActions = NavigationActions(navController)
-        MapScreen(mockBookManagerViewModel, navigationActions, 0)
+
+    run {
+      step("Compose screen") { composeMapScreen(0) }
+      step("Accept Permissions") {
+        flakySafely { device.permissions.clickOn(Permissions.Button.ALLOW_FOREGROUND) }
+      }
+      step("") {
+        // Ensure the DraggableMenu is initially displayed
+        composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_container).assertIsDisplayed()
+
+        // Simulate a drag gesture by swiping up (closing the menu)
+        composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_container).performTouchInput {
+          swipeUp(startY = bottom, endY = top, durationMillis = 500)
+        }
+
+        // Assert that after swiping, the menu is still displayed but in a new position
+        composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_container).assertIsDisplayed()
+
+        // Simulate dragging the menu back down (opening the menu)
+        composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_container).performTouchInput {
+          swipe(start = Offset(0f, 100f), end = Offset(0f, -500f), durationMillis = 500)
+        }
+
+        // Assert that after swiping, the menu is still displayed but in a new position
+        composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_container).assertIsDisplayed()
       }
     }
-    // Ensure the DraggableMenu is initially displayed
-    composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_container).assertIsDisplayed()
-
-    // Simulate a drag gesture by swiping up (closing the menu)
-    composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_container).performTouchInput {
-      swipeUp(startY = bottom, endY = top, durationMillis = 500)
-    }
-
-    // Assert that after swiping, the menu is still displayed but in a new position
-    composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_container).assertIsDisplayed()
-
-    // Simulate dragging the menu back down (opening the menu)
-    composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_container).performTouchInput {
-      swipe(start = Offset(0f, 100f), end = Offset(0f, -500f), durationMillis = 500)
-    }
-
-    // Assert that after swiping, the menu is still displayed but in a new position
-    composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_container).assertIsDisplayed()
   }
 
   @Test
   fun draggableMenuListIsScrollable() {
-
     every { mockBookManagerViewModel.filteredBooks } answers { MutableStateFlow(longListBook) }
     every { mockBookManagerViewModel.filteredUsers } answers
         {
           MutableStateFlow(userBooksWithLocationLongList)
         }
-    composeTestRule.setContent {
-      CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = userVM)) {
-        val navController = rememberNavController()
-        val navigationActions = NavigationActions(navController)
-        MapScreen(mockBookManagerViewModel, navigationActions, 0)
-      }
-    }
 
-    // Assert initial state: Only first item(s) are visible
-    composeTestRule
-        .onNodeWithTag("0_" + C.Tag.BookDisplayComp.book_display_container)
-        .assertIsDisplayed()
-    composeTestRule
-        .onNodeWithTag("19_" + C.Tag.BookDisplayComp.book_display_container)
-        .assertIsNotDisplayed()
-    // Perform scroll gesture on LazyColumn
-    composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_layout).performTouchInput {
-      for (i in 1..19) {
-        swipeUp()
+    run {
+      step("Compose screen") { composeMapScreen(0) }
+      step("Accept Permissions") {
+        flakySafely { device.permissions.clickOn(Permissions.Button.ALLOW_FOREGROUND) }
+      }
+      step("") {
+        // Assert initial state: Only first item(s) are visible
+        composeTestRule
+            .onNodeWithTag("0_" + C.Tag.BookDisplayComp.book_display_container)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag("19_" + C.Tag.BookDisplayComp.book_display_container)
+            .assertIsNotDisplayed()
+        // Perform scroll gesture on LazyColumn
+        composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_layout).performTouchInput {
+          for (i in 1..19) {
+            swipeUp()
+          }
+        }
+        composeTestRule
+            .onNodeWithTag("0_" + C.Tag.BookDisplayComp.book_display_container)
+            .assertIsNotDisplayed()
+        composeTestRule
+            .onNodeWithTag("19_" + C.Tag.BookDisplayComp.book_display_container)
+            .assertIsDisplayed()
       }
     }
-    composeTestRule
-        .onNodeWithTag("0_" + C.Tag.BookDisplayComp.book_display_container)
-        .assertIsNotDisplayed()
-    composeTestRule
-        .onNodeWithTag("19_" + C.Tag.BookDisplayComp.book_display_container)
-        .assertIsDisplayed()
   }
 
   @Test
   fun mapHasGeoLocation() {
-    val geolocation = DefaultGeolocation()
-    composeTestRule.setContent {
-      CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = userVM)) {
-        val navController = rememberNavController()
-        val navigationActions = NavigationActions(navController)
-        MapScreen(mockBookManagerViewModel, navigationActions, 0)
+    run {
+      step("Accept Permissions") {
+        flakySafely {
+          device.hackPermissions.grant(
+              device.targetContext.packageName, android.Manifest.permission.ACCESS_COARSE_LOCATION)
+          device.hackPermissions.grant(
+              device.targetContext.packageName, android.Manifest.permission.ACCESS_FINE_LOCATION)
+        }
+      }
+      step("Compose screen") { composeMapScreen(0) }
+      step("") {
+        val node1 = composeTestRule.onNodeWithTag(C.Tag.Map.google_map).fetchSemanticsNode()
+        val cameraPositionState: CameraPositionState? = node1.config.getOrNull(CameraPositionKey)
+
+        assertEquals(geolocation.latitude.value, cameraPositionState?.position?.target?.latitude)
+        assertEquals(geolocation.longitude.value, cameraPositionState?.position?.target?.longitude)
       }
     }
-    val node1 = composeTestRule.onNodeWithTag(C.Tag.Map.google_map).fetchSemanticsNode()
-    val cameraPositionState: CameraPositionState? = node1.config.getOrNull(CameraPositionKey)
-
-    assertEquals(geolocation.latitude.value, cameraPositionState?.position?.target?.latitude)
-    assertEquals(geolocation.longitude.value, cameraPositionState?.position?.target?.longitude)
   }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,6 @@
     <!-- Permissions -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/app/src/main/java/com/android/bookswap/model/map/Geolocation.kt
+++ b/app/src/main/java/com/android/bookswap/model/map/Geolocation.kt
@@ -4,11 +4,8 @@ import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.pm.PackageManager
-import android.os.Build
 import android.os.Looper
-import androidx.annotation.RequiresApi
 import androidx.compose.runtime.mutableStateOf
-import androidx.core.app.ActivityCompat
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationRequest
@@ -65,8 +62,12 @@ class Geolocation(private val activity: Activity) : IGeolocation {
 
   /** Check if permissions are granted */
   private fun hasLocationPermissions(): Boolean {
-    val fine = activity.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
-    val coarse = activity.checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
+    val fine =
+        activity.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED
+    val coarse =
+        activity.checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED
     return fine || coarse
   }
 

--- a/app/src/main/java/com/android/bookswap/ui/map/Map.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/Map.kt
@@ -106,17 +106,17 @@ fun MapScreen(
     mutableStateOf(MapUiSettings(myLocationButtonEnabled = false, zoomControlsEnabled = false))
   }
   val permissions =
-    arrayOf(
-      android.Manifest.permission.ACCESS_COARSE_LOCATION,
-      android.Manifest.permission.ACCESS_FINE_LOCATION)
+      arrayOf(
+          android.Manifest.permission.ACCESS_COARSE_LOCATION,
+          android.Manifest.permission.ACCESS_FINE_LOCATION)
   val permLauncher =
-    rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
-      if (it.values.contains(true)) {
-        geolocation.startLocationUpdates()
-        mapProperties = MapProperties(isMyLocationEnabled = true)
-        mapUISettings = MapUiSettings(myLocationButtonEnabled = true, zoomControlsEnabled = false)
+      rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
+        if (it.values.contains(true)) {
+          geolocation.startLocationUpdates()
+          mapProperties = MapProperties(isMyLocationEnabled = true)
+          mapUISettings = MapUiSettings(myLocationButtonEnabled = true, zoomControlsEnabled = false)
+        }
       }
-    }
   // Get the user's current location
   val latitude = geolocation.latitude.collectAsState()
   val longitude = geolocation.longitude.collectAsState()
@@ -130,11 +130,11 @@ fun MapScreen(
       Toast.makeText(context, "Please connect to Internet to actualise", Toast.LENGTH_SHORT).show()
     }
     val hasPermissions =
-      permissions
-        .map {
-          ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
-        }
-        .contains(true)
+        permissions
+            .map {
+              ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
+            }
+            .contains(true)
     if (hasPermissions) {
       geolocation.startLocationUpdates()
       mapProperties = MapProperties(isMyLocationEnabled = true)

--- a/app/src/main/java/com/android/bookswap/ui/map/Map.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/Map.kt
@@ -149,7 +149,11 @@ fun MapScreen(
   // Stop location and books updates when the screen is disposed
   DisposableEffect(Unit) {
     onDispose {
-      userVM.updateAddress(latitude.value, longitude.value, context)
+      if (latitude.value.isNaN() || longitude.value.isNaN()) {
+        userVM.updateAddress(userVM.getUser().latitude, userVM.getUser().longitude, context)
+      } else {
+        userVM.updateAddress(latitude.value, longitude.value, context)
+      }
       geolocation.stopLocationUpdates()
       bookManagerViewModel.stopUpdatingBooks()
     }

--- a/app/src/main/java/com/android/bookswap/ui/map/Map.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/Map.kt
@@ -105,6 +105,11 @@ fun MapScreen(
   var mapUISettings by remember {
     mutableStateOf(MapUiSettings(myLocationButtonEnabled = false, zoomControlsEnabled = false))
   }
+  fun enableLocation() {
+    geolocation.startLocationUpdates()
+    mapProperties = MapProperties(isMyLocationEnabled = true)
+    mapUISettings = MapUiSettings(myLocationButtonEnabled = true, zoomControlsEnabled = false)
+  }
   val permissions =
       arrayOf(
           android.Manifest.permission.ACCESS_COARSE_LOCATION,
@@ -112,9 +117,7 @@ fun MapScreen(
   val permLauncher =
       rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
         if (it.values.contains(true)) {
-          geolocation.startLocationUpdates()
-          mapProperties = MapProperties(isMyLocationEnabled = true)
-          mapUISettings = MapUiSettings(myLocationButtonEnabled = true, zoomControlsEnabled = false)
+          enableLocation()
         }
       }
   // Get the user's current location
@@ -136,9 +139,7 @@ fun MapScreen(
             }
             .contains(true)
     if (hasPermissions) {
-      geolocation.startLocationUpdates()
-      mapProperties = MapProperties(isMyLocationEnabled = true)
-      mapUISettings = MapUiSettings(myLocationButtonEnabled = true, zoomControlsEnabled = false)
+      enableLocation()
     } else {
       permLauncher.launch(permissions)
     }

--- a/app/src/test/java/com/android/bookswap/model/map/GeolocationTest.kt
+++ b/app/src/test/java/com/android/bookswap/model/map/GeolocationTest.kt
@@ -5,16 +5,13 @@ import android.app.Activity
 import android.content.pm.PackageManager
 import android.location.Location
 import android.os.Looper
-import androidx.core.app.ActivityCompat
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationResult
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.tasks.Tasks
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
@@ -25,7 +22,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 class GeolocationTest {
@@ -41,24 +37,18 @@ class GeolocationTest {
     every { LocationServices.getFusedLocationProviderClient(mockActivity) } returns
         mockFusedLocationClient
 
-    mockkStatic(ActivityCompat::class)
     every {
-      ActivityCompat.checkSelfPermission(mockActivity, Manifest.permission.ACCESS_FINE_LOCATION)
+      mockActivity.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
     } returns PackageManager.PERMISSION_GRANTED
     every {
-      ActivityCompat.checkSelfPermission(mockActivity, Manifest.permission.ACCESS_COARSE_LOCATION)
+      mockActivity.checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION)
     } returns PackageManager.PERMISSION_GRANTED
 
     geolocation = Geolocation(mockActivity)
   }
 
   @Test
-  fun `startLocationUpdates should request location updates if permissions are granted`() {
-    // Mock the permission check to return true
-    every {
-      mockActivity.checkPermission(Manifest.permission.ACCESS_BACKGROUND_LOCATION, any(), any())
-    } returns PackageManager.PERMISSION_GRANTED
-
+  fun `startLocationUpdates should request location updates`() {
     every {
       mockFusedLocationClient.requestLocationUpdates(
           any(), any<LocationCallback>(), Looper.getMainLooper())
@@ -72,100 +62,6 @@ class GeolocationTest {
           any(), any<LocationCallback>(), Looper.getMainLooper())
     }
     assertEquals(true, geolocation.isRunning.value)
-  }
-
-  @Config(sdk = [30])
-  @Test
-  fun `startLocationUpdates should request permissions if not granted`() {
-    every {
-      ActivityCompat.checkSelfPermission(mockActivity, Manifest.permission.ACCESS_FINE_LOCATION)
-    } returns PackageManager.PERMISSION_DENIED
-    every {
-      ActivityCompat.checkSelfPermission(
-          mockActivity, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
-    } returns PackageManager.PERMISSION_DENIED
-
-    // Mock ActivityCompat.requestPermissions (static method)
-    mockkStatic(ActivityCompat::class)
-
-    every { ActivityCompat.requestPermissions(any(), any(), any()) } just Runs
-
-    geolocation.startLocationUpdates()
-
-    // Define the expected permissions array
-    val expectedLocationPermissions =
-        arrayOf(
-            Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION)
-
-    // Verify that ActivityCompat.requestPermissions is called with the correct arguments
-    verify {
-      ActivityCompat.requestPermissions(eq(mockActivity), eq(expectedLocationPermissions), eq(1))
-    }
-    assertEquals(false, geolocation.isRunning.value)
-  }
-
-  @Config(sdk = [30])
-  @Test
-  fun `startLocationUpdates should request background permissions if not granted`() {
-    every {
-      ActivityCompat.checkSelfPermission(
-          mockActivity, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
-    } returns PackageManager.PERMISSION_DENIED
-
-    // Mock ActivityCompat.requestPermissions (static method)
-    mockkStatic(ActivityCompat::class)
-
-    every { ActivityCompat.requestPermissions(any(), any(), any()) } just Runs
-    every {
-      mockFusedLocationClient.requestLocationUpdates(
-          any(), any<LocationCallback>(), Looper.getMainLooper())
-    } returns Tasks.forResult(null)
-    every { mockFusedLocationClient.lastLocation } returns Tasks.forResult(null)
-
-    geolocation.startLocationUpdates()
-
-    val expectedBackgroundPermissions = arrayOf(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
-
-    // Verify that ActivityCompat.requestPermissions is called with the correct arguments
-    verify {
-      ActivityCompat.requestPermissions(eq(mockActivity), eq(expectedBackgroundPermissions), eq(2))
-    }
-    assertEquals(true, geolocation.isRunning.value)
-  }
-
-  @Config(sdk = [28])
-  @Test
-  fun `startLocationUpdates should request permissions If not granted API 28`() {
-    every {
-      ActivityCompat.checkSelfPermission(mockActivity, Manifest.permission.ACCESS_FINE_LOCATION)
-    } returns PackageManager.PERMISSION_DENIED
-    every {
-      ActivityCompat.checkSelfPermission(
-          mockActivity, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
-    } returns PackageManager.PERMISSION_DENIED
-
-    // Mock ActivityCompat.requestPermissions (static method)
-    mockkStatic(ActivityCompat::class)
-
-    every { ActivityCompat.requestPermissions(any(), any(), any()) } just Runs
-
-    geolocation.startLocationUpdates()
-
-    // Define the expected permissions array
-    val expectedLocationPermissions =
-        arrayOf(
-            Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION)
-
-    val expectedBackgroundPermissions = arrayOf(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
-
-    // Verify that ActivityCompat.requestPermissions is called with the correct arguments
-    verify {
-      ActivityCompat.requestPermissions(eq(mockActivity), eq(expectedLocationPermissions), eq(1))
-    }
-    verify(exactly = 0) {
-      ActivityCompat.requestPermissions(any(), eq(expectedBackgroundPermissions), any())
-    }
-    assertEquals(false, geolocation.isRunning.value)
   }
 
   @Test
@@ -177,9 +73,6 @@ class GeolocationTest {
     every { mockFusedLocationClient.removeLocationUpdates(any<LocationCallback>()) } returns
         Tasks.forResult(null)
     every { mockFusedLocationClient.lastLocation } returns Tasks.forResult(null)
-    every {
-      mockActivity.checkPermission(Manifest.permission.ACCESS_BACKGROUND_LOCATION, any(), any())
-    } returns PackageManager.PERMISSION_GRANTED
 
     geolocation.startLocationUpdates()
     geolocation.stopLocationUpdates()
@@ -197,9 +90,6 @@ class GeolocationTest {
 
   @Test
   fun `latitude and longitude should be updated in location callback`() {
-    every {
-      mockActivity.checkPermission(Manifest.permission.ACCESS_BACKGROUND_LOCATION, any(), any())
-    } returns PackageManager.PERMISSION_GRANTED
 
     val mockLocation: Location = mockk()
     every { mockLocation.latitude } returns 37.7749

--- a/app/src/test/java/com/android/bookswap/model/map/GeolocationTest.kt
+++ b/app/src/test/java/com/android/bookswap/model/map/GeolocationTest.kt
@@ -37,12 +37,10 @@ class GeolocationTest {
     every { LocationServices.getFusedLocationProviderClient(mockActivity) } returns
         mockFusedLocationClient
 
-    every {
-      mockActivity.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION)
-    } returns PackageManager.PERMISSION_GRANTED
-    every {
-      mockActivity.checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION)
-    } returns PackageManager.PERMISSION_GRANTED
+    every { mockActivity.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) } returns
+        PackageManager.PERMISSION_GRANTED
+    every { mockActivity.checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) } returns
+        PackageManager.PERMISSION_GRANTED
 
     geolocation = Geolocation(mockActivity)
   }


### PR DESCRIPTION
Fix app crash when navigating to the Map screen for the first time and location permissions are not yet granted by the user when location service enters the composition