### PR TITLE
Strings.xml and C.kt

### DIFF
--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.navigation.compose.NavHost
@@ -164,7 +165,7 @@ class MainActivity : ComponentActivity() {
           composable(C.Screen.CHAT_LIST) {
             ListChatScreen(
                 navigationActions,
-                topAppBar = { topAppBar("Messages") },
+                topAppBar = { topAppBar(stringResource(R.string.chat_list_screen_title)) },
                 bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
                 contactViewModel = contactViewModel)
           }
@@ -184,7 +185,7 @@ class MainActivity : ComponentActivity() {
             } else {
               BookAdditionChoiceScreen(
                   navigationActions,
-                  topAppBar = { topAppBar("Add a Book") },
+                  topAppBar = { topAppBar(stringResource(R.string.book_addition_choice_title)) },
                   bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
                   photoFirebaseStorageRepository = photoStorage,
                   booksRepository = bookRepository)
@@ -197,7 +198,7 @@ class MainActivity : ComponentActivity() {
                 BookManagerViewModel(geolocation, bookRepository, userRepository, bookFilter),
                 navigationActions = navigationActions,
                 geolocation = geolocation,
-                topAppBar = { topAppBar("Map") },
+                topAppBar = { topAppBar(stringResource(R.string.map_screen_title)) },
                 bottomAppBar = { bottomAppBar(this@navigation.route ?: "") })
           }
           composable(C.Screen.MAP_FILTER) { FilterMapScreen(navigationActions, bookFilter) }
@@ -206,7 +207,7 @@ class MainActivity : ComponentActivity() {
           composable(C.Screen.NEW_BOOK) {
             BookAdditionChoiceScreen(
                 navigationActions,
-                topAppBar = { topAppBar("Add a Book") },
+                topAppBar = { topAppBar(stringResource(R.string.book_addition_choice_title)) },
                 bottomAppBar = { bottomAppBar(this@navigation.route ?: "") },
                 photoFirebaseStorageRepository = photoStorage,
                 booksRepository = bookRepository)
@@ -232,7 +233,7 @@ class MainActivity : ComponentActivity() {
                 photoStorage = photoStorage,
                 booksRepository = bookRepository,
                 navigationActions = navigationActions,
-                topAppBar = { topAppBar("Your Profile") },
+                topAppBar = { topAppBar(stringResource(R.string.user_profile_screen_title)) },
                 bottomAppBar = { bottomAppBar(this@navigation.route ?: "") })
           }
           composable("${C.Screen.BOOK_PROFILE}/{bookId}") { backStackEntry ->
@@ -241,7 +242,7 @@ class MainActivity : ComponentActivity() {
             if (bookId != null) {
               BookProfileScreen(
                   bookId = bookId, // Default for testing
-                  topAppBar = { topAppBar("Book Profile") },
+                  topAppBar = { topAppBar(stringResource(R.string.book_profile_screen_title)) },
                   booksRepository = BooksFirestoreSource(FirebaseFirestore.getInstance()),
                   navController = NavigationActions(navController),
               )
@@ -270,7 +271,7 @@ class MainActivity : ComponentActivity() {
                       userId = userId,
                       booksRepository = bookRepository,
                       navigationActions = navigationActions,
-                      topAppBar = { topAppBar("User Profile") },
+                      topAppBar = { topAppBar(stringResource(R.string.other_user_profile_screen_title)) },
                       bottomAppBar = { bottomAppBar(this@navigation.route ?: "") })
                 } else {
                   Log.e("Navigation", "Invalid userId passed to OthersUserProfileScreen")

--- a/app/src/main/java/com/android/bookswap/MainActivity.kt
+++ b/app/src/main/java/com/android/bookswap/MainActivity.kt
@@ -271,7 +271,9 @@ class MainActivity : ComponentActivity() {
                       userId = userId,
                       booksRepository = bookRepository,
                       navigationActions = navigationActions,
-                      topAppBar = { topAppBar(stringResource(R.string.other_user_profile_screen_title)) },
+                      topAppBar = {
+                        topAppBar(stringResource(R.string.other_user_profile_screen_title))
+                      },
                       bottomAppBar = { bottomAppBar(this@navigation.route ?: "") })
                 } else {
                   Log.e("Navigation", "Invalid userId passed to OthersUserProfileScreen")

--- a/app/src/main/java/com/android/bookswap/data/DataBook.kt
+++ b/app/src/main/java/com/android/bookswap/data/DataBook.kt
@@ -1,5 +1,6 @@
 package com.android.bookswap.data
 
+import com.android.bookswap.resources.Enums
 import java.util.UUID
 
 /**
@@ -35,33 +36,37 @@ data class DataBook(
 
 /** All supported book language type */
 enum class BookLanguages(val languageName: String, val languageCode: String) {
-  FRENCH("French", "FR"), // French language
-  GERMAN("German", "DE"), // German language
-  ENGLISH("English", "EN"), // English language
-  SPANISH("Spanish", "ES"), // Spanish language
-  ITALIAN("Italian", "IT"), // Italian language
-  ROMANSH("Romansh", "RM"), // Romansh, a language spoken in Switzerland
-  OTHER("Other", "OTHER") // All languages that are not yet implemented
+  FRENCH(Enums.Languages.FRENCH, Enums.LanguagesCode.FRENCH), // French language
+  GERMAN(Enums.Languages.GERMAN, Enums.LanguagesCode.GERMAN), // German language
+  ENGLISH(Enums.Languages.ENGLISH, Enums.LanguagesCode.ENGLISH), // English language
+  SPANISH(Enums.Languages.SPANISH, Enums.LanguagesCode.SPANISH), // Spanish language
+  ITALIAN(Enums.Languages.ITALIAN, Enums.LanguagesCode.ITALIAN), // Italian language
+  ROMANSH(
+      Enums.Languages.ROMANSH,
+      Enums.LanguagesCode.ROMANSH), // Romansh, a language spoken in Switzerland
+  OTHER(
+      Enums.Languages.OTHER,
+      Enums.LanguagesCode.OTHER) // All languages that are not yet implemented
 }
 /** Genre of a book */
-enum class BookGenres(val Genre: String = "Other") {
-  FICTION("Fiction"),
-  NONFICTION("Non-Fiction"),
-  FANTASY("Fantasy"),
-  SCIENCEFICTION("Science-Fiction"),
-  MYSTERY("Mystery"),
-  THRILLER("Thriller"),
-  ROMANCE("Romance"),
-  HORROR("Horror"),
-  HISTORICAL("Historical"),
-  WESTERN("Western"),
-  DYSTOPIAN("Dystopian"),
-  MEMOIR("Memoir"),
-  BIOGRAPHY("Biography"),
-  AUTOBIOGRAPHY("Autobiography"),
-  SELFHELP("Self-Help"),
-  HEALTH("Health"),
-  TRAVEL("Travel"),
-  GUIDE("Guide"),
-  OTHER("Other") // Allows custom genre name
+enum class BookGenres(val genre: String) {
+  FICTION(Enums.Genres.FICTION),
+  NONFICTION(Enums.Genres.NONFICTION),
+  FANTASY(Enums.Genres.FANTASY),
+  SCIENCEFICTION(Enums.Genres.SCIENCEFICTION),
+  MYSTERY(Enums.Genres.MYSTERY),
+  THRILLER(Enums.Genres.THRILLER),
+  ROMANCE(Enums.Genres.ROMANCE),
+  HORROR(Enums.Genres.HORROR),
+  HISTORICAL(Enums.Genres.HISTORICAL),
+  WESTERN(Enums.Genres.WESTERN),
+  DYSTOPIAN(Enums.Genres.DYSTOPIAN),
+  MEMOIR(Enums.Genres.MEMOIR),
+  BIOGRAPHY(Enums.Genres.BIOGRAPHY),
+  AUTOBIOGRAPHY(Enums.Genres.AUTOBIOGRAPHY),
+  SELFHELP(Enums.Genres.SELFHELP),
+  HEALTH(Enums.Genres.HEALTH),
+  TRAVEL(Enums.Genres.TRAVEL),
+  GUIDE(Enums.Genres.GUIDE),
+  OTHER(Enums.Genres.OTHER)
 }

--- a/app/src/main/java/com/android/bookswap/data/DataBook.kt
+++ b/app/src/main/java/com/android/bookswap/data/DataBook.kt
@@ -49,7 +49,7 @@ enum class BookLanguages(val languageName: String, val languageCode: String) {
       Enums.LanguagesCode.OTHER) // All languages that are not yet implemented
 }
 /** Genre of a book */
-enum class BookGenres(val genre: String) {
+enum class BookGenres(val Genre: String) {
   FICTION(Enums.Genres.FICTION),
   NONFICTION(Enums.Genres.NONFICTION),
   FANTASY(Enums.Genres.FANTASY),

--- a/app/src/main/java/com/android/bookswap/data/source/network/ImageToDataSource.kt
+++ b/app/src/main/java/com/android/bookswap/data/source/network/ImageToDataSource.kt
@@ -1,6 +1,7 @@
 package com.android.bookswap.data.source.network
 
 import android.util.Log
+import com.android.bookswap.R
 import com.android.bookswap.data.source.api.ApiService
 import org.json.JSONException
 import org.json.JSONObject
@@ -83,7 +84,6 @@ class ImageToDataSource(private val apiService: ApiService) {
 
   companion object {
     const val UNDEFINED_ATTRIBUTE = "N/A"
-    const val PROMPT =
-        "You are an AI designed to analyze images of book covers. Given an image of a book\'s back cover in URL format, extract the following information in a structured format (JSON) with the specified fields: title, author, description, language, and ISBN. Please ensure that: 1. If any of the fields are not present or cannot be confidently identified, indicate them with \"N/A\". 2. If the image does not appear to be a book cover, return an error message stating \"The image does not appear to be a valid book cover.\" 3. If the title, author, description, or other fields are in a different language, keep the original text for reference, and provide the appropriate language code using the following classification: - FRENCH (\"FR\") - GERMAN (\"DE\") - ENGLISH (\"EN\") - SPANISH (\"ES\") - ITALIAN (\"IT\") - ROMANSH (\"RM\") - OTHER (\"OTHER\") 4. The description should be the one written on the book\'s. 5. The ISBN is often over a barcode, in the bottom left or right corner. Example output format: { \"title\": \"Example Title\", \"author\": \"Example Author\", \"description\": \"An example description of the book.\", \"language\": \"EN\", \"isbn\": \"1234567890\" } The image URL:"
+    val PROMPT = R.string.prompt_book_scanning
   }
 }

--- a/app/src/main/java/com/android/bookswap/model/add/AddToBookViewModel.kt
+++ b/app/src/main/java/com/android/bookswap/model/add/AddToBookViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import android.widget.Toast
 import androidx.lifecycle.ViewModel
+import com.android.bookswap.R
 import com.android.bookswap.data.BookGenres
 import com.android.bookswap.data.BookLanguages
 import com.android.bookswap.data.DataBook
@@ -70,9 +71,12 @@ class AddToBookViewModel(
           if (it.isSuccess) {
             // add the book to the list of books of the user
             userVM.updateUser(bookList = userVM.getUser().bookList.plus(book.uuid))
-            Toast.makeText(context, "Book added.", Toast.LENGTH_LONG).show()
+            Toast.makeText(context, context.getString(R.string.add_book_toast), Toast.LENGTH_LONG)
+                .show()
           } else {
-            Toast.makeText(context, "Failed to add book.", Toast.LENGTH_LONG).show()
+            Toast.makeText(
+                    context, context.getString(R.string.add_book_toast_error), Toast.LENGTH_LONG)
+                .show()
           }
         })
   }

--- a/app/src/main/java/com/android/bookswap/model/chat/NotificationActionReceiver.kt
+++ b/app/src/main/java/com/android/bookswap/model/chat/NotificationActionReceiver.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.widget.Toast
+import com.android.bookswap.R
 
 /** BroadcastReceiver to handle notification actions. */
 class NotificationActionReceiver : BroadcastReceiver() {
@@ -33,6 +34,10 @@ class NotificationActionReceiver : BroadcastReceiver() {
    */
   private fun requestCode(context: Context, action: String) {
     // Implement the logic to handle the request code based on the action
-    Toast.makeText(context, "Action: $action", Toast.LENGTH_SHORT).show()
+    Toast.makeText(
+            context,
+            context.getString(R.string.notification_toast_request_action) + action,
+            Toast.LENGTH_SHORT)
+        .show()
   }
 }

--- a/app/src/main/java/com/android/bookswap/model/chat/PermissionHandler.kt
+++ b/app/src/main/java/com/android/bookswap/model/chat/PermissionHandler.kt
@@ -10,6 +10,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
+import com.android.bookswap.R
 import com.google.firebase.messaging.FirebaseMessaging
 
 class PermissionHandler(private val activity: ComponentActivity) {
@@ -61,7 +62,9 @@ class PermissionHandler(private val activity: ComponentActivity) {
     // Initialize FCM SDK
     FirebaseMessaging.getInstance().isAutoInitEnabled = true
     // Additional setup if needed
-    Toast.makeText(activity, "Notifications have been enabled.", Toast.LENGTH_LONG).show()
+    Toast.makeText(
+            activity, activity.getString(R.string.notification_toast_enable), Toast.LENGTH_LONG)
+        .show()
   }
   /**
    * Informs the user that notifications are disabled.
@@ -74,9 +77,7 @@ class PermissionHandler(private val activity: ComponentActivity) {
     // For example, you might show a Toast or a Snackbar
     // This is a placeholder implementation
     Toast.makeText(
-            activity,
-            "Notifications are disabled. You will not receive updates.",
-            Toast.LENGTH_LONG)
+            activity, activity.getString(R.string.notification_toast_disable), Toast.LENGTH_LONG)
         .show()
   }
   /**
@@ -88,14 +89,13 @@ class PermissionHandler(private val activity: ComponentActivity) {
   @RequiresApi(Build.VERSION_CODES.TIRAMISU)
   private fun showRationaleDialog() {
     AlertDialog.Builder(activity)
-        .setTitle("Notification Permission Required")
-        .setMessage(
-            "To keep you informed about important updates, please allow notification permissions.")
-        .setPositiveButton("OK") { _, _ ->
+        .setTitle(activity.getString(R.string.notification_title))
+        .setMessage(activity.getString(R.string.notification_message))
+        .setPositiveButton(activity.getString(R.string.notification_ok)) { _, _ ->
           // Request the permission when the user agrees
           requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
-        .setNegativeButton("No thanks") { dialog, _ ->
+        .setNegativeButton(activity.getString(R.string.notification_no)) { dialog, _ ->
           // Dismiss the dialog and continue without asking for permission
           dialog.dismiss()
         }

--- a/app/src/main/java/com/android/bookswap/resources/C.kt
+++ b/app/src/main/java/com/android/bookswap/resources/C.kt
@@ -356,3 +356,48 @@ object C {
     const val SETTINGS = S.SETTINGS + SCREEN
   }
 }
+
+object Enums {
+
+  object Languages {
+    const val FRENCH = "French"
+    const val GERMAN = "German"
+    const val ENGLISH = "English"
+    const val SPANISH = "Spanish"
+    const val ITALIAN = "Italian"
+    const val ROMANSH = "Romansh"
+    const val OTHER = "Other"
+  }
+
+  object LanguagesCode {
+    const val FRENCH = "FR"
+    const val GERMAN = "DE"
+    const val ENGLISH = "EN"
+    const val SPANISH = "ES"
+    const val ITALIAN = "IT"
+    const val ROMANSH = "RM"
+    const val OTHER = "OTHER"
+  }
+
+  object Genres {
+    const val FICTION = "Fiction"
+    const val NONFICTION = "Non-Fiction"
+    const val FANTASY = "Fantasy"
+    const val SCIENCEFICTION = "Science-Fiction"
+    const val MYSTERY = "Mystery"
+    const val THRILLER = "Thriller"
+    const val ROMANCE = "Romance"
+    const val HORROR = "Horror"
+    const val HISTORICAL = "Historical"
+    const val WESTERN = "Western"
+    const val DYSTOPIAN = "Dystopian"
+    const val MEMOIR = "Memoir"
+    const val BIOGRAPHY = "Biography"
+    const val AUTOBIOGRAPHY = "Autobiography"
+    const val SELFHELP = "Self-Help"
+    const val HEALTH = "Health"
+    const val TRAVEL = "Travel"
+    const val GUIDE = "Guide"
+    const val OTHER = "Other"
+  }
+}

--- a/app/src/main/java/com/android/bookswap/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/bookswap/ui/authentication/SignIn.kt
@@ -81,11 +81,11 @@ fun SignInScreen(navigationActions: NavigationActions) {
             appConfig.userViewModel.getUserByGoogleUid(googleUid)
             Log.d("SignInScreen", "isStored: ${appConfig.userViewModel.isStored}")
             Log.d("SignInScreen", "User signed in: $googleUserName")
-            Toast.makeText(context, "Welcome $googleUserName!", Toast.LENGTH_LONG).show()
+            Toast.makeText(context, context.resources.getString(R.string.sign_in_toast_welcome) +" $googleUserName!", Toast.LENGTH_LONG).show()
           },
           onAuthError = {
             Log.e("SignInScreen", "Failed to sign in: ${it.statusCode}")
-            Toast.makeText(context, "Login Failed!", Toast.LENGTH_LONG).show()
+            Toast.makeText(context, context.resources.getString(R.string.sign_in_toast_login_failed), Toast.LENGTH_LONG).show()
           })
   val token = stringResource(R.string.default_web_client_id)
 
@@ -121,7 +121,7 @@ fun SignInScreen(navigationActions: NavigationActions) {
           // First part of the title:
           Text(
               modifier = Modifier.testTag(C.Tag.TopAppBar.screen_title),
-              text = "Welcome to",
+              text = stringResource(R.string.sign_in_screen_welcome),
               style =
                   TextStyle(
                       fontSize = 40.sp,
@@ -137,7 +137,7 @@ fun SignInScreen(navigationActions: NavigationActions) {
           // Second part of the logo:
           Text(
               modifier = Modifier.testTag(C.Tag.SignIn.app_name),
-              text = "BookSwap",
+              text = stringResource(R.string.sign_in_screen_app_name),
               style =
                   TextStyle(
                       fontSize = 60.sp,
@@ -199,7 +199,7 @@ fun GoogleSignInButton(onSignInClick: () -> Unit) {
 
               // Text for the button
               Text(
-                  text = "Sign in with Google",
+                  text = stringResource(R.string.sign_in_button_google), // Button text
                   color = ColorVariable.Accent, // Text color
                   fontSize = 16.sp, // Font size
                   fontWeight = FontWeight.Medium)

--- a/app/src/main/java/com/android/bookswap/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/bookswap/ui/authentication/SignIn.kt
@@ -81,11 +81,20 @@ fun SignInScreen(navigationActions: NavigationActions) {
             appConfig.userViewModel.getUserByGoogleUid(googleUid)
             Log.d("SignInScreen", "isStored: ${appConfig.userViewModel.isStored}")
             Log.d("SignInScreen", "User signed in: $googleUserName")
-            Toast.makeText(context, context.resources.getString(R.string.sign_in_toast_welcome) +" $googleUserName!", Toast.LENGTH_LONG).show()
+            Toast.makeText(
+                    context,
+                    context.resources.getString(R.string.sign_in_toast_welcome) +
+                        " $googleUserName!",
+                    Toast.LENGTH_LONG)
+                .show()
           },
           onAuthError = {
             Log.e("SignInScreen", "Failed to sign in: ${it.statusCode}")
-            Toast.makeText(context, context.resources.getString(R.string.sign_in_toast_login_failed), Toast.LENGTH_LONG).show()
+            Toast.makeText(
+                    context,
+                    context.resources.getString(R.string.sign_in_toast_login_failed),
+                    Toast.LENGTH_LONG)
+                .show()
           })
   val token = stringResource(R.string.default_web_client_id)
 

--- a/app/src/main/java/com/android/bookswap/ui/books/BookProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/BookProfile.kt
@@ -123,7 +123,11 @@ fun BookProfileScreen(
                   item {
                     // Display an error message
                     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                      Text(text =stringResource(R.string.book_profile_error_loading) + "${error.message}", color = Color.Red)
+                      Text(
+                          text =
+                              stringResource(R.string.book_profile_error_loading) +
+                                  "${error.message}",
+                          color = Color.Red)
                     }
                   }
                 }
@@ -138,7 +142,8 @@ fun BookProfileScreen(
                   }
                   item {
                     Text(
-                        text = dataBook.author ?: stringResource(R.string.book_profile_author_unknown),
+                        text =
+                            dataBook.author ?: stringResource(R.string.book_profile_author_unknown),
                         modifier = Modifier.testTag(C.Tag.BookProfile.author),
                         color = ColorVariable.AccentSecondary,
                         style = MaterialTheme.typography.titleMedium)
@@ -172,7 +177,7 @@ fun BookProfileScreen(
                   item {
                     dataBook.rating?.let {
                       Text(
-                          text = stringResource(R.string.book_profile_rating_label)+" $it/5",
+                          text = stringResource(R.string.book_profile_rating_label) + " $it/5",
                           color = ColorVariable.Accent,
                           style = MaterialTheme.typography.bodyMedium,
                           modifier = Modifier.testTag(C.Tag.BookProfile.rating))
@@ -195,9 +200,14 @@ fun BookProfileScreen(
                             Modifier.fillMaxWidth().padding(horizontal = HORIZONTAL_PADDING)) {
                           Column(modifier = Modifier.weight(COLUMN_WEIGHT)) {
                             ProfileText(
-                                text = stringResource(R.string.book_profile_language_label)+" " +dataBook.language.languageName,
+                                text =
+                                    stringResource(R.string.book_profile_language_label) +
+                                        " " +
+                                        dataBook.language.languageName,
                                 testTag = C.Tag.BookProfile.language)
-                            ProfileText(text = stringResource(R.string.book_profile_genres_label), testTag = C.Tag.BookProfile.genres)
+                            ProfileText(
+                                text = stringResource(R.string.book_profile_genres_label),
+                                testTag = C.Tag.BookProfile.genres)
                             dataBook.genres.forEach { genre ->
                               Text(
                                   text = "- ${genre.Genre}",
@@ -210,7 +220,8 @@ fun BookProfileScreen(
                             }
                             ProfileText(
                                 text =
-                                    stringResource(R.string.book_profile_isbn_label)+" ${dataBook.isbn ?: stringResource(R.string.book_profile_isbn_missing)}",
+                                    stringResource(R.string.book_profile_isbn_label) +
+                                        " ${dataBook.isbn ?: stringResource(R.string.book_profile_isbn_missing)}",
                                 testTag = C.Tag.BookProfile.isbn)
                           }
 

--- a/app/src/main/java/com/android/bookswap/ui/books/BookProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/BookProfile.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -122,7 +123,7 @@ fun BookProfileScreen(
                   item {
                     // Display an error message
                     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                      Text(text = "Error loading book details: ${error.message}", color = Color.Red)
+                      Text(text =stringResource(R.string.book_profile_error_loading) + "${error.message}", color = Color.Red)
                     }
                   }
                 }
@@ -137,7 +138,7 @@ fun BookProfileScreen(
                   }
                   item {
                     Text(
-                        text = dataBook.author ?: "Author Unknown",
+                        text = dataBook.author ?: stringResource(R.string.book_profile_author_unknown),
                         modifier = Modifier.testTag(C.Tag.BookProfile.author),
                         color = ColorVariable.AccentSecondary,
                         style = MaterialTheme.typography.titleMedium)
@@ -171,7 +172,7 @@ fun BookProfileScreen(
                   item {
                     dataBook.rating?.let {
                       Text(
-                          text = "Rating: $it/5",
+                          text = stringResource(R.string.book_profile_rating_label)+" $it/5",
                           color = ColorVariable.Accent,
                           style = MaterialTheme.typography.bodyMedium,
                           modifier = Modifier.testTag(C.Tag.BookProfile.rating))
@@ -181,7 +182,7 @@ fun BookProfileScreen(
 
                   item {
                     Text(
-                        text = "Synopsis",
+                        text = stringResource(R.string.book_profile_synopsis_label),
                         color = ColorVariable.Accent,
                         style = MaterialTheme.typography.titleSmall,
                         modifier = Modifier.testTag(C.Tag.BookProfile.synopsis_label))
@@ -194,9 +195,9 @@ fun BookProfileScreen(
                             Modifier.fillMaxWidth().padding(horizontal = HORIZONTAL_PADDING)) {
                           Column(modifier = Modifier.weight(COLUMN_WEIGHT)) {
                             ProfileText(
-                                text = "Language: ${dataBook.language.languageName}",
+                                text = stringResource(R.string.book_profile_language_label)+" " +dataBook.language.languageName,
                                 testTag = C.Tag.BookProfile.language)
-                            ProfileText(text = "Genres:", testTag = C.Tag.BookProfile.genres)
+                            ProfileText(text = stringResource(R.string.book_profile_genres_label), testTag = C.Tag.BookProfile.genres)
                             dataBook.genres.forEach { genre ->
                               Text(
                                   text = "- ${genre.Genre}",
@@ -209,25 +210,25 @@ fun BookProfileScreen(
                             }
                             ProfileText(
                                 text =
-                                    "ISBN: ${dataBook.isbn ?: "ISBN doesn't exist or is not available"}",
+                                    stringResource(R.string.book_profile_isbn_label)+" ${dataBook.isbn ?: stringResource(R.string.book_profile_isbn_missing)}",
                                 testTag = C.Tag.BookProfile.isbn)
                           }
 
                           Column(modifier = Modifier.weight(COLUMN_WEIGHT)) {
                             ProfileText(
-                                text = "Date of Publication: [Temporary Date]",
+                                text = stringResource(R.string.book_profile_date_label),
                                 testTag = C.Tag.BookProfile.date)
                             ProfileText(
-                                text = "Volume: [Temporary Volume]",
+                                text = stringResource(R.string.book_profile_volume_label),
                                 testTag = C.Tag.BookProfile.volume)
                             ProfileText(
-                                text = "Issue: [Temporary Issue]",
+                                text = stringResource(R.string.book_profile_issue_label),
                                 testTag = C.Tag.BookProfile.issue)
                             ProfileText(
-                                text = "Editorial: [Temporary Editorial]",
+                                text = stringResource(R.string.book_profile_editorial_label),
                                 testTag = C.Tag.BookProfile.editorial)
                             ProfileText(
-                                text = "Place of Edition: [Temporary Place]",
+                                text = stringResource(R.string.book_profile_location_label),
                                 testTag = C.Tag.BookProfile.location)
                           }
                         }
@@ -257,9 +258,9 @@ fun BookProfileScreen(
                                 .fillMaxWidth(HALF_WIDTH)) {
                           Text(
                               if (dataBook.userId == appConfig.userViewModel.getUser().userUUID) {
-                                "Edit Book"
+                                stringResource(R.string.book_profile_edit_button)
                               } else {
-                                "Go to User"
+                                stringResource(R.string.book_profile_go_to_user_button)
                               })
                         }
                   }
@@ -305,7 +306,7 @@ fun BookSynopsis(description: String) {
               .padding(start = HORIZONTAL_PADDING, end = HORIZONTAL_PADDING)
               .testTag(C.Tag.BookProfile.synopsis)) {
         Text(
-            text = description.ifEmpty { "No description available" },
+            text = description.ifEmpty { stringResource(R.string.book_profile_synopsis_empty) },
             color = ColorVariable.Accent,
             style = MaterialTheme.typography.bodyMedium,
             textAlign = TextAlign.Start)

--- a/app/src/main/java/com/android/bookswap/ui/books/add/AddISBNScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/add/AddISBNScreen.kt
@@ -79,7 +79,10 @@ fun AddISBNScreen(
                                 isbn, appConfig.userViewModel.getUser().userUUID) { result ->
                                   if (result.isFailure) {
                                     Toast.makeText(
-                                            context, context.resources.getString(R.string.add_isbn_toast_search_unsuccessful), Toast.LENGTH_LONG)
+                                            context,
+                                            context.resources.getString(
+                                                R.string.add_isbn_toast_search_unsuccessful),
+                                            Toast.LENGTH_LONG)
                                         .show()
                                     Log.e("AddBook", result.exceptionOrNull().toString())
                                   } else {
@@ -106,7 +109,11 @@ fun AddISBNScreen(
                                   }
                                 }
                           } else {
-                            Toast.makeText(context, context.resources.getString(R.string.add_isbn_toast_invalid), Toast.LENGTH_LONG).show()
+                            Toast.makeText(
+                                    context,
+                                    context.resources.getString(R.string.add_isbn_toast_invalid),
+                                    Toast.LENGTH_LONG)
+                                .show()
                           }
                         }) {
                           Row(verticalAlignment = Alignment.CenterVertically) {

--- a/app/src/main/java/com/android/bookswap/ui/books/add/AddISBNScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/add/AddISBNScreen.kt
@@ -24,7 +24,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.android.bookswap.R
 import com.android.bookswap.data.repository.BooksRepository
 import com.android.bookswap.data.source.api.GoogleBookDataSource
 import com.android.bookswap.model.InputVerification
@@ -63,7 +65,7 @@ fun AddISBNScreen(
                   verticalArrangement = Arrangement.spacedBy(45.dp)) {
                     FieldComponent(
                         modifier = Modifier.testTag(C.Tag.NewBookISBN.isbn),
-                        labelText = "ISBN*",
+                        labelText = stringResource(R.string.add_isbn_field_label),
                         value = isbn,
                         maxLength = MAXLENGTHISBN) {
                           isbn = it
@@ -77,7 +79,7 @@ fun AddISBNScreen(
                                 isbn, appConfig.userViewModel.getUser().userUUID) { result ->
                                   if (result.isFailure) {
                                     Toast.makeText(
-                                            context, "Search unsuccessful", Toast.LENGTH_LONG)
+                                            context, context.resources.getString(R.string.add_isbn_toast_search_unsuccessful), Toast.LENGTH_LONG)
                                         .show()
                                     Log.e("AddBook", result.exceptionOrNull().toString())
                                   } else {
@@ -104,11 +106,11 @@ fun AddISBNScreen(
                                   }
                                 }
                           } else {
-                            Toast.makeText(context, "Invalid ISBN", Toast.LENGTH_LONG).show()
+                            Toast.makeText(context, context.resources.getString(R.string.add_isbn_toast_invalid), Toast.LENGTH_LONG).show()
                           }
                         }) {
                           Row(verticalAlignment = Alignment.CenterVertically) {
-                            Text("Search")
+                            Text(stringResource(R.string.add_isbn_button_search))
                             Icon(
                                 Icons.Filled.Search,
                                 contentDescription = "Search icon",

--- a/app/src/main/java/com/android/bookswap/ui/books/add/BookAdditionChoiceScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/books/add/BookAdditionChoiceScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -91,21 +92,21 @@ fun BookAdditionChoiceScreen(
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally) {
               ButtonWithIcon(
-                  text = "Manually",
+                  text = stringResource(R.string.book_addition_choice_button_manually),
                   leftIcon = Icons.Default.Add,
                   leftIconPainter = null,
                   onClick = { navController.navigateTo(C.Screen.ADD_BOOK_MANUALLY) },
                   buttonWidth = buttonWidth)
               Spacer(modifier = Modifier.height(2f * columnPadding))
               ButtonWithIcon(
-                  text = "From ISBN",
+                  text = stringResource(R.string.book_addition_choice_button_from_isbn),
                   leftIcon = null,
                   leftIconPainter = painterResource(id = R.drawable.download),
                   onClick = { navController.navigateTo(C.Screen.ADD_BOOK_ISBN) },
                   buttonWidth = buttonWidth)
               Spacer(modifier = Modifier.height(2f * columnPadding))
               ButtonWithIcon(
-                  text = "From Photo",
+                  text = stringResource(R.string.book_addition_choice_button_from_photo),
                   leftIcon = null,
                   leftIconPainter = painterResource(id = R.drawable.photoicon),
                   onClick = { photoRequester.requestPhoto() },

--- a/app/src/main/java/com/android/bookswap/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/chat/ChatScreen.kt
@@ -131,7 +131,9 @@ fun ChatScreen(
                               Log.d("ChatScreen", "Image stored successfully")
                             } else {
                               Toast.makeText(
-                                      context, context.getString(R.string.chat_message_stored_error), Toast.LENGTH_LONG)
+                                      context,
+                                      context.getString(R.string.chat_message_stored_error),
+                                      Toast.LENGTH_LONG)
                                   .show()
                               Log.e("ChatScreen", "Image could not be stored.")
                             }
@@ -142,7 +144,9 @@ fun ChatScreen(
                     }
               })
         } else {
-          Toast.makeText(context, context.getString(R.string.chat_message_stored_error), Toast.LENGTH_LONG).show()
+          Toast.makeText(
+                  context, context.getString(R.string.chat_message_stored_error), Toast.LENGTH_LONG)
+              .show()
           Log.e("ChatScreen", "Image could not be stored.")
         }
       }
@@ -267,7 +271,11 @@ fun ChatScreen(
               Button(
                   onClick = {
                     if (newMessageText.text.isEmpty()) {
-                      Toast.makeText(context, context.getString(R.string.chat_message_empty_error), Toast.LENGTH_SHORT).show()
+                      Toast.makeText(
+                              context,
+                              context.getString(R.string.chat_message_empty_error),
+                              Toast.LENGTH_SHORT)
+                          .show()
                     } else if (updateActive) {
                       // Update the message
                       messageRepository.updateMessage(
@@ -311,7 +319,10 @@ fun ChatScreen(
                         if (result.isSuccess) {
                           newMessageText = TextFieldValue("")
                         } else {
-                          Toast.makeText(context, context.getString(R.string.chat_send_error), Toast.LENGTH_LONG)
+                          Toast.makeText(
+                                  context,
+                                  context.getString(R.string.chat_send_error),
+                                  Toast.LENGTH_LONG)
                               .show()
                           Log.e(
                               "MessageView",
@@ -329,7 +340,9 @@ fun ChatScreen(
                   modifier =
                       Modifier.padding(horizontal = padding8)
                           .testTag(C.Tag.ChatScreen.confirm_button)) {
-                    Text(if (updateActive) stringResource(R.string.chat_update_button) else stringResource(R.string.chat_send_button))
+                    Text(
+                        if (updateActive) stringResource(R.string.chat_update_button)
+                        else stringResource(R.string.chat_send_button))
                   }
             }
       }

--- a/app/src/main/java/com/android/bookswap/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/android/bookswap/ui/chat/ChatScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
@@ -130,7 +131,7 @@ fun ChatScreen(
                               Log.d("ChatScreen", "Image stored successfully")
                             } else {
                               Toast.makeText(
-                                      context, "Image could not be stored.", Toast.LENGTH_LONG)
+                                      context, context.getString(R.string.chat_message_stored_error), Toast.LENGTH_LONG)
                                   .show()
                               Log.e("ChatScreen", "Image could not be stored.")
                             }
@@ -141,7 +142,7 @@ fun ChatScreen(
                     }
               })
         } else {
-          Toast.makeText(context, "Image could not be stored.", Toast.LENGTH_LONG).show()
+          Toast.makeText(context, context.getString(R.string.chat_message_stored_error), Toast.LENGTH_LONG).show()
           Log.e("ChatScreen", "Image could not be stored.")
         }
       }
@@ -266,7 +267,7 @@ fun ChatScreen(
               Button(
                   onClick = {
                     if (newMessageText.text.isEmpty()) {
-                      Toast.makeText(context, "Message cannot be empty", Toast.LENGTH_SHORT).show()
+                      Toast.makeText(context, context.getString(R.string.chat_message_empty_error), Toast.LENGTH_SHORT).show()
                     } else if (updateActive) {
                       // Update the message
                       messageRepository.updateMessage(
@@ -281,7 +282,7 @@ fun ChatScreen(
                             } else {
                               Toast.makeText(
                                       context,
-                                      "Message can only be updated within 15 minutes of being sent",
+                                      context.getString(R.string.chat_update_error),
                                       Toast.LENGTH_LONG)
                                   .show()
                               Log.e(
@@ -310,7 +311,7 @@ fun ChatScreen(
                         if (result.isSuccess) {
                           newMessageText = TextFieldValue("")
                         } else {
-                          Toast.makeText(context, "Message could not be sent.", Toast.LENGTH_LONG)
+                          Toast.makeText(context, context.getString(R.string.chat_send_error), Toast.LENGTH_LONG)
                               .show()
                           Log.e(
                               "MessageView",
@@ -328,7 +329,7 @@ fun ChatScreen(
                   modifier =
                       Modifier.padding(horizontal = padding8)
                           .testTag(C.Tag.ChatScreen.confirm_button)) {
-                    Text(if (updateActive) "Update" else "Send")
+                    Text(if (updateActive) stringResource(R.string.chat_update_button) else stringResource(R.string.chat_send_button))
                   }
             }
       }
@@ -360,7 +361,7 @@ fun ChatScreen(
                                     ColorVariable.Primary, shape = RoundedCornerShape(50))
                                 .padding(padding8)
                                 .testTag(C.Tag.ChatScreen.edit)) {
-                          Text("Edit")
+                          Text(stringResource(R.string.chat_edit_button))
                         }
                     Button(
                         onClick = {
@@ -374,7 +375,7 @@ fun ChatScreen(
                                   } else {
                                     Toast.makeText(
                                             context,
-                                            "Message can only be deleted within 15 minutes of being sent",
+                                            context.getString(R.string.chat_delete_error),
                                             Toast.LENGTH_LONG)
                                         .show()
                                     Log.e(
@@ -389,7 +390,7 @@ fun ChatScreen(
                                     ColorVariable.Primary, shape = RoundedCornerShape(50))
                                 .padding(padding8)
                                 .testTag(C.Tag.ChatScreen.delete)) {
-                          Text("Delete")
+                          Text(stringResource(R.string.chat_delete_button))
                         }
                   }
             }

--- a/app/src/main/java/com/android/bookswap/ui/chat/ListChat.kt
+++ b/app/src/main/java/com/android/bookswap/ui/chat/ListChat.kt
@@ -141,7 +141,9 @@ fun MessageBoxDisplay(message: MessageBox, onClick: () -> Unit = {}) {
               }
 
           Text(
-              text = message.message?.takeUnless { it.isEmpty() } ?: stringResource(R.string.chat_list_no_messages),
+              text =
+                  message.message?.takeUnless { it.isEmpty() }
+                      ?: stringResource(R.string.chat_list_no_messages),
               fontSize = 14.sp,
               color = ColorVariable.AccentSecondary,
               maxLines = 1,

--- a/app/src/main/java/com/android/bookswap/ui/chat/ListChat.kt
+++ b/app/src/main/java/com/android/bookswap/ui/chat/ListChat.kt
@@ -30,12 +30,14 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import com.android.bookswap.R
 import com.android.bookswap.data.MessageBox
 import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.model.chat.ContactViewModel
@@ -68,7 +70,7 @@ fun ListChatScreen(
               if (messageBoxMap.isEmpty()) {
                 item {
                   Text(
-                      text = "No messages yet",
+                      text = stringResource(R.string.chat_list_no_messages),
                       modifier = Modifier.fillMaxWidth().padding(16.dp),
                       color = ColorVariable.Primary,
                       fontSize = 20.sp,
@@ -139,7 +141,7 @@ fun MessageBoxDisplay(message: MessageBox, onClick: () -> Unit = {}) {
               }
 
           Text(
-              text = message.message?.takeUnless { it.isEmpty() } ?: "No messages yet",
+              text = message.message?.takeUnless { it.isEmpty() } ?: stringResource(R.string.chat_list_no_messages),
               fontSize = 14.sp,
               color = ColorVariable.AccentSecondary,
               maxLines = 1,

--- a/app/src/main/java/com/android/bookswap/ui/map/FilterMap.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/FilterMap.kt
@@ -119,7 +119,11 @@ fun FilterMapScreen(navigationActions: NavigationActions, bookFilter: BookFilter
                 onClick = {
                   bookFilter.setGenres(selectedFiltersGenres.map { it.Genre })
                   bookFilter.setLanguages(selectedFiltersLanguages.map { it.languageName })
-                  Toast.makeText(context, context.getString(R.string.filters_applied_message), Toast.LENGTH_SHORT).show()
+                  Toast.makeText(
+                          context,
+                          context.getString(R.string.filters_applied_message),
+                          Toast.LENGTH_SHORT)
+                      .show()
                   navigationActions.goBack()
                 },
                 colors = ButtonDefaults.buttonColors(ColorVariable.Primary),
@@ -128,7 +132,9 @@ fun FilterMapScreen(navigationActions: NavigationActions, bookFilter: BookFilter
                         .height(BUTTON_HEIGHT)
                         .testTag(C.Tag.MapFilter.apply)) {
                   Text(
-                      text = stringResource(R.string.filter_apply_button_text), // Hard coded string that should
+                      text =
+                          stringResource(
+                              R.string.filter_apply_button_text), // Hard coded string that should
                       textAlign = TextAlign.Center,
                       style =
                           TextStyle(

--- a/app/src/main/java/com/android/bookswap/ui/map/FilterMap.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/FilterMap.kt
@@ -29,11 +29,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.android.bookswap.R
 import com.android.bookswap.data.BookGenres
 import com.android.bookswap.data.BookLanguages
 import com.android.bookswap.model.map.BookFilter
@@ -117,7 +119,7 @@ fun FilterMapScreen(navigationActions: NavigationActions, bookFilter: BookFilter
                 onClick = {
                   bookFilter.setGenres(selectedFiltersGenres.map { it.Genre })
                   bookFilter.setLanguages(selectedFiltersLanguages.map { it.languageName })
-                  Toast.makeText(context, "Filters applied", Toast.LENGTH_SHORT).show()
+                  Toast.makeText(context, context.getString(R.string.filters_applied_message), Toast.LENGTH_SHORT).show()
                   navigationActions.goBack()
                 },
                 colors = ButtonDefaults.buttonColors(ColorVariable.Primary),
@@ -126,7 +128,7 @@ fun FilterMapScreen(navigationActions: NavigationActions, bookFilter: BookFilter
                         .height(BUTTON_HEIGHT)
                         .testTag(C.Tag.MapFilter.apply)) {
                   Text(
-                      text = "Apply",
+                      text = stringResource(R.string.filter_apply_button_text), // Hard coded string that should
                       textAlign = TextAlign.Center,
                       style =
                           TextStyle(

--- a/app/src/main/java/com/android/bookswap/ui/map/Map.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/Map.kt
@@ -132,7 +132,11 @@ fun MapScreen(
     if (isOnline) {
       bookManagerViewModel.startUpdatingBooks()
     } else {
-      Toast.makeText(context, context.getString(R.string.map_screen_please_connect_to_internet), Toast.LENGTH_SHORT).show()
+      Toast.makeText(
+              context,
+              context.getString(R.string.map_screen_please_connect_to_internet),
+              Toast.LENGTH_SHORT)
+          .show()
     }
     val hasPermissions =
         permissions

--- a/app/src/main/java/com/android/bookswap/ui/map/Map.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/Map.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 import androidx.compose.ui.semantics.semantics
@@ -47,6 +48,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
+import com.android.bookswap.R
 import com.android.bookswap.data.DataBook
 import com.android.bookswap.model.LocalAppConfig
 import com.android.bookswap.model.isNetworkAvailable
@@ -130,7 +132,7 @@ fun MapScreen(
     if (isOnline) {
       bookManagerViewModel.startUpdatingBooks()
     } else {
-      Toast.makeText(context, "Please connect to Internet to actualise", Toast.LENGTH_SHORT).show()
+      Toast.makeText(context, context.getString(R.string.map_screen_please_connect_to_internet), Toast.LENGTH_SHORT).show()
     }
     val hasPermissions =
         permissions
@@ -221,7 +223,7 @@ fun MapScreen(
                 if (!latitude.value.isNaN() && !longitude.value.isNaN()) {
                   Marker(
                       state = MarkerState(position = LatLng(latitude.value, longitude.value)),
-                      title = "Your Location",
+                      title = stringResource(R.string.map_screen_your_location),
                       icon =
                           BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_BLUE))
                 }

--- a/app/src/main/java/com/android/bookswap/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/profile/EditProfile.kt
@@ -11,10 +11,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.android.bookswap.R
 import com.android.bookswap.data.DataUser
 import com.android.bookswap.model.InputVerification
 import com.android.bookswap.model.LocalAppConfig
@@ -59,7 +61,7 @@ fun EditProfileDialog(onDismiss: () -> Unit, onSave: (DataUser) -> Unit) {
             Modifier.fillMaxWidth().padding(16.dp),
             Arrangement.Center,
             Alignment.CenterHorizontally) {
-              Text("Edit Profile", Modifier.testTag(C.Tag.TopAppBar.screen_title))
+              Text(stringResource(R.string.edit_profile_screen_title), Modifier.testTag(C.Tag.TopAppBar.screen_title))
               OutlinedTextField(
                   value = _greeting.value,
                   onValueChange = {
@@ -72,8 +74,8 @@ fun EditProfileDialog(onDismiss: () -> Unit, onSave: (DataUser) -> Unit) {
                     }
                   },
                   Modifier.testTag(C.Tag.EditProfile.greeting).fillMaxWidth().padding(8.dp, 4.dp),
-                  label = { Text("Greeting") },
-                  placeholder = { Text("Mr.", Modifier, Color.Gray) },
+                  label = { Text(stringResource(R.string.edit_profile_greeting)) },
+                  placeholder = { Text(stringResource(R.string.edit_profile_mr), Modifier, Color.Gray) },
                   keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
                   singleLine = true,
                   isError = greetingError.value,
@@ -91,8 +93,8 @@ fun EditProfileDialog(onDismiss: () -> Unit, onSave: (DataUser) -> Unit) {
                     }
                   },
                   Modifier.testTag(C.Tag.EditProfile.firstname).fillMaxWidth().padding(8.dp, 4.dp),
-                  label = { Text("Firstname") },
-                  placeholder = { Text("John", Modifier, Color.Gray) },
+                  label = { Text(stringResource(R.string.edit_profile_firstname)) },
+                  placeholder = { Text(stringResource(R.string.edit_profile_john), Modifier, Color.Gray) },
                   keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
                   singleLine = true,
                   isError = firstNameError.value)
@@ -109,8 +111,8 @@ fun EditProfileDialog(onDismiss: () -> Unit, onSave: (DataUser) -> Unit) {
                     }
                   },
                   Modifier.testTag(C.Tag.EditProfile.lastname).fillMaxWidth().padding(8.dp, 4.dp),
-                  label = { Text("Lastname") },
-                  placeholder = { Text("Doe", Modifier, Color.Gray) },
+                  label = { Text(stringResource(R.string.edit_profile_lastname)) },
+                  placeholder = { Text(stringResource(R.string.edit_profile_Doe), Modifier, Color.Gray) },
                   keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
                   singleLine = true,
                   isError = lastNameError.value)
@@ -129,8 +131,8 @@ fun EditProfileDialog(onDismiss: () -> Unit, onSave: (DataUser) -> Unit) {
                     }
                   },
                   Modifier.testTag(C.Tag.EditProfile.email).fillMaxWidth().padding(8.dp, 4.dp),
-                  label = { Text("Email") },
-                  placeholder = { Text("John.Doe@example.com", Modifier, Color.Gray) },
+                  label = { Text(stringResource(R.string.edit_profile_email)) },
+                  placeholder = { Text(stringResource(R.string.edit_profile_email_example), Modifier, Color.Gray) },
                   keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
                   singleLine = true,
                   isError = emailError.value)
@@ -149,8 +151,8 @@ fun EditProfileDialog(onDismiss: () -> Unit, onSave: (DataUser) -> Unit) {
                     }
                   },
                   Modifier.testTag(C.Tag.EditProfile.phone).fillMaxWidth().padding(8.dp, 4.dp),
-                  label = { Text("Phone") },
-                  placeholder = { Text("+4122345678", Modifier, Color.Gray) },
+                  label = { Text(stringResource(R.string.edit_profile_phone)) },
+                  placeholder = { Text(stringResource(R.string.edit_profile_phone_example), Modifier, Color.Gray) },
                   keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
                   singleLine = true,
                   isError = phoneError.value)
@@ -164,13 +166,13 @@ fun EditProfileDialog(onDismiss: () -> Unit, onSave: (DataUser) -> Unit) {
                       onSave(dataUser)
                     },
                     Modifier.testTag(C.Tag.EditProfile.confirm)) {
-                      Text("Save")
+                      Text(stringResource(R.string.edit_profile_save_button))
                     }
 
                 Button(
                     { Log.d("EditProfile_ClickBtn", "Cancel Clicked") },
                     Modifier.testTag(C.Tag.EditProfile.dismiss)) {
-                      Text("Cancel")
+                      Text(stringResource(R.string.edit_profile_cancel_button))
                     }
               }
             }

--- a/app/src/main/java/com/android/bookswap/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/profile/EditProfile.kt
@@ -61,7 +61,9 @@ fun EditProfileDialog(onDismiss: () -> Unit, onSave: (DataUser) -> Unit) {
             Modifier.fillMaxWidth().padding(16.dp),
             Arrangement.Center,
             Alignment.CenterHorizontally) {
-              Text(stringResource(R.string.edit_profile_screen_title), Modifier.testTag(C.Tag.TopAppBar.screen_title))
+              Text(
+                  stringResource(R.string.edit_profile_screen_title),
+                  Modifier.testTag(C.Tag.TopAppBar.screen_title))
               OutlinedTextField(
                   value = _greeting.value,
                   onValueChange = {
@@ -75,7 +77,9 @@ fun EditProfileDialog(onDismiss: () -> Unit, onSave: (DataUser) -> Unit) {
                   },
                   Modifier.testTag(C.Tag.EditProfile.greeting).fillMaxWidth().padding(8.dp, 4.dp),
                   label = { Text(stringResource(R.string.edit_profile_greeting)) },
-                  placeholder = { Text(stringResource(R.string.edit_profile_mr), Modifier, Color.Gray) },
+                  placeholder = {
+                    Text(stringResource(R.string.edit_profile_mr), Modifier, Color.Gray)
+                  },
                   keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
                   singleLine = true,
                   isError = greetingError.value,
@@ -94,7 +98,9 @@ fun EditProfileDialog(onDismiss: () -> Unit, onSave: (DataUser) -> Unit) {
                   },
                   Modifier.testTag(C.Tag.EditProfile.firstname).fillMaxWidth().padding(8.dp, 4.dp),
                   label = { Text(stringResource(R.string.edit_profile_firstname)) },
-                  placeholder = { Text(stringResource(R.string.edit_profile_john), Modifier, Color.Gray) },
+                  placeholder = {
+                    Text(stringResource(R.string.edit_profile_john), Modifier, Color.Gray)
+                  },
                   keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
                   singleLine = true,
                   isError = firstNameError.value)
@@ -112,7 +118,9 @@ fun EditProfileDialog(onDismiss: () -> Unit, onSave: (DataUser) -> Unit) {
                   },
                   Modifier.testTag(C.Tag.EditProfile.lastname).fillMaxWidth().padding(8.dp, 4.dp),
                   label = { Text(stringResource(R.string.edit_profile_lastname)) },
-                  placeholder = { Text(stringResource(R.string.edit_profile_Doe), Modifier, Color.Gray) },
+                  placeholder = {
+                    Text(stringResource(R.string.edit_profile_Doe), Modifier, Color.Gray)
+                  },
                   keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
                   singleLine = true,
                   isError = lastNameError.value)
@@ -132,7 +140,9 @@ fun EditProfileDialog(onDismiss: () -> Unit, onSave: (DataUser) -> Unit) {
                   },
                   Modifier.testTag(C.Tag.EditProfile.email).fillMaxWidth().padding(8.dp, 4.dp),
                   label = { Text(stringResource(R.string.edit_profile_email)) },
-                  placeholder = { Text(stringResource(R.string.edit_profile_email_example), Modifier, Color.Gray) },
+                  placeholder = {
+                    Text(stringResource(R.string.edit_profile_email_example), Modifier, Color.Gray)
+                  },
                   keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
                   singleLine = true,
                   isError = emailError.value)
@@ -152,7 +162,9 @@ fun EditProfileDialog(onDismiss: () -> Unit, onSave: (DataUser) -> Unit) {
                   },
                   Modifier.testTag(C.Tag.EditProfile.phone).fillMaxWidth().padding(8.dp, 4.dp),
                   label = { Text(stringResource(R.string.edit_profile_phone)) },
-                  placeholder = { Text(stringResource(R.string.edit_profile_phone_example), Modifier, Color.Gray) },
+                  placeholder = {
+                    Text(stringResource(R.string.edit_profile_phone_example), Modifier, Color.Gray)
+                  },
                   keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
                   singleLine = true,
                   isError = phoneError.value)

--- a/app/src/main/java/com/android/bookswap/ui/profile/NewUser.kt
+++ b/app/src/main/java/com/android/bookswap/ui/profile/NewUser.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -43,6 +44,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import com.android.bookswap.R
 import com.android.bookswap.data.repository.PhotoFirebaseStorageRepository
 import com.android.bookswap.model.InputVerification
 import com.android.bookswap.model.LocalAppConfig
@@ -112,14 +114,14 @@ fun NewUserScreen(
                         onSuccess = { url -> profilPicture.value = url },
                         onFailure = { exception ->
                           Log.e("NewUserScreen", "Error uploading photo: $exception")
-                          Toast.makeText(context, "Error uploading photo", Toast.LENGTH_SHORT)
+                          Toast.makeText(context, context.getString(R.string.new_user_toast_error_upload), Toast.LENGTH_SHORT)
                               .show()
                         })
                   })
             },
             onFailure = { exception ->
               Log.e("NewUserScreen", "Error taking photo: $exception")
-              Toast.makeText(context, "Error taking photo", Toast.LENGTH_SHORT).show()
+              Toast.makeText(context, context.getString(R.string.new_user_toast_error_taking), Toast.LENGTH_SHORT).show()
             })
       }
   photoRequester.Init() // This is the initialization of the photo requester
@@ -131,7 +133,7 @@ fun NewUserScreen(
               .testTag(C.Tag.new_user_screen_container)) {
         item {
           Text(
-              "Welcome",
+              stringResource(R.string.new_user_welcome),
               modifier = Modifier.testTag(C.Tag.TopAppBar.screen_title).fillMaxWidth(),
               style =
                   TextStyle(
@@ -144,7 +146,7 @@ fun NewUserScreen(
         item {
           // The personal information text
           Text(
-              "Please fill in your personal information to start BookSwapping",
+              stringResource(R.string.new_user_indication_text),
               modifier = Modifier.testTag(C.Tag.NewUser.personal_info).fillMaxWidth(),
               style =
                   TextStyle(
@@ -192,8 +194,8 @@ fun NewUserScreen(
                           Modifier.testTag(C.Tag.NewUser.greeting)
                               .fillMaxWidth()
                               .padding(TEXT_PADDING),
-                          label = { Text("Greeting") },
-                          placeholder = { Text("Mr.", Modifier, Color.Gray) },
+                          label = { Text(stringResource(R.string.edit_profile_greeting)) },
+                          placeholder = { Text(stringResource(R.string.edit_profile_mr), Modifier, Color.Gray) },
                           keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
                           singleLine = true)
 
@@ -203,8 +205,8 @@ fun NewUserScreen(
                           Modifier.testTag(C.Tag.NewUser.firstname)
                               .fillMaxWidth()
                               .padding(TEXT_PADDING),
-                          label = { Text("Firstname") },
-                          placeholder = { Text("John", Modifier, Color.Gray) },
+                          label = { Text(stringResource(R.string.edit_profile_firstname)) },
+                          placeholder = { Text(stringResource(R.string.edit_profile_john), Modifier, Color.Gray) },
                           keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
                           singleLine = true,
                           isError =
@@ -223,8 +225,8 @@ fun NewUserScreen(
                           Modifier.testTag(C.Tag.NewUser.lastname)
                               .fillMaxWidth()
                               .padding(TEXT_PADDING),
-                          label = { Text("Lastname") },
-                          placeholder = { Text("Doe", Modifier, Color.Gray) },
+                          label = { Text(stringResource(R.string.edit_profile_lastname)) },
+                          placeholder = { Text(stringResource(R.string.edit_profile_Doe), Modifier, Color.Gray) },
                           keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
                           singleLine = true,
                           isError = !verification.validateNonEmpty(lastName.value) && !firstAttempt)
@@ -242,8 +244,8 @@ fun NewUserScreen(
                           Modifier.testTag(C.Tag.NewUser.email)
                               .fillMaxWidth()
                               .padding(TEXT_PADDING),
-                          label = { Text("Email") },
-                          placeholder = { Text("John.Doe@example.com", Modifier, Color.Gray) },
+                          label = { Text(stringResource(R.string.edit_profile_email)) },
+                          placeholder = { Text(stringResource(R.string.edit_profile_email_example), Modifier, Color.Gray) },
                           keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
                           singleLine = true,
                           isError = !verification.validateEmail(email.value) && !firstAttempt)
@@ -261,8 +263,8 @@ fun NewUserScreen(
                           Modifier.testTag(C.Tag.NewUser.phone)
                               .fillMaxWidth()
                               .padding(TEXT_PADDING),
-                          label = { Text("Phone") },
-                          placeholder = { Text("+4122345678", Modifier, Color.Gray) },
+                          label = { Text(stringResource(R.string.edit_profile_phone)) },
+                          placeholder = { Text(stringResource(R.string.edit_profile_phone_example), Modifier, Color.Gray) },
                           keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
                           singleLine = true,
                           isError = !verification.validatePhone(phone.value) && !firstAttempt)
@@ -296,7 +298,7 @@ fun NewUserScreen(
                     navigationActions.navigateTo(C.Route.MAP)
                   } else {
                     firstAttempt = false
-                    Toast.makeText(context, "Please correct the errors", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(context, context.getString(R.string.new_user_toast_correct_error), Toast.LENGTH_SHORT).show()
                   }
                 },
                 colors = ButtonDefaults.buttonColors(ColorVariable.Primary),
@@ -305,7 +307,7 @@ fun NewUserScreen(
                         .height(BUTTON_HEIGHT)
                         .testTag(C.Tag.NewUser.confirm)) {
                   Text(
-                      text = "Create",
+                      text = stringResource(R.string.new_user_create_button),
                       textAlign = TextAlign.Center,
                       style = TextStyle(color = ColorVariable.BackGround))
                 }

--- a/app/src/main/java/com/android/bookswap/ui/profile/NewUser.kt
+++ b/app/src/main/java/com/android/bookswap/ui/profile/NewUser.kt
@@ -114,14 +114,21 @@ fun NewUserScreen(
                         onSuccess = { url -> profilPicture.value = url },
                         onFailure = { exception ->
                           Log.e("NewUserScreen", "Error uploading photo: $exception")
-                          Toast.makeText(context, context.getString(R.string.new_user_toast_error_upload), Toast.LENGTH_SHORT)
+                          Toast.makeText(
+                                  context,
+                                  context.getString(R.string.new_user_toast_error_upload),
+                                  Toast.LENGTH_SHORT)
                               .show()
                         })
                   })
             },
             onFailure = { exception ->
               Log.e("NewUserScreen", "Error taking photo: $exception")
-              Toast.makeText(context, context.getString(R.string.new_user_toast_error_taking), Toast.LENGTH_SHORT).show()
+              Toast.makeText(
+                      context,
+                      context.getString(R.string.new_user_toast_error_taking),
+                      Toast.LENGTH_SHORT)
+                  .show()
             })
       }
   photoRequester.Init() // This is the initialization of the photo requester
@@ -195,7 +202,9 @@ fun NewUserScreen(
                               .fillMaxWidth()
                               .padding(TEXT_PADDING),
                           label = { Text(stringResource(R.string.edit_profile_greeting)) },
-                          placeholder = { Text(stringResource(R.string.edit_profile_mr), Modifier, Color.Gray) },
+                          placeholder = {
+                            Text(stringResource(R.string.edit_profile_mr), Modifier, Color.Gray)
+                          },
                           keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
                           singleLine = true)
 
@@ -206,7 +215,9 @@ fun NewUserScreen(
                               .fillMaxWidth()
                               .padding(TEXT_PADDING),
                           label = { Text(stringResource(R.string.edit_profile_firstname)) },
-                          placeholder = { Text(stringResource(R.string.edit_profile_john), Modifier, Color.Gray) },
+                          placeholder = {
+                            Text(stringResource(R.string.edit_profile_john), Modifier, Color.Gray)
+                          },
                           keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
                           singleLine = true,
                           isError =
@@ -226,7 +237,9 @@ fun NewUserScreen(
                               .fillMaxWidth()
                               .padding(TEXT_PADDING),
                           label = { Text(stringResource(R.string.edit_profile_lastname)) },
-                          placeholder = { Text(stringResource(R.string.edit_profile_Doe), Modifier, Color.Gray) },
+                          placeholder = {
+                            Text(stringResource(R.string.edit_profile_Doe), Modifier, Color.Gray)
+                          },
                           keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
                           singleLine = true,
                           isError = !verification.validateNonEmpty(lastName.value) && !firstAttempt)
@@ -245,7 +258,12 @@ fun NewUserScreen(
                               .fillMaxWidth()
                               .padding(TEXT_PADDING),
                           label = { Text(stringResource(R.string.edit_profile_email)) },
-                          placeholder = { Text(stringResource(R.string.edit_profile_email_example), Modifier, Color.Gray) },
+                          placeholder = {
+                            Text(
+                                stringResource(R.string.edit_profile_email_example),
+                                Modifier,
+                                Color.Gray)
+                          },
                           keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
                           singleLine = true,
                           isError = !verification.validateEmail(email.value) && !firstAttempt)
@@ -264,7 +282,12 @@ fun NewUserScreen(
                               .fillMaxWidth()
                               .padding(TEXT_PADDING),
                           label = { Text(stringResource(R.string.edit_profile_phone)) },
-                          placeholder = { Text(stringResource(R.string.edit_profile_phone_example), Modifier, Color.Gray) },
+                          placeholder = {
+                            Text(
+                                stringResource(R.string.edit_profile_phone_example),
+                                Modifier,
+                                Color.Gray)
+                          },
                           keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
                           singleLine = true,
                           isError = !verification.validatePhone(phone.value) && !firstAttempt)
@@ -298,7 +321,11 @@ fun NewUserScreen(
                     navigationActions.navigateTo(C.Route.MAP)
                   } else {
                     firstAttempt = false
-                    Toast.makeText(context, context.getString(R.string.new_user_toast_correct_error), Toast.LENGTH_SHORT).show()
+                    Toast.makeText(
+                            context,
+                            context.getString(R.string.new_user_toast_correct_error),
+                            Toast.LENGTH_SHORT)
+                        .show()
                   }
                 },
                 colors = ButtonDefaults.buttonColors(ColorVariable.Primary),

--- a/app/src/main/java/com/android/bookswap/ui/profile/OthersUserProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/profile/OthersUserProfile.kt
@@ -154,7 +154,9 @@ fun OthersUserProfileScreen(
 
                 // Email:
                 LabeledText(
-                    testTag = C.Tag.OtherUserProfile.email, label = stringResource(R.string.user_profile_email), value = user.email)
+                    testTag = C.Tag.OtherUserProfile.email,
+                    label = stringResource(R.string.user_profile_email),
+                    value = user.email)
 
                 // Phone Number:
                 LabeledText(
@@ -184,7 +186,9 @@ fun OthersUserProfileScreen(
                     onClick = {
                       navigationActions.navigateTo(C.Screen.CHAT, user.userUUID.toString())
                     }) {
-                      Text(stringResource(R.string.user_profile_message_with_button) + user.firstName )
+                      Text(
+                          stringResource(R.string.user_profile_message_with_button) +
+                              user.firstName)
                     }
 
                 // Book List

--- a/app/src/main/java/com/android/bookswap/ui/profile/OthersUserProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/profile/OthersUserProfile.kt
@@ -21,8 +21,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.android.bookswap.R
 import com.android.bookswap.data.DataBook
 import com.android.bookswap.data.DataUser
 import com.android.bookswap.data.repository.BooksRepository
@@ -152,18 +154,18 @@ fun OthersUserProfileScreen(
 
                 // Email:
                 LabeledText(
-                    testTag = C.Tag.OtherUserProfile.email, label = "Email:", value = user.email)
+                    testTag = C.Tag.OtherUserProfile.email, label = stringResource(R.string.user_profile_email), value = user.email)
 
                 // Phone Number:
                 LabeledText(
                     testTag = C.Tag.OtherUserProfile.phone,
-                    label = "Phone:",
+                    label = stringResource(R.string.user_profile_phone),
                     value = user.phoneNumber)
 
                 // Address:
                 LabeledText(
                     testTag = C.Tag.OtherUserProfile.address,
-                    label = "Address:",
+                    label = stringResource(R.string.user_profile_address),
                     value = "${user.latitude}, ${user.longitude}")
 
                 // Chat Button
@@ -182,7 +184,7 @@ fun OthersUserProfileScreen(
                     onClick = {
                       navigationActions.navigateTo(C.Screen.CHAT, user.userUUID.toString())
                     }) {
-                      Text("Message with ${user.firstName}")
+                      Text(stringResource(R.string.user_profile_message_with_button) + user.firstName )
                     }
 
                 // Book List

--- a/app/src/main/java/com/android/bookswap/ui/profile/OthersUserProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/profile/OthersUserProfile.kt
@@ -188,6 +188,7 @@ fun OthersUserProfileScreen(
                     }) {
                       Text(
                           stringResource(R.string.user_profile_message_with_button) +
+                              " " +
                               user.firstName)
                     }
 

--- a/app/src/main/java/com/android/bookswap/ui/profile/UserProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/profile/UserProfile.kt
@@ -30,10 +30,12 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import coil.compose.AsyncImage
+import com.android.bookswap.R
 import com.android.bookswap.data.DataBook
 import com.android.bookswap.data.repository.BooksRepository
 import com.android.bookswap.data.repository.PhotoFirebaseStorageRepository
@@ -122,14 +124,14 @@ fun UserProfile(
                         },
                         onFailure = { exception ->
                           Log.e("NewUserScreen", "Error uploading photo: $exception")
-                          Toast.makeText(context, "Error uploading photo", Toast.LENGTH_SHORT)
+                          Toast.makeText(context, context.getString(R.string.new_user_toast_error_upload), Toast.LENGTH_SHORT)
                               .show()
                         })
                   })
             },
             onFailure = { exception ->
               Log.e("NewUserScreen", "Error taking photo: $exception")
-              Toast.makeText(context, "Error taking photo", Toast.LENGTH_SHORT).show()
+              Toast.makeText(context, context.getString(R.string.new_user_toast_error_taking), Toast.LENGTH_SHORT).show()
             })
       }
   photoRequester.Init() // Initialize the photoRequester
@@ -170,11 +172,11 @@ fun UserProfile(
                 Modifier.fillMaxWidth().padding(PADDING),
                 Arrangement.Center,
                 Alignment.CenterHorizontally) {
-                  Text("Edit Profile Picture")
+                  Text(stringResource(R.string.user_profile_edit_picture))
                   ButtonComponent(
                       { photoRequester.requestPhoto() },
                       Modifier.testTag(C.Tag.UserProfile.take_photo)) {
-                        Text("Take Photo")
+                        Text(stringResource(R.string.user_profile_take_photo))
                       }
                 }
           }
@@ -238,21 +240,21 @@ fun UserProfile(
           // Full name text
           LabeledTextUserProfile(
               testTag = C.Tag.OtherUserProfile.fullname,
-              label = "Your name:",
+              label = stringResource(R.string.user_profile_your_name),
               value = "${userData.greeting} ${userData.firstName} ${userData.lastName}")
 
           // Email text
           LabeledTextUserProfile(
-              testTag = C.Tag.OtherUserProfile.email, label = "Your email:", value = userData.email)
+              testTag = C.Tag.OtherUserProfile.email, label = stringResource(R.string.user_profile_your_email), value = userData.email)
 
           // Phone number text
           LabeledTextUserProfile(
               testTag = C.Tag.OtherUserProfile.phone,
-              label = "Your phone:",
+              label = stringResource(R.string.user_profile_your_phone),
               value = userData.phoneNumber)
           // User address:
           LabeledTextUserProfile(
-              testTag = C.Tag.OtherUserProfile.address, label = "Your address:", value = addressStr)
+              testTag = C.Tag.OtherUserProfile.address, label = stringResource(R.string.user_profile_your_address), value = addressStr)
 
           Spacer(modifier = Modifier.height(SPACER_HEIGHT_INFO_EDIT))
 
@@ -260,7 +262,7 @@ fun UserProfile(
           ButtonComponent(
               { showEditProfile = true },
               Modifier.testTag(C.Tag.UserProfile.edit).align(Alignment.CenterHorizontally)) {
-                Text("Edit Profile")
+                Text(stringResource(R.string.user_profile_edit))
               }
 
           // Book List
@@ -269,7 +271,7 @@ fun UserProfile(
             CircularProgressIndicator(modifier = Modifier.padding(PADDING))
           } else if (bookListData.value.isEmpty()) {
             Log.e("UserProfileScreen", "No books available")
-            Text("No books available", style = MaterialTheme.typography.bodyLarge)
+            Text(stringResource(R.string.user_profile_no_books), style = MaterialTheme.typography.bodyLarge)
           } else {
             Log.i("UserProfileScreen", "Displaying book list")
             BookListComponent(

--- a/app/src/main/java/com/android/bookswap/ui/profile/UserProfile.kt
+++ b/app/src/main/java/com/android/bookswap/ui/profile/UserProfile.kt
@@ -124,14 +124,21 @@ fun UserProfile(
                         },
                         onFailure = { exception ->
                           Log.e("NewUserScreen", "Error uploading photo: $exception")
-                          Toast.makeText(context, context.getString(R.string.new_user_toast_error_upload), Toast.LENGTH_SHORT)
+                          Toast.makeText(
+                                  context,
+                                  context.getString(R.string.new_user_toast_error_upload),
+                                  Toast.LENGTH_SHORT)
                               .show()
                         })
                   })
             },
             onFailure = { exception ->
               Log.e("NewUserScreen", "Error taking photo: $exception")
-              Toast.makeText(context, context.getString(R.string.new_user_toast_error_taking), Toast.LENGTH_SHORT).show()
+              Toast.makeText(
+                      context,
+                      context.getString(R.string.new_user_toast_error_taking),
+                      Toast.LENGTH_SHORT)
+                  .show()
             })
       }
   photoRequester.Init() // Initialize the photoRequester
@@ -245,7 +252,9 @@ fun UserProfile(
 
           // Email text
           LabeledTextUserProfile(
-              testTag = C.Tag.OtherUserProfile.email, label = stringResource(R.string.user_profile_your_email), value = userData.email)
+              testTag = C.Tag.OtherUserProfile.email,
+              label = stringResource(R.string.user_profile_your_email),
+              value = userData.email)
 
           // Phone number text
           LabeledTextUserProfile(
@@ -254,7 +263,9 @@ fun UserProfile(
               value = userData.phoneNumber)
           // User address:
           LabeledTextUserProfile(
-              testTag = C.Tag.OtherUserProfile.address, label = stringResource(R.string.user_profile_your_address), value = addressStr)
+              testTag = C.Tag.OtherUserProfile.address,
+              label = stringResource(R.string.user_profile_your_address),
+              value = addressStr)
 
           Spacer(modifier = Modifier.height(SPACER_HEIGHT_INFO_EDIT))
 
@@ -271,7 +282,9 @@ fun UserProfile(
             CircularProgressIndicator(modifier = Modifier.padding(PADDING))
           } else if (bookListData.value.isEmpty()) {
             Log.e("UserProfileScreen", "No books available")
-            Text(stringResource(R.string.user_profile_no_books), style = MaterialTheme.typography.bodyLarge)
+            Text(
+                stringResource(R.string.user_profile_no_books),
+                style = MaterialTheme.typography.bodyLarge)
           } else {
             Log.i("UserProfileScreen", "Displaying book list")
             BookListComponent(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,58 @@
     <string name="user_profile_edit">Edit Profile</string>
     <string name="user_profile_no_books">No Books available</string>
 
+    <!-- Notification -->
+    <string name="notification_toast_disable">Notifications are disabled. You will not receive updates.</string>
+    <string name="notification_toast_enable">Notifications have been enabled.</string>
+    <string name="notification_title">Notification Permission Required</string>
+    <string name="notification_message">To keep you informed about important updates, please allow notification permissions.</string>
+    <string name="notification_ok">OK</string>
+    <string name="notification_no">No thanks</string>
+
+    <string name="notification_toast_request_action">Action: </string>
+
+    <!-- Add Book VM -->
+    <string name="add_book_toast">Book added</string>
+    <string name="add_book_toast_error">Failed to add book</string>
+
+    <!-- Book Languages -->
+    <string name="language_french">French</string>
+    <string name="language_german">German</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Spanish</string>
+    <string name="language_italian">Italian</string>
+    <string name="language_romansh">Romansh</string>
+    <string name="language_other">Other</string>
+
+    <!-- Book Languages Codes -->
+    <string name="language_code_french">FR</string>
+    <string name="language_code_german">DE</string>
+    <string name="language_code_english">EN</string>
+    <string name="language_code_spanish">ES</string>
+    <string name="language_code_italian">IT</string>
+    <string name="language_code_romansh">RM</string>
+    <string name="language_code_other">OTHER</string>
+
+    <!-- Book Genres -->
+    <string name="genre_fiction">Fiction</string>
+    <string name="genre_nonfiction">Non-Fiction</string>
+    <string name="genre_fantasy">Fantasy</string>
+    <string name="genre_science_fiction">Science-Fiction</string>
+    <string name="genre_mystery">Mystery</string>
+    <string name="genre_thriller">Thriller</string>
+    <string name="genre_romance">Romance</string>
+    <string name="genre_horror">Horror</string>
+    <string name="genre_historical">Historical</string>
+    <string name="genre_western">Western</string>
+    <string name="genre_dystopian">Dystopian</string>
+    <string name="genre_memoir">Memoir</string>
+    <string name="genre_biography">Biography</string>
+    <string name="genre_autobiography">Autobiography</string>
+    <string name="genre_self_help">Self-Help</string>
+    <string name="genre_health">Health</string>
+    <string name="genre_travel">Travel</string>
+    <string name="genre_guide">Guide</string>
+    <string name="genre_other">Other</string>
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,111 @@
     <string name="label_isbn">ISBN*</string>
     <string name="label_photo">Pics*</string>
     <string name="label_language">Language*</string>
+    <!-- Book Addition Choice Screen -->
+    <string name="book_addition_choice_title">Add a Book</string>
+    <string name="book_addition_choice_button_manually">Manually</string>
+    <string name="book_addition_choice_button_from_isbn">From ISBN</string>
+    <string name="book_addition_choice_button_from_photo">From Photo</string>
+    <string name="book_addition_choice_toast_error">An error occurred while adding the book</string>
+
+    <!-- Book Profile Screen -->
+    <string name="book_profile_screen_title">Book Profile</string>
+    <string name="book_profile_error_loading">Error loading book details: %1$s</string>
+    <string name="book_profile_author_unknown">Author Unknown</string>
+    <string name="book_profile_rating_label">Rating: </string>
+    <string name="book_profile_synopsis_label">Synopsis</string>
+    <string name="book_profile_synopsis_empty">No description available</string>
+    <string name="book_profile_language_label">Language: </string>
+    <string name="book_profile_genres_label">Genres:</string>
+    <string name="book_profile_isbn_label">ISBN:</string>
+    <string name="book_profile_isbn_missing">ISBN does not exist or is not available</string>
+    <string name="book_profile_date_label">Date of Publication: [Temporary Date]</string>
+    <string name="book_profile_volume_label">Volume: [Temporary Volume]</string>
+    <string name="book_profile_issue_label">Issue: [Temporary Issue]</string>
+    <string name="book_profile_editorial_label">Editorial: [Temporary Editorial]</string>
+    <string name="book_profile_location_label">Place of Edition: [Temporary Place]</string>
+    <string name="book_profile_edit_button">Edit Book</string>
+    <string name="book_profile_go_to_user_button">Go to User</string>
+    <!-- SignIn Screen -->
+    <string name="sign_in_screen_welcome">Welcome to</string>
+    <string name="sign_in_screen_app_name">BookSwap</string>
+    <string name="sign_in_button_google">Sign in with Google</string>
+    <string name="sign_in_toast_welcome">Welcome </string>
+    <string name="sign_in_toast_login_failed">Login Failed!</string>
+    <!-- ISBN Screen -->
+    <string name="add_isbn_screen_title">Add a Book by ISBN</string>
+    <string name="add_isbn_field_label">ISBN*</string>
+    <string name="add_isbn_button_search">Search</string>
+    <string name="add_isbn_toast_invalid">Invalid ISBN</string>
+    <string name="add_isbn_toast_search_unsuccessful">Search unsuccessful</string>
+    <string name="add_isbn_toast_error_message">Error: </string>
+    <!-- List Chat Screen -->
+    <string name="chat_list_screen_title">Messages</string>
+    <string name="chat_list_no_messages">No messages yet</string>
+
+    <!-- Chat Screen -->
+
+    <string name="chat_message_empty_error">Message cannot be empty</string>
+    <string name="chat_update_error">Message can only be updated within 15 minutes of being sent</string>
+    <string name="chat_send_error">Message could not be sent.</string>
+    <string name="chat_delete_error">Message can only be deleted within 15 minutes of being sent</string>
+    <string name="chat_message_stored_error">"Image could not be stored."</string>
+
+    <string name="chat_update_button">Update</string>
+    <string name="chat_send_button">Send</string>
+    <string name="chat_edit_button">Edit</string>
+    <string name="chat_delete_button">Delete</string>
+
+    <!-- Filter Screen -->
+    <string name="filter_map_screen_title">Filters</string>
+    <string name="filter_apply_button_text">Apply</string>
+    <string name="filters_applied_message">Filters applied</string>
+    <!-- Map Screen -->
+    <string name="map_screen_title">Map</string>
+    <string name="map_screen_please_connect_to_internet">Please connect to Internet to actualise</string>
+    <string name="map_screen_your_location">Your Location</string>
+    <!-- Edit Profile Screen -->
+    <string name="edit_profile_screen_title">Edit Profile</string>
+    <string name="edit_profile_greeting">Greeting</string>
+    <string name="edit_profile_mr">Mr.</string>
+    <string name="edit_profile_firstname">Firstname</string>
+    <string name="edit_profile_john">John</string>
+    <string name="edit_profile_lastname">Lastname</string>
+    <string name="edit_profile_Doe">Doe</string>
+    <string name="edit_profile_email">Email</string>
+    <string name="edit_profile_email_example">John.Doe@example.com</string>
+    <string name="edit_profile_phone">Phone</string>
+    <string name="edit_profile_phone_example">+4122345678</string>
+    <string name="edit_profile_save_button">Save</string>
+    <string name="edit_profile_cancel_button">Cancel</string>
+
+    <!-- New User Screen -->
+    <string name="new_user_screen_title">New User</string>
+    <string name="new_user_toast_error_upload">Error uploading photo</string>
+    <string name="new_user_toast_error_taking">Error taking photo</string>
+    <string name="new_user_welcome">Welcome</string>
+    <string name="new_user_indication_text">Please fill in your personal information to start BookSwapping</string>
+    <string name="new_user_toast_correct_error">Please correct the errors</string>
+    <string name="new_user_create_button">Create</string>
+
+    <!-- User Profile Screen -->
+    <string name="other_user_profile_screen_title">User Profile</string>
+    <string name="user_profile_screen_title">Your Profile</string>
+    <string name="user_profile_email">Email:</string>
+    <string name="user_profile_phone">Phone:</string>
+    <string name="user_profile_address">Address:</string>
+    <string name="user_profile_message_with_button">Message with </string>
+    <string name="user_profile_toast_error_upload">Error uploading photo</string>
+    <string name="user_profile_toast_error_taking">Error taking photo</string>
+    <string name="user_profile_take_photo">Take Photo</string>
+    <string name="user_profile_edit_picture">Edit Profile Picture</string>
+    <string name="user_profile_your_name">Your name:</string>
+    <string name="user_profile_your_email">Your email:</string>
+    <string name="user_profile_your_phone">Your phone:</string>
+    <string name="user_profile_your_address">Your address:</string>
+    <string name="user_profile_edit">Edit Profile</string>
+    <string name="user_profile_no_books">No Books available</string>
+
+
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,6 +172,8 @@
     <string name="genre_travel">Travel</string>
     <string name="genre_guide">Guide</string>
     <string name="genre_other">Other</string>
+    <!-- Prompt -->
+    <string name="prompt_book_scanning">You are an AI designed to analyze images of book covers. Given an image of a book\'s back cover in URL format, extract the following information in a structured format (JSON) with the specified fields: title, author, description, language, and ISBN. Please ensure that: 1. If any of the fields are not present or cannot be confidently identified, indicate them with \"N/A\". 2. If the image does not appear to be a book cover, return an error message stating \"The image does not appear to be a valid book cover.\" 3. If the title, author, description, or other fields are in a different language, keep the original text for reference, and provide the appropriate language code using the following classification: - FRENCH (\"FR\") - GERMAN (\"DE\") - ENGLISH (\"EN\") - SPANISH (\"ES\") - ITALIAN (\"IT\") - ROMANSH (\"RM\") - OTHER (\"OTHER\") 4. The description should be the one written on the book\'s. 5. The ISBN is often over a barcode, in the bottom left or right corner. Example output format: { \"title\": \"Example Title\", \"author\": \"Example Author\", \"description\": \"An example description of the book.\", \"language\": \"EN\", \"isbn\": \"1234567890\" } The image URL:</string>
 
 
 </resources>

--- a/app/src/test/java/com/android/bookswap/model/add/AddToBookViewModelTest.kt
+++ b/app/src/test/java/com/android/bookswap/model/add/AddToBookViewModelTest.kt
@@ -43,7 +43,7 @@ class AddToBookViewModelTest {
   @Before
   fun setup() {
     booksRepository = mockk()
-    context = mockk()
+    context = mockk(relaxed = true)
     val mockUserRepository: UsersRepository = mockk()
 
     mockUserViewModel = spyk(UserViewModel(uuid, mockUserRepository, user))


### PR DESCRIPTION
This PR moves all user-facing strings to `strings.xml` or `C.kt`. This includes:
- Text displayed in the UI
- Toast messages
- Enum values such as language and genre

Strings used in logs have not been moved, as keeping them in the code simplifies debugging and they are not visible to the user. Similarly, strings used for content descriptions remain unchanged, as they are also not directly visible to the user.

If I missed any user-facing strings, please feel free to flag them.