### PR TITLE
Add tests coverage for PhotoRequester

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/model/PhotoRequesterTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/model/PhotoRequesterTest.kt
@@ -13,7 +13,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.core.app.ActivityOptionsCompat
 import androidx.core.content.FileProvider
@@ -22,222 +21,225 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import io.mockk.spyk
 import io.mockk.verify
+import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.kotlin.mock
-import java.io.File
 
 /*
- Thanks https://medium.com/@adrian.gl/how-to-mock-and-test-activityresult-apis-with-jetpack-compose-f3a1d6311171
- for most parts on how to implement this.
- */
+Thanks https://medium.com/@adrian.gl/how-to-mock-and-test-activityresult-apis-with-jetpack-compose-f3a1d6311171
+for most parts on how to implement this.
+*/
 class PhotoRequesterTest {
-    @get:Rule val composeTestRule = createComposeRule()
-    private val mockContext: Context = mockk()
+  @get:Rule val composeTestRule = createComposeRule()
+  private val mockContext: Context = mockk()
 
+  @Before
+  fun setup() {
 
-    @Before
-    fun setup() {
+    val mockFile: File = mockk()
+    val mockURI: Uri = mockk()
+    val mockContentResolver: ContentResolver = mockk()
 
-        val mockFile: File = mockk()
-        val mockURI: Uri = mockk()
-        val mockContentResolver: ContentResolver = mockk()
+    every { mockContext.cacheDir } returns mockFile
+    every { mockContext.contentResolver } returns mockContentResolver
 
-        every { mockContext.cacheDir } returns mockFile
-        every { mockContext.contentResolver } returns mockContentResolver
+    // Mock all file functions for PhotoRequester#getTempUri()
+    mockkStatic(File::class)
+    every { File.createTempFile(any(), any(), any()) } returns mockFile
+    mockkStatic(FileProvider::class)
 
-        //Mock all file functions for PhotoRequester#getTempUri()
-        mockkStatic(File::class)
-        every { File.createTempFile(any(), any(), any()) } returns mockFile
-        mockkStatic(FileProvider::class)
+    every { FileProvider.getUriForFile(any(), any(), any()) } returns mockURI
+  }
 
-        every { FileProvider.getUriForFile(any(), any(), any()) } returns mockURI
+  @Test
+  fun photoRequesterSuccessWhenFine() {
+    val mockCallback: (Result<ImageBitmap>) -> Unit = mockk()
+    every { mockCallback(any()) } just Runs
+
+    val mockSource: ImageDecoder.Source = mockk()
+    val mockBitmap: Bitmap = mockk()
+
+    mockkStatic(ImageDecoder::class)
+    every { ImageDecoder.createSource(any<ContentResolver>(), any()) } returns mockSource
+    every { ImageDecoder.decodeBitmap(mockSource) } returns mockBitmap
+
+    // Every ActivityResultContracts needed returns true
+    val testRegistry =
+        object : ActivityResultRegistry() {
+
+          override fun <I, O> onLaunch(
+              requestCode: Int,
+              contract: ActivityResultContract<I, O>,
+              input: I,
+              options: ActivityOptionsCompat?
+          ) {
+            when (contract::class) {
+              ActivityResultContracts.RequestPermission::class -> {
+                val requestPermissionResponse = true
+                dispatchResult(requestCode, requestPermissionResponse)
+              }
+              ActivityResultContracts.TakePicture::class -> {
+                val takePictureResponse = true
+                dispatchResult(requestCode, takePictureResponse)
+              }
+              else -> {
+                assertTrue("Contract of type ${contract::class} is not implemented", false)
+              }
+            }
+          }
+        }
+
+    val photoRequester = PhotoRequester(mockContext, mockCallback)
+
+    // Init PhotoRequester
+    composeTestRule.setContent {
+      WithActivityResultRegistry(testRegistry) { photoRequester.Init() }
+    }
+    photoRequester.requestPhoto()
+
+    // Received ImageBitmap
+    verify { mockCallback(Result.success(any<ImageBitmap>())) }
+  }
+
+  @Test
+  fun photoRequesterInitError() {
+    val mockCallback: (Result<ImageBitmap>) -> Unit = mockk()
+    every { mockCallback(any()) } just Runs
+
+    val photoRequester = PhotoRequester(mockContext, mockCallback)
+
+    // If PhotoRequester#Init() was not called, correct exception is raised
+    assertThrows(PhotoRequester.Companion.ExceptionType.INIT_NOT_CALLED.toException()::class.java) {
+      photoRequester.requestPhoto()
+    }
+  }
+
+  @Test
+  fun photoRequesterErrorImageSaved() {
+    val mockCallback: (Result<ImageBitmap>) -> Unit = mockk()
+
+    // Register all contracts, but image was not saved
+    val testRegistry =
+        object : ActivityResultRegistry() {
+
+          override fun <I, O> onLaunch(
+              requestCode: Int,
+              contract: ActivityResultContract<I, O>,
+              input: I,
+              options: ActivityOptionsCompat?
+          ) {
+            when (contract::class) {
+              ActivityResultContracts.RequestPermission::class -> {
+                val requestPermissionResponse = true
+                dispatchResult(requestCode, requestPermissionResponse)
+              }
+              // Make TakePicture fail
+              ActivityResultContracts.TakePicture::class -> {
+                val takePictureResponse = false
+                dispatchResult(requestCode, takePictureResponse)
+              }
+              else -> {
+                assertTrue("Contract of type ${contract::class} is not implemented", false)
+              }
+            }
+          }
+        }
+
+    val photoRequester = PhotoRequester(mockContext, mockCallback)
+
+    composeTestRule.setContent {
+      WithActivityResultRegistry(testRegistry) { photoRequester.Init() }
     }
 
-    @Test
-    fun photoRequesterSuccessWhenFine() {
-        val mockCallback: (Result<ImageBitmap>) -> Unit = mockk()
-        every { mockCallback(any()) } just Runs
-
-        val mockSource: ImageDecoder.Source = mockk()
-        val mockBitmap: Bitmap = mockk()
-
-        mockkStatic(ImageDecoder::class)
-        every { ImageDecoder.createSource(any<ContentResolver>(), any()) } returns mockSource
-        every { ImageDecoder.decodeBitmap(mockSource) } returns mockBitmap
-
-        // Every ActivityResultContracts needed returns true
-        val testRegistry = object : ActivityResultRegistry() {
-
-            override fun <I, O> onLaunch(
-                requestCode: Int,
-                contract: ActivityResultContract<I, O>,
-                input: I,
-                options: ActivityOptionsCompat?
-            ) {
-                when( contract::class) {
-                    ActivityResultContracts.RequestPermission::class -> {
-                        val requestPermissionResponse = true
-                        dispatchResult(requestCode, requestPermissionResponse)
-                    }
-                    ActivityResultContracts.TakePicture::class -> {
-                        val takePictureResponse = true
-                        dispatchResult(requestCode, takePictureResponse)
-                    }
-                    else -> {
-                        assertTrue("Contract of type ${contract::class} is not implemented", false)
-                    }
-                }
-            }
+    every { mockCallback(any()) } answers
+        {
+          val exception = firstArg<Result<ImageBitmap>>().exceptionOrNull()
+          // Check that exception message is correct. Direct exception check is not possible.
+          assertEquals(
+              PhotoRequester.Companion.ExceptionType.IMAGE_NOT_SAVED.toException().message,
+              exception!!.message)
         }
 
-        val photoRequester = PhotoRequester(mockContext, mockCallback)
+    photoRequester.requestPhoto()
 
-        // Init PhotoRequester
-        composeTestRule.setContent {
-            WithActivityResultRegistry(testRegistry) {
-                photoRequester.Init()
+    // Verify that the callback and thus subsequent checks was call at least once
+    verify { mockCallback(any()) }
+  }
+
+  @Test
+  fun photoRequesterErrorCameraPermissionDenied() {
+    val mockCallback: (Result<ImageBitmap>) -> Unit = mockk()
+
+    // Register all contracts, but camera permission is denied
+    val testRegistry =
+        object : ActivityResultRegistry() {
+
+          override fun <I, O> onLaunch(
+              requestCode: Int,
+              contract: ActivityResultContract<I, O>,
+              input: I,
+              options: ActivityOptionsCompat?
+          ) {
+            when (contract::class) {
+              // Make request permission fail
+              ActivityResultContracts.RequestPermission::class -> {
+                val requestPermissionResponse = false
+                dispatchResult(requestCode, requestPermissionResponse)
+              }
+              else -> {
+                assertTrue("Contract of type ${contract::class} is not implemented", false)
+              }
             }
-
+          }
         }
-        photoRequester.requestPhoto()
 
-        // Received ImageBitmap
-        verify { mockCallback(Result.success(any<ImageBitmap>())) }
+    val photoRequester = PhotoRequester(mockContext, mockCallback)
+
+    composeTestRule.setContent {
+      WithActivityResultRegistry(testRegistry) { photoRequester.Init() }
     }
 
-    @Test
-    fun photoRequesterInitError() {
-        val mockCallback: (Result<ImageBitmap>) -> Unit = mockk()
-        every { mockCallback(any()) } just Runs
-
-        val photoRequester = PhotoRequester(mockContext, mockCallback)
-
-        // If PhotoRequester#Init() was not called, correct exception is raised
-        assertThrows(PhotoRequester.Companion.ExceptionType.INIT_NOT_CALLED.toException()::class.java) {
-            photoRequester.requestPhoto()
-        }
-    }
-
-    @Test
-    fun photoRequesterErrorImageSaved() {
-        val mockCallback: (Result<ImageBitmap>) -> Unit = mockk()
-
-        // Register all contracts, but image was not saved
-        val testRegistry = object : ActivityResultRegistry() {
-
-            override fun <I, O> onLaunch(
-                requestCode: Int,
-                contract: ActivityResultContract<I, O>,
-                input: I,
-                options: ActivityOptionsCompat?
-            ) {
-                when( contract::class) {
-                    ActivityResultContracts.RequestPermission::class -> {
-                        val requestPermissionResponse = true
-                        dispatchResult(requestCode, requestPermissionResponse)
-                    }
-                    //Make TakePicture fail
-                    ActivityResultContracts.TakePicture::class -> {
-                        val takePictureResponse = false
-                        dispatchResult(requestCode, takePictureResponse)
-                    }
-                    else -> {
-                        assertTrue("Contract of type ${contract::class} is not implemented", false)
-                    }
-                }
-            }
+    every { mockCallback(any()) } answers
+        {
+          val exception = firstArg<Result<ImageBitmap>>().exceptionOrNull()
+          // Check that exception message is correct. Direct exception check is not possible.
+          assertEquals(
+              PhotoRequester.Companion.ExceptionType.PERMISSION_DENIED.toException().message,
+              exception!!.message)
         }
 
-        val photoRequester = PhotoRequester(mockContext, mockCallback)
+    photoRequester.requestPhoto()
 
-        composeTestRule.setContent {
-            WithActivityResultRegistry(testRegistry) {
-                photoRequester.Init()
-            }
+    // Verify that the callback and thus subsequent checks was call at least once
+    verify { mockCallback(any()) }
+  }
 
+  /**
+   * Defines a custom [ActivityResultRegistry] to be used when calls to ActivityResultContracts API
+   * via rememberLauncherForActivityResult.
+   *
+   * This allow us to mock external Activity calls in tests or in mock mode.
+   *
+   * Thanks
+   * https://medium.com/@adrian.gl/how-to-mock-and-test-activityresult-apis-with-jetpack-compose-f3a1d6311171
+   */
+  @Composable
+  fun WithActivityResultRegistry(
+      activityResultRegistry: ActivityResultRegistry,
+      content: @Composable () -> Unit
+  ) {
+    val activityResultRegistryOwner =
+        object : ActivityResultRegistryOwner {
+          override val activityResultRegistry = activityResultRegistry
         }
-
-        every { mockCallback(any()) } answers {
-            val exception = firstArg<Result<ImageBitmap>>().exceptionOrNull()
-            // Check that exception message is correct. Direct exception check is not possible.
-            assertEquals(PhotoRequester.Companion.ExceptionType.IMAGE_NOT_SAVED.toException().message, exception!!.message)
+    CompositionLocalProvider(
+        LocalActivityResultRegistryOwner provides activityResultRegistryOwner) {
+          content()
         }
-
-        photoRequester.requestPhoto()
-
-        // Verify that the callback and thus subsequent checks was call at least once
-        verify { mockCallback(any()) }
-    }
-
-    @Test
-    fun photoRequesterErrorCameraPermissionDenied() {
-        val mockCallback: (Result<ImageBitmap>) -> Unit = mockk()
-
-        // Register all contracts, but camera permission is denied
-        val testRegistry = object : ActivityResultRegistry() {
-
-            override fun <I, O> onLaunch(
-                requestCode: Int,
-                contract: ActivityResultContract<I, O>,
-                input: I,
-                options: ActivityOptionsCompat?
-            ) {
-                when( contract::class) {
-                    //Make request permission fail
-                    ActivityResultContracts.RequestPermission::class -> {
-                        val requestPermissionResponse = false
-                        dispatchResult(requestCode, requestPermissionResponse)
-                    }
-                    else -> {
-                        assertTrue("Contract of type ${contract::class} is not implemented", false)
-                    }
-                }
-            }
-        }
-
-        val photoRequester = PhotoRequester(mockContext, mockCallback)
-
-        composeTestRule.setContent {
-            WithActivityResultRegistry(testRegistry) {
-                photoRequester.Init()
-            }
-
-        }
-
-        every { mockCallback(any()) } answers {
-            val exception = firstArg<Result<ImageBitmap>>().exceptionOrNull()
-            // Check that exception message is correct. Direct exception check is not possible.
-            assertEquals(PhotoRequester.Companion.ExceptionType.PERMISSION_DENIED.toException().message, exception!!.message)
-        }
-
-        photoRequester.requestPhoto()
-
-        // Verify that the callback and thus subsequent checks was call at least once
-        verify { mockCallback(any()) }
-    }
-
-
-
-    /**
-     * Defines a custom [ActivityResultRegistry] to be used when calls to ActivityResultContracts API via rememberLauncherForActivityResult.
-     *
-     * This allow us to mock external Activity calls in tests or in mock mode.
-     *
-     * Thanks https://medium.com/@adrian.gl/how-to-mock-and-test-activityresult-apis-with-jetpack-compose-f3a1d6311171
-     */
-    @Composable
-    fun WithActivityResultRegistry(activityResultRegistry: ActivityResultRegistry, content: @Composable () -> Unit) {
-        val activityResultRegistryOwner = object : ActivityResultRegistryOwner {
-            override val activityResultRegistry = activityResultRegistry
-        }
-        CompositionLocalProvider(LocalActivityResultRegistryOwner provides activityResultRegistryOwner) { content() }
-    }
-
+  }
 }

--- a/app/src/androidTest/java/com/android/bookswap/model/PhotoRequesterTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/model/PhotoRequesterTest.kt
@@ -1,0 +1,229 @@
+package com.android.bookswap.model
+
+import android.content.ContentResolver
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.ImageDecoder
+import android.net.Uri
+import androidx.activity.compose.LocalActivityResultRegistryOwner
+import androidx.activity.result.ActivityResultRegistry
+import androidx.activity.result.ActivityResultRegistryOwner
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.core.app.ActivityOptionsCompat
+import androidx.core.content.FileProvider
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.spyk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import java.io.File
+
+class PhotoRequesterTest {
+    @get:Rule val composeTestRule = createComposeRule()
+    private val mockContext: Context = mockk()
+
+
+    @Before
+    fun setup() {
+
+        val mockFile: File = mockk()
+        val mockURI: Uri = mockk()
+        val mockContentResolver: ContentResolver = mockk()
+
+        every { mockContext.cacheDir } returns mockFile
+        every { mockContext.contentResolver } returns mockContentResolver
+
+        mockkStatic(File::class)
+        every { File.createTempFile(any(), any(), any()) } returns mockFile
+        mockkStatic(FileProvider::class)
+
+        every { FileProvider.getUriForFile(any(), any(), any()) } returns mockURI
+    }
+
+    @Test
+    fun photoRequesterSuccessWhenFine() {
+        val mockCallback: (Result<ImageBitmap>) -> Unit = mockk()
+        every { mockCallback(any()) } just Runs
+
+
+        val mockSource: ImageDecoder.Source = mockk()
+        val mockBitmap: Bitmap = mockk()
+
+
+        mockkStatic(ImageDecoder::class)
+        every { ImageDecoder.createSource(any<ContentResolver>(), any()) } returns mockSource
+        every { ImageDecoder.decodeBitmap(mockSource) } returns mockBitmap
+
+
+        val testRegistry = object : ActivityResultRegistry() {
+
+            override fun <I, O> onLaunch(
+                requestCode: Int,
+                contract: ActivityResultContract<I, O>,
+                input: I,
+                options: ActivityOptionsCompat?
+            ) {
+                when( contract::class) {
+                    ActivityResultContracts.RequestPermission::class -> {
+                        val requestPermissionResponse = true
+                        dispatchResult(requestCode, requestPermissionResponse)
+                    }
+                    ActivityResultContracts.TakePicture::class -> {
+                        val takePictureResponse = true
+                        dispatchResult(requestCode, takePictureResponse)
+                    }
+                    else -> {
+                        assertTrue("Contract of type ${contract::class} is not implemented", false)
+                    }
+                }
+            }
+        }
+
+        val photoRequester = PhotoRequester(mockContext, mockCallback)
+
+        composeTestRule.setContent {
+            WithActivityResultRegistry(testRegistry) {
+                photoRequester.Init()
+            }
+
+        }
+        photoRequester.requestPhoto()
+
+        verify { mockCallback(Result.success(any<ImageBitmap>())) }
+    }
+
+    @Test
+    fun photoRequesterInitError() {
+        val mockCallback: (Result<ImageBitmap>) -> Unit = mockk()
+        every { mockCallback(any()) } just Runs
+
+        val photoRequester = PhotoRequester(mockContext, mockCallback)
+
+        assertThrows(PhotoRequester.Companion.ExceptionType.INIT_NOT_CALLED.toException()::class.java) {
+            photoRequester.requestPhoto()
+        }
+    }
+
+    @Test
+    fun photoRequesterErrorPermissionDenied() {
+        val mockCallback: (Result<ImageBitmap>) -> Unit = mockk()
+
+        val testRegistry = object : ActivityResultRegistry() {
+
+            override fun <I, O> onLaunch(
+                requestCode: Int,
+                contract: ActivityResultContract<I, O>,
+                input: I,
+                options: ActivityOptionsCompat?
+            ) {
+                when( contract::class) {
+                    ActivityResultContracts.RequestPermission::class -> {
+                        val requestPermissionResponse = true
+                        dispatchResult(requestCode, requestPermissionResponse)
+                    }
+                    //Make TakePicture fail
+                    ActivityResultContracts.TakePicture::class -> {
+                        val takePictureResponse = false
+                        dispatchResult(requestCode, takePictureResponse)
+                    }
+                    else -> {
+                        assertTrue("Contract of type ${contract::class} is not implemented", false)
+                    }
+                }
+            }
+        }
+
+        val photoRequester = PhotoRequester(mockContext, mockCallback)
+
+        composeTestRule.setContent {
+            WithActivityResultRegistry(testRegistry) {
+                photoRequester.Init()
+            }
+
+        }
+
+        every { mockCallback(any()) } answers {
+            val exception = firstArg<Result<ImageBitmap>>().exceptionOrNull()
+            assertEquals(PhotoRequester.Companion.ExceptionType.IMAGE_NOT_SAVED.toException().message, exception!!.message)
+        }
+
+        photoRequester.requestPhoto()
+
+        verify { mockCallback(any()) }
+    }
+
+    @Test
+    fun photoRequesterErrorImageSaved() {
+        val mockCallback: (Result<ImageBitmap>) -> Unit = mockk()
+
+        val testRegistry = object : ActivityResultRegistry() {
+
+            override fun <I, O> onLaunch(
+                requestCode: Int,
+                contract: ActivityResultContract<I, O>,
+                input: I,
+                options: ActivityOptionsCompat?
+            ) {
+                when( contract::class) {
+                    //Make request permission fail
+                    ActivityResultContracts.RequestPermission::class -> {
+                        val requestPermissionResponse = false
+                        dispatchResult(requestCode, requestPermissionResponse)
+                    }
+                    else -> {
+                        assertTrue("Contract of type ${contract::class} is not implemented", false)
+                    }
+                }
+            }
+        }
+
+        val photoRequester = PhotoRequester(mockContext, mockCallback)
+
+        composeTestRule.setContent {
+            WithActivityResultRegistry(testRegistry) {
+                photoRequester.Init()
+            }
+
+        }
+
+        every { mockCallback(any()) } answers {
+            val exception = firstArg<Result<ImageBitmap>>().exceptionOrNull()
+            assertEquals(PhotoRequester.Companion.ExceptionType.PERMISSION_DENIED.toException().message, exception!!.message)
+        }
+
+        photoRequester.requestPhoto()
+
+        verify { mockCallback(any()) }
+    }
+
+
+
+    /**
+     * Defines a custom [ActivityResultRegistry] to be used when calls to ActivityResultContracts API via rememberLauncherForActivityResult.
+     *
+     * This allow us to mock external Activity calls in tests or in mock mode.
+     */
+    @Composable
+    fun WithActivityResultRegistry(activityResultRegistry: ActivityResultRegistry, content: @Composable () -> Unit) {
+        val activityResultRegistryOwner = object : ActivityResultRegistryOwner {
+            override val activityResultRegistry = activityResultRegistry
+        }
+        CompositionLocalProvider(LocalActivityResultRegistryOwner provides activityResultRegistryOwner) { content() }
+    }
+
+}

--- a/app/src/main/java/com/android/bookswap/model/PhotoRequester.kt
+++ b/app/src/main/java/com/android/bookswap/model/PhotoRequester.kt
@@ -47,7 +47,7 @@ class PhotoRequester(
             callback(Result.success(ImageDecoder.decodeBitmap(source).asImageBitmap()))
           } else {
             fileUri = null
-            callback(Result.failure(Exception("Image could not be saved in phone.")))
+            callback(Result.failure(ExceptionType.IMAGE_NOT_SAVED.toException()))
           }
         }
     // Ask for permission before using the camera.
@@ -58,14 +58,14 @@ class PhotoRequester(
             fileUri = getTempUri()
             cameraLauncher.launch(fileUri)
           } else {
-            callback(Result.failure(Exception("Permission denied.")))
+            callback(Result.failure(ExceptionType.PERMISSION_DENIED.toException()))
           }
         }
   }
 
   /** Request a photo from the user, this will ends-up calling [callback] */
   fun requestPhoto() {
-    if (!initialized) throw Error("Always call Init() before using requestPhoto()")
+    if (!initialized) throw ExceptionType.INIT_NOT_CALLED.toException()
 
     permissionLauncher.launch(Manifest.permission.CAMERA)
   }
@@ -85,4 +85,14 @@ class PhotoRequester(
 
     return uri
   }
+
+    companion object {
+        enum class ExceptionType(private val exceptionMessage: String) {
+            INIT_NOT_CALLED("Always call #Init() before using #requestPhoto()."),
+            PERMISSION_DENIED("Camera permission denied."),
+            IMAGE_NOT_SAVED("Image could not be saved in phone.");
+
+            fun toException(): Exception = Exception(exceptionMessage)
+        }
+    }
 }

--- a/app/src/main/java/com/android/bookswap/model/PhotoRequester.kt
+++ b/app/src/main/java/com/android/bookswap/model/PhotoRequester.kt
@@ -86,13 +86,13 @@ class PhotoRequester(
     return uri
   }
 
-    companion object {
-        enum class ExceptionType(private val exceptionMessage: String) {
-            INIT_NOT_CALLED("Always call #Init() before using #requestPhoto()."),
-            PERMISSION_DENIED("Camera permission denied."),
-            IMAGE_NOT_SAVED("Image could not be saved in phone.");
+  companion object {
+    enum class ExceptionType(private val exceptionMessage: String) {
+      INIT_NOT_CALLED("Always call #Init() before using #requestPhoto()."),
+      PERMISSION_DENIED("Camera permission denied."),
+      IMAGE_NOT_SAVED("Image could not be saved in phone.");
 
-            fun toException(): Exception = Exception(exceptionMessage)
-        }
+      fun toException(): Exception = Exception(exceptionMessage)
     }
+  }
 }


### PR DESCRIPTION
PhotoRequester is a hard class to test because it relies on permissions and ActivityResultContracts.
The best way to test that I found is following this : https://medium.com/@adrian.gl/how-to-mock-and-test-activityresult-apis-with-jetpack-compose-f3a1d6311171
But I added more type check safety because otherwise finer testing was not possible.

