### PR TITLE
Book created from IBSN are sent to EditScreen

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/ui/books/add/ISBNAddTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/books/add/ISBNAddTest.kt
@@ -22,7 +22,6 @@ import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.model.UserViewModel
 import com.android.bookswap.resources.C
 import com.android.bookswap.ui.navigation.NavigationActions
-import com.android.bookswap.ui.navigation.TopLevelDestination
 import com.android.bookswap.utils.matchDataBook
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.mockk.Runs
@@ -152,7 +151,7 @@ class ISBNAddTest : TestCase() {
 
     // Mock the navigation
     val mockNavigationActions: NavigationActions = mockk()
-    every { mockNavigationActions.navigateTo(any(TopLevelDestination::class)) } just Runs
+    every { mockNavigationActions.navigateTo(C.Screen.EDIT_BOOK, any()) } just Runs
 
     composeTestRule.setContent {
       CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserVM)) {
@@ -169,7 +168,7 @@ class ISBNAddTest : TestCase() {
     } // Api is called
     verify { mockBooksRepository.addBook(matchDataBook(dataBook), any()) } // Book is added
     verify {
-      mockNavigationActions.navigateTo(any(TopLevelDestination::class))
+      mockNavigationActions.navigateTo(C.Screen.EDIT_BOOK, any())
     } // Navigation is called when book is added
   }
 
@@ -189,7 +188,11 @@ class ISBNAddTest : TestCase() {
     // Mock call to repository
     val mockBooksRepository: BooksRepository = mockk()
 
-    composeTestRule.setContent { AddISBNScreen(mockNavigationActions, mockBooksRepository) }
+    composeTestRule.setContent {
+      CompositionLocalProvider(LocalAppConfig provides AppConfig(userViewModel = mockUserVM)) {
+        AddISBNScreen(mockNavigationActions, mockBooksRepository)
+      }
+    }
 
     composeTestRule.onNodeWithTag(C.Tag.NewBookISBN.isbn).performTextInput("9783161484100")
     composeTestRule.onNodeWithTag(C.Tag.NewBookISBN.search).performClick()

--- a/app/src/main/java/com/android/bookswap/ui/books/add/AddISBNScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/add/AddISBNScreen.kt
@@ -34,7 +34,6 @@ import com.android.bookswap.ui.MAXLENGTHISBN
 import com.android.bookswap.ui.components.ButtonComponent
 import com.android.bookswap.ui.components.FieldComponent
 import com.android.bookswap.ui.navigation.NavigationActions
-import com.android.bookswap.ui.navigation.TopLevelDestinations
 import com.android.bookswap.ui.theme.ColorVariable
 
 /** This is the main screen for the chat feature. It displays the list of messages */
@@ -91,7 +90,9 @@ fun AddISBNScreen(
                                                     result.getOrThrow().uuid
                                             appConfig.userViewModel.updateUser(
                                                 bookList = newBookList)
-                                              navigationActions.navigateTo(C.Screen.EDIT_BOOK, result.getOrThrow().uuid.toString())
+                                            navigationActions.navigateTo(
+                                                C.Screen.EDIT_BOOK,
+                                                result.getOrThrow().uuid.toString())
                                           } else {
                                             val error = res.exceptionOrNull()!!
                                             Log.e("AddBook", res.toString())

--- a/app/src/main/java/com/android/bookswap/ui/books/add/AddISBNScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/add/AddISBNScreen.kt
@@ -75,7 +75,7 @@ fun AddISBNScreen(
                         onClick = {
                           if (inputVerification.testIsbn(isbn)) {
                             GoogleBookDataSource(context).getBookFromISBN(
-                                isbn, appConfig.userViewModel.uuid) { result ->
+                                isbn, appConfig.userViewModel.getUser().userUUID) { result ->
                                   if (result.isFailure) {
                                     Toast.makeText(
                                             context, "Search unsuccessful", Toast.LENGTH_LONG)
@@ -88,16 +88,10 @@ fun AddISBNScreen(
                                           if (res.isSuccess) {
                                             val newBookList =
                                                 appConfig.userViewModel.getUser().bookList +
-                                                    result.getOrNull()?.uuid!!
+                                                    result.getOrThrow().uuid
                                             appConfig.userViewModel.updateUser(
                                                 bookList = newBookList)
-                                            Toast.makeText(
-                                                    context,
-                                                    "${result.getOrNull()?.title} added",
-                                                    Toast.LENGTH_LONG)
-                                                .show()
-                                            navigationActions.navigateTo(
-                                                TopLevelDestinations.NEW_BOOK)
+                                              navigationActions.navigateTo(C.Screen.EDIT_BOOK, result.getOrThrow().uuid.toString())
                                           } else {
                                             val error = res.exceptionOrNull()!!
                                             Log.e("AddBook", res.toString())


### PR DESCRIPTION
Before, when creating a book using the ISBN book creation screen, the books were directly added to the user list. 
Usually users were expecting to each time go search their book to edit it and add the genre and the language after.
Now when the book is added, the user is directly sent to the EditScreen where the book can be edited.

To note, I also fixed the problem in the ISBN creation where the userId of the createdBook was not always the user creating the book.