### PR TITLE
Fix map display of User's self-location marker

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/map/MapScreenTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipe
 import androidx.compose.ui.test.swipeUp
@@ -380,6 +381,27 @@ class MapScreenTest : TestCase() {
 
         assertEquals(geolocation.latitude.value, cameraPositionState?.position?.target?.latitude)
         assertEquals(geolocation.longitude.value, cameraPositionState?.position?.target?.longitude)
+      }
+    }
+  }
+
+  @Test
+  fun markerNotDisplayedWhenLaunch() {
+    run {
+      step("Accept Permissions") {
+        flakySafely {
+          device.permissions.clickOn(Permissions.Button.ALLOW_FOREGROUND)
+          device.hackPermissions.grant(
+              device.targetContext.packageName, android.Manifest.permission.ACCESS_COARSE_LOCATION)
+          device.hackPermissions.grant(
+              device.targetContext.packageName, android.Manifest.permission.ACCESS_FINE_LOCATION)
+        }
+      }
+      step("Compose screen") { composeMapScreen(0) }
+      step("") {
+
+        // Assert that the marker is visible and the InfoWindow is displayed
+        composeTestRule.onNodeWithText("Your Location").assertDoesNotExist()
       }
     }
   }

--- a/app/src/main/java/com/android/bookswap/ui/map/Map.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/Map.kt
@@ -238,10 +238,7 @@ fun MapScreen(
               }
 
               GoogleMap(
-                  onMapClick = { // mutableStateSelectedUser = NO_USER_SELECTED
-                      // showMarker = true // Hide the marker when map is clicked elsewhere
-                      // Log.d("MapScreen", "Map clicked, hiding marker")
-                      clickedLatLng ->
+                  onMapClick = { clickedLatLng ->
                     Log.e("MapScreen", "Map clicked")
 
                     // Check if the clicked location is near the user's location
@@ -283,8 +280,7 @@ fun MapScreen(
                       title = stringResource(R.string.map_screen_your_location),
                       visible = showMarker,
                       icon =
-                          BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_BLUE),
-                  )
+                          BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_BLUE))
                 }
                 filteredUsers.value
                     .filter {

--- a/app/src/main/java/com/android/bookswap/ui/map/Map.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/Map.kt
@@ -271,7 +271,6 @@ fun MapScreen(
                   uiSettings = mapUISettings,
                   properties = mapProperties,
               ) {
-
                 // Marker for user's current location
                 if (!latitude.value.isNaN() && !longitude.value.isNaN()) {
                   Log.e("MapScreen", "Marker displayed at: ${latitude.value}, ${longitude.value}")

--- a/app/src/main/java/com/android/bookswap/ui/map/Map.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/Map.kt
@@ -70,8 +70,10 @@ import com.google.maps.android.compose.GoogleMap
 import kotlin.math.roundToInt
 import kotlinx.coroutines.launch
 
+/** Constants * */
 const val INIT_ZOOM = 10F
 const val NO_USER_SELECTED = -1
+const val SHOW_MARKER_DISTANCE = 50
 
 val CameraPositionKey = SemanticsPropertyKey<CameraPositionState>("CameraPosition")
 var SemanticsPropertyReceiver.cameraPosition by CameraPositionKey
@@ -204,10 +206,10 @@ fun MapScreen(
     }
   }
 
-    // State to control the visibility of the marker
-    var showMarker by remember { mutableStateOf(false) }
+  // State to control the visibility of the marker
+  var showMarker by remember { mutableStateOf(false) }
 
-    Scaffold(
+  Scaffold(
       modifier = Modifier.testTag(C.Tag.map_screen_container),
       topBar = topAppBar,
       bottomBar = bottomAppBar,
@@ -215,44 +217,50 @@ fun MapScreen(
         Box(
             Modifier.padding(
                 top = pd.calculateTopPadding(), bottom = pd.calculateBottomPadding())) {
-            // Marker state for user's location
-            val markerState = remember { MarkerState(position = LatLng(latitude.value, longitude.value)) }
 
-            // Update the marker's position when latitude or longitude changes
-            LaunchedEffect(latitude.value, longitude.value) {
+              // Marker state for user's location
+              val markerState = remember {
+                MarkerState(position = LatLng(latitude.value, longitude.value))
+              }
+
+              // Update the marker's position when latitude or longitude changes
+              LaunchedEffect(latitude.value, longitude.value) {
                 markerState.position = LatLng(latitude.value, longitude.value)
-            }
+              }
 
-            // Show the InfoWindow when the marker becomes visible
-            LaunchedEffect(showMarker) {
+              // Show the InfoWindow when the marker becomes visible
+              LaunchedEffect(showMarker) {
                 if (showMarker) {
-                    markerState.showInfoWindow()
+                  markerState.showInfoWindow()
                 } else {
-                    markerState.hideInfoWindow()
+                  markerState.hideInfoWindow()
                 }
-            }
+              }
 
-            GoogleMap(
-                  onMapClick = { //mutableStateSelectedUser = NO_USER_SELECTED
-                      //showMarker = true // Hide the marker when map is clicked elsewhere
-                      //Log.d("MapScreen", "Map clicked, hiding marker")
+              GoogleMap(
+                  onMapClick = { // mutableStateSelectedUser = NO_USER_SELECTED
+                      // showMarker = true // Hide the marker when map is clicked elsewhere
+                      // Log.d("MapScreen", "Map clicked, hiding marker")
                       clickedLatLng ->
-                      // Check if the clicked location is near the user's location
-                      val userLocation = LatLng(latitude.value, longitude.value)
-                      val distance = FloatArray(1)
+                    Log.e("MapScreen", "Map clicked")
 
-                      // Calculate the distance between the clicked point and the user's location
-                      Location.distanceBetween(
-                          clickedLatLng.latitude, clickedLatLng.longitude,
-                          userLocation.latitude, userLocation.longitude,
-                          distance
-                      )
+                    // Check if the clicked location is near the user's location
+                    val userLocation = LatLng(latitude.value, longitude.value)
+                    val distance = FloatArray(1)
 
-                      // Show marker if the distance is within 50 meters
-                      showMarker = distance[0] <= 50
+                    // Calculate the distance between the clicked point and the user's location
+                    Location.distanceBetween(
+                        clickedLatLng.latitude,
+                        clickedLatLng.longitude,
+                        userLocation.latitude,
+                        userLocation.longitude,
+                        distance)
 
-                      mutableStateSelectedUser = NO_USER_SELECTED
-                      },
+                    // Show marker if the distance is within 50 meters
+                    showMarker = distance[0] <= SHOW_MARKER_DISTANCE
+
+                    mutableStateSelectedUser = NO_USER_SELECTED
+                  },
                   onMapLoaded = {
                     cameraPositionState.position =
                         CameraPosition.fromLatLngZoom(
@@ -269,15 +277,14 @@ fun MapScreen(
 
                 // Marker for user's current location
                 if (!latitude.value.isNaN() && !longitude.value.isNaN()) {
-                    Log.d("MapScreen", "Marker displayed at: ${latitude.value}, ${longitude.value}")
-                    Marker(
-                        state = markerState,
-                        title = stringResource(R.string.map_screen_your_location),
-                        visible = showMarker,
-                        icon =
-                        BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_BLUE),
-                    )
-
+                  Log.e("MapScreen", "Marker displayed at: ${latitude.value}, ${longitude.value}")
+                  Marker(
+                      state = markerState,
+                      title = stringResource(R.string.map_screen_your_location),
+                      visible = showMarker,
+                      icon =
+                          BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_BLUE),
+                  )
                 }
                 filteredUsers.value
                     .filter {

--- a/app/src/main/java/com/android/bookswap/ui/map/Map.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/Map.kt
@@ -239,7 +239,7 @@ fun MapScreen(
 
               GoogleMap(
                   onMapClick = { clickedLatLng ->
-                    Log.e("MapScreen", "Map clicked")
+                    Log.i("MapScreen", "Map clicked")
 
                     // Check if the clicked location is near the user's location
                     val userLocation = LatLng(latitude.value, longitude.value)
@@ -273,7 +273,7 @@ fun MapScreen(
               ) {
                 // Marker for user's current location
                 if (!latitude.value.isNaN() && !longitude.value.isNaN()) {
-                  Log.e("MapScreen", "Marker displayed at: ${latitude.value}, ${longitude.value}")
+                  Log.i("MapScreen", "Marker displayed at: ${latitude.value}, ${longitude.value}")
                   Marker(
                       state = markerState,
                       title = stringResource(R.string.map_screen_your_location),


### PR DESCRIPTION
### Summary
This PR addresses the issue in the `MapScreen` where the user had both a blue dot and a marker for his location. The changes ensure the marker:
- Only the blue dot is always present
- When click near your location (50-meter radius) the Marker shows and the Marker's text directly appears with "Your Location"
- When you click on the map outside of the 50 meter distance from the location, the Marker is no more displayed.

### Key Changes
**1. Map Screen :**
- Marker Visibility State:
  - Added a showMarker state variable to control the marker's visibility dynamically.
- Marker State Management:
  - Introduced MarkerState to manage the position of the user's self-location marker.
  - Used LaunchedEffect to update the marker position when the latitude/longitude changes.
- Distance Calculation for Clicks:
  - Calculated the distance between the clicked point and the user's location using Location.distanceBetween.
  - Displayed the marker only if the clicked point is within a 50-meter radius.
- InfoWindow Behavior:
  - Showed or hid the InfoWindow based on the visibility of the marker using markerState.showInfoWindow() and markerState.hideInfoWindow().

**2. UI Tests:** 
- Added a test markerNotDisplayedWhenLaunch to verify:
  - The marker is not displayed initially when the screen launches.

### UI visual representation:
![Screenshot 2024-12-19 095721](https://github.com/user-attachments/assets/6c6f8e01-aee1-4efc-b455-8f2eca6e8a58)
![Screenshot 2024-12-19 095740](https://github.com/user-attachments/assets/cbbda60a-e5ab-4894-976e-f3dac8e1b87a)
