### PR TITLE
Remove useless argument in deleteBooks in book repository

### DIFF
--- a/app/src/main/java/com/android/bookswap/data/repository/BookRepository.kt
+++ b/app/src/main/java/com/android/bookswap/data/repository/BookRepository.kt
@@ -49,8 +49,7 @@ interface BooksRepository {
    * Function to delete a book from the repository.
    *
    * @param uuid The unique identifier of the book to be deleted.
-   * @param dataBook The book data to be deleted (can also just use the uuid).
    * @param callback A callback function that receives an exception if the operation fails.
    */
-  fun deleteBooks(uuid: UUID, dataBook: DataBook, callback: (Result<Unit>) -> Unit)
+  fun deleteBooks(uuid: UUID, callback: (Result<Unit>) -> Unit)
 }

--- a/app/src/main/java/com/android/bookswap/data/repository/BookRepository.kt
+++ b/app/src/main/java/com/android/bookswap/data/repository/BookRepository.kt
@@ -51,5 +51,5 @@ interface BooksRepository {
    * @param uuid The unique identifier of the book to be deleted.
    * @param callback A callback function that receives an exception if the operation fails.
    */
-  fun deleteBooks(uuid: UUID, callback: (Result<Unit>) -> Unit)
+  fun deleteBook(uuid: UUID, callback: (Result<Unit>) -> Unit)
 }

--- a/app/src/main/java/com/android/bookswap/data/source/network/BookFirestoreSource.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/network/BookFirestoreSource.kt
@@ -186,13 +186,12 @@ class BooksFirestoreSource(private val db: FirebaseFirestore) : BooksRepository 
    * Deletes a book from the Firestore database.
    *
    * @param uuid The UUID of the book to be deleted.
-   * @param dataBook The DataBook object containing the book details.
    * @param callback Callback to be invoked with the result of the operation. The result is Unit on
    *   success, or an exception on failure.
    */
-  override fun deleteBooks(uuid: UUID, dataBook: DataBook, callback: (Result<Unit>) -> Unit) {
+  override fun deleteBooks(uuid: UUID, callback: (Result<Unit>) -> Unit) {
     performFirestoreOperation(
-        db.collection(collectionBooks).document(dataBook.uuid.toString()).delete(), callback)
+        db.collection(collectionBooks).document(uuid.toString()).delete(), callback)
   }
   /**
    * Maps a Firestore document to a DataBook object. If any required field is missing, returns null

--- a/app/src/main/java/com/android/bookswap/data/source/network/BookFirestoreSource.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/network/BookFirestoreSource.kt
@@ -189,7 +189,7 @@ class BooksFirestoreSource(private val db: FirebaseFirestore) : BooksRepository 
    * @param callback Callback to be invoked with the result of the operation. The result is Unit on
    *   success, or an exception on failure.
    */
-  override fun deleteBooks(uuid: UUID, callback: (Result<Unit>) -> Unit) {
+  override fun deleteBook(uuid: UUID, callback: (Result<Unit>) -> Unit) {
     performFirestoreOperation(
         db.collection(collectionBooks).document(uuid.toString()).delete(), callback)
   }

--- a/app/src/main/java/com/android/bookswap/ui/books/edit/EditBookScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/edit/EditBookScreen.kt
@@ -336,9 +336,8 @@ fun EditBookScreen(
                     Button(
                         onClick = {
                           booksRepository.deleteBooks(
-                              book.uuid,
-                              book,
-                              callback = { result ->
+                              book.uuid)
+                              { result ->
                                 if (result.isSuccess) {
                                   navigationActions.goBack()
                                 } else {
@@ -346,7 +345,7 @@ fun EditBookScreen(
                                           context, "Failed to delete book.", Toast.LENGTH_SHORT)
                                       .show()
                                 }
-                              })
+                              }
                         },
                         modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.delete),
                         colors =

--- a/app/src/main/java/com/android/bookswap/ui/books/edit/EditBookScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/edit/EditBookScreen.kt
@@ -335,7 +335,7 @@ fun EditBookScreen(
                   item {
                     Button(
                         onClick = {
-                          booksRepository.deleteBooks(book.uuid) { result ->
+                          booksRepository.deleteBook(book.uuid) { result ->
                             if (result.isSuccess) {
                               navigationActions.goBack()
                             } else {

--- a/app/src/main/java/com/android/bookswap/ui/books/edit/EditBookScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/edit/EditBookScreen.kt
@@ -335,17 +335,14 @@ fun EditBookScreen(
                   item {
                     Button(
                         onClick = {
-                          booksRepository.deleteBooks(
-                              book.uuid)
-                              { result ->
-                                if (result.isSuccess) {
-                                  navigationActions.goBack()
-                                } else {
-                                  Toast.makeText(
-                                          context, "Failed to delete book.", Toast.LENGTH_SHORT)
-                                      .show()
-                                }
-                              }
+                          booksRepository.deleteBooks(book.uuid) { result ->
+                            if (result.isSuccess) {
+                              navigationActions.goBack()
+                            } else {
+                              Toast.makeText(context, "Failed to delete book.", Toast.LENGTH_SHORT)
+                                  .show()
+                            }
+                          }
                         },
                         modifier = Modifier.fillMaxWidth().testTag(C.Tag.EditBook.delete),
                         colors =

--- a/app/src/test/java/com/android/bookswap/data/source/network/BooksFirestoreSourceTest.kt
+++ b/app/src/test/java/com/android/bookswap/data/source/network/BooksFirestoreSourceTest.kt
@@ -88,7 +88,7 @@ class BooksFirestoreSourceTest {
     every { mockDocumentReference.delete() }.returns(Tasks.forResult(null))
 
     // Act
-    bookSource.deleteBooks(testBook.uuid) {}
+    bookSource.deleteBook(testBook.uuid) {}
 
     // Assert
     verify { mockDocumentReference.delete() }

--- a/app/src/test/java/com/android/bookswap/data/source/network/BooksFirestoreSourceTest.kt
+++ b/app/src/test/java/com/android/bookswap/data/source/network/BooksFirestoreSourceTest.kt
@@ -88,7 +88,7 @@ class BooksFirestoreSourceTest {
     every { mockDocumentReference.delete() }.returns(Tasks.forResult(null))
 
     // Act
-    bookSource.deleteBooks(testBook.uuid, testBook) {}
+    bookSource.deleteBooks(testBook.uuid) {}
 
     // Assert
     verify { mockDocumentReference.delete() }


### PR DESCRIPTION
This PR comes from the closed PR : https://github.com/BookswapEPFL/Bookswap/pull/251.
The other PR was closed because it was full of bugs and became far too big as the merges were added each week, so it was decided to split the tasks into several smaller PR.

This PR removes an argument from the BookRepository's deleteBooks function. The uuid argument was sufficient for this function, so the argument that wanted the whole book was removed.