### PR TITLE
Fix crash when trying to resolve address with NaN coords

### DIFF
--- a/app/src/main/java/com/android/bookswap/ui/map/Map.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/Map.kt
@@ -116,7 +116,7 @@ fun MapScreen(
           android.Manifest.permission.ACCESS_FINE_LOCATION)
   val permLauncher =
       rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
-        if (it.values.contains(true)) {
+        if (permissions.map { p -> it.getOrDefault(p, false) }.contains(true)) {
           enableLocation()
         }
       }
@@ -143,16 +143,12 @@ fun MapScreen(
     } else {
       permLauncher.launch(permissions)
     }
-    cameraPositionState.position =
-        CameraPosition.fromLatLngZoom(LatLng(latitude.value, longitude.value), INIT_ZOOM)
     isOnline = isNetworkAvailable(context)
   }
   // Stop location and books updates when the screen is disposed
   DisposableEffect(Unit) {
     onDispose {
-      if (latitude.value.isNaN() || longitude.value.isNaN()) {
-        userVM.updateAddress(userVM.getUser().latitude, userVM.getUser().longitude, context)
-      } else {
+      if (!latitude.value.isNaN() && !longitude.value.isNaN()) {
         userVM.updateAddress(latitude.value, longitude.value, context)
       }
       geolocation.stopLocationUpdates()


### PR DESCRIPTION
Fix crash happening while trying to translate an address from coordinates when location is not enabled and no previous location is available, thus using NaN values and causing a crash.