### PR TITLE
Update upload-artifact of github actions to v4

### DIFF
--- a/.github/workflows/buildApk.yml
+++ b/.github/workflows/buildApk.yml
@@ -53,7 +53,7 @@ jobs:
           keyStorePassword: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           keyPassword: ${{ secrets.ANDROID_KEY_PASSWORD }}
       - name: Upload Release Build to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: apk-signed.apk
           path: ${{ env.ANDROID_SIGNED_FILE }}


### PR DESCRIPTION
For several weeks, github announced the deprecation of upload-artifact@v3 announcing temporary disruption to warn people and later a full shutdown of the oldest version.
To allow long-term usage of this code (and prevent mail spam) an update was needed to v4.

This turned out to be very straightforward.