### PR TITLE
InfoWindow is displayed instead of navigating to user profile

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/map/MapScreenTest.kt
@@ -169,6 +169,7 @@ class MapScreenTest : TestCase() {
         composeTestRule.onAllNodesWithTag(C.Tag.Map.Marker.book_title).assertCountEquals(2)
         composeTestRule.onAllNodesWithTag(C.Tag.Map.Marker.book_author).assertCountEquals(2)
         composeTestRule.onAllNodesWithTag(C.Tag.Map.Marker.info_window_divider).assertCountEquals(1)
+        composeTestRule.onNodeWithTag(C.Tag.Map.Marker.info_window_user_profile).assertIsDisplayed()
 
         // components of Draggable Menu
         composeTestRule.onNodeWithTag(C.Tag.Map.bottom_drawer_container).assertIsDisplayed()

--- a/app/src/main/java/com/android/bookswap/resources/C.kt
+++ b/app/src/main/java/com/android/bookswap/resources/C.kt
@@ -299,6 +299,7 @@ object C {
       const val filter_button = "filter" + UI_T.BUTTON
       // Tags specific to components related to Google Maps Markers
       object Marker {
+        const val info_window_user_profile = "marker_info" + "_user_profile"
         const val info_window_container = "marker_info" + UI_T.CONTAINER
         const val info_window_scrollable = "marker_info" + UI_T.SCROLLABLE_CONTAINER
         const val info_window_divider = "marker_info" + UI_T.DIVIDER

--- a/app/src/main/java/com/android/bookswap/ui/map/Map.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/Map.kt
@@ -393,7 +393,7 @@ private fun CustomInfoWindow(
                             .background(ColorVariable.Green)
                             .testTag(C.Tag.Map.Marker.info_window_user_profile)) {
                       Text(
-                          text = "User profile",
+                          text = stringResource(R.string.map_screen_window_user),
                           color = ColorVariable.Accent,
                           fontSize = PRIMARY_TEXT_FONT_SP.sp,
                           modifier =

--- a/app/src/main/java/com/android/bookswap/ui/map/Map.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/Map.kt
@@ -26,12 +26,9 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
@@ -68,9 +65,9 @@ import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.*
 import com.google.maps.android.compose.GoogleMap
+import java.util.UUID
 import kotlin.math.roundToInt
 import kotlinx.coroutines.launch
-import java.util.UUID
 
 /** Constants * */
 const val INIT_ZOOM = 10F
@@ -300,12 +297,12 @@ fun MapScreen(
                             }
                             // Navigate to the user profile
                             /*navigationActions.navigateTo(
-                                screen = C.Screen.OTHERS_USER_PROFILE,
-                                UUID =
-                                    item.userUUID
-                                        .toString() // Assuming `item` has a unique UUID field
-                                // called `id`
-                                )*/
+                            screen = C.Screen.OTHERS_USER_PROFILE,
+                            UUID =
+                                item.userUUID
+                                    .toString() // Assuming `item` has a unique UUID field
+                            // called `id`
+                            )*/
                             false
                           })
                     }
@@ -358,7 +355,12 @@ const val SECONDARY_TEXT_FONT_SP = 16
  *   info window.
  */
 @Composable
-private fun CustomInfoWindow(modifier: Modifier = Modifier, userBooks: List<DataBook>, userUUID: UUID, navigationActions: NavigationActions) {
+private fun CustomInfoWindow(
+    modifier: Modifier = Modifier,
+    userBooks: List<DataBook>,
+    userUUID: UUID,
+    navigationActions: NavigationActions
+) {
   Card(
       modifier =
           modifier
@@ -381,25 +383,29 @@ private fun CustomInfoWindow(modifier: Modifier = Modifier, userBooks: List<Data
               0.dp, CARD_CORNER_RADIUS.dp, CARD_CORNER_RADIUS.dp, CARD_CORNER_RADIUS.dp)) {
         LazyColumn(
             modifier = Modifier.fillMaxWidth().testTag(C.Tag.Map.Marker.info_window_scrollable)) {
-                item {
-                    Column(modifier = Modifier.clickable {
-                        navigationActions.navigateTo(
-                            screen = C.Screen.OTHERS_USER_PROFILE,
-                            UUID = userUUID.toString()
-                        )
-                    }){
-                        Text(
-                            text = "User profile",
-                            color = ColorVariable.Accent,
-                            fontSize = PRIMARY_TEXT_FONT_SP.sp,
-                            modifier = Modifier.padding(horizontal = PADDING_HORIZONTAL_DP.dp, vertical = CARD_CORNER_RADIUS.dp))
-                        HorizontalDivider(
-                            modifier =
-                            Modifier.fillMaxWidth(),
-                            thickness = DIVIDER_THICKNESS_DP.dp,
-                            color = ColorVariable.Accent)
+              item {
+                Column(
+                    modifier =
+                        Modifier.clickable {
+                              navigationActions.navigateTo(
+                                  screen = C.Screen.OTHERS_USER_PROFILE, UUID = userUUID.toString())
+                            }
+                            .background(ColorVariable.Green)
+                            .testTag(C.Tag.Map.Marker.info_window_user_profile)) {
+                      Text(
+                          text = "User profile",
+                          color = ColorVariable.Accent,
+                          fontSize = PRIMARY_TEXT_FONT_SP.sp,
+                          modifier =
+                              Modifier.padding(
+                                  horizontal = PADDING_HORIZONTAL_DP.dp,
+                                  vertical = CARD_CORNER_RADIUS.dp))
+                      HorizontalDivider(
+                          modifier = Modifier.fillMaxWidth(),
+                          thickness = DIVIDER_THICKNESS_DP.dp,
+                          color = ColorVariable.Accent)
                     }
-                }
+              }
               itemsIndexed(userBooks) { index, book ->
                 Column(
                     modifier =

--- a/app/src/main/java/com/android/bookswap/ui/map/Map.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/Map.kt
@@ -9,6 +9,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -69,6 +70,7 @@ import com.google.maps.android.compose.*
 import com.google.maps.android.compose.GoogleMap
 import kotlin.math.roundToInt
 import kotlinx.coroutines.launch
+import java.util.UUID
 
 /** Constants * */
 const val INIT_ZOOM = 10F
@@ -297,13 +299,13 @@ fun MapScreen(
                               computePositionOfMarker(cameraPositionState, markerState.position)
                             }
                             // Navigate to the user profile
-                            navigationActions.navigateTo(
+                            /*navigationActions.navigateTo(
                                 screen = C.Screen.OTHERS_USER_PROFILE,
                                 UUID =
                                     item.userUUID
                                         .toString() // Assuming `item` has a unique UUID field
                                 // called `id`
-                                )
+                                )*/
                             false
                           })
                     }
@@ -320,7 +322,9 @@ fun MapScreen(
                           Modifier.offset {
                             IntOffset(screenPos.x.roundToInt(), screenPos.y.roundToInt())
                           },
-                      userBooks = filteredUsers.value[mutableStateSelectedUser].books)
+                      userBooks = filteredUsers.value[mutableStateSelectedUser].books,
+                      filteredUsers.value[mutableStateSelectedUser].userUUID,
+                      navigationActions)
                 }
               }
               // Draggable Bottom List
@@ -354,7 +358,7 @@ const val SECONDARY_TEXT_FONT_SP = 16
  *   info window.
  */
 @Composable
-private fun CustomInfoWindow(modifier: Modifier = Modifier, userBooks: List<DataBook>) {
+private fun CustomInfoWindow(modifier: Modifier = Modifier, userBooks: List<DataBook>, userUUID: UUID, navigationActions: NavigationActions) {
   Card(
       modifier =
           modifier
@@ -375,9 +379,27 @@ private fun CustomInfoWindow(modifier: Modifier = Modifier, userBooks: List<Data
       shape =
           RoundedCornerShape(
               0.dp, CARD_CORNER_RADIUS.dp, CARD_CORNER_RADIUS.dp, CARD_CORNER_RADIUS.dp)) {
-        Spacer(modifier.height(CARD_CORNER_RADIUS.dp))
         LazyColumn(
             modifier = Modifier.fillMaxWidth().testTag(C.Tag.Map.Marker.info_window_scrollable)) {
+                item {
+                    Column(modifier = Modifier.clickable {
+                        navigationActions.navigateTo(
+                            screen = C.Screen.OTHERS_USER_PROFILE,
+                            UUID = userUUID.toString()
+                        )
+                    }){
+                        Text(
+                            text = "User profile",
+                            color = ColorVariable.Accent,
+                            fontSize = PRIMARY_TEXT_FONT_SP.sp,
+                            modifier = Modifier.padding(horizontal = PADDING_HORIZONTAL_DP.dp, vertical = CARD_CORNER_RADIUS.dp))
+                        HorizontalDivider(
+                            modifier =
+                            Modifier.fillMaxWidth(),
+                            thickness = DIVIDER_THICKNESS_DP.dp,
+                            color = ColorVariable.Accent)
+                    }
+                }
               itemsIndexed(userBooks) { index, book ->
                 Column(
                     modifier =
@@ -410,19 +432,11 @@ private fun CustomInfoWindow(modifier: Modifier = Modifier, userBooks: List<Data
 }
 /** Constants used for dimensions and sizes in the draggable menu UI components. */
 const val HEIGHT_RETRACTED_DRAGGABLE_MENU_DP = 50
-const val MIN_BOX_BOOK_HEIGHT_DP = 90
-const val IMAGE_HEIGHT_DP = MIN_BOX_BOOK_HEIGHT_DP - PADDING_VERTICAL_DP * 2
 // 1.5:1 ratio + the padding
-const val IMAGE_WIDTH_DP = MIN_BOX_BOOK_HEIGHT_DP * 2 / 3 + PADDING_HORIZONTAL_DP * 2
 const val HANDLE_WIDTH_DP = 120
 const val HANDLE_HEIGHT_DP = 15
 const val HANDLE_CORNER_RADIUS_DP = 10
 const val SPACER_HEIGHT_DP = 20
-const val STAR_HEIGHT_DP = 30
-const val STAR_SIZE_DP = 26
-const val STAR_INNER_SIZE_DP = STAR_SIZE_DP / 2
-const val WIDTH_TITLE_BOX_DP = 150
-const val MAX_RATING = 5
 
 /**
  * Composable function to display a draggable menu containing all the nearest books available.
@@ -500,38 +514,4 @@ private fun DraggableMenu(listAllBooks: List<DataBook>, navigationActions: Navig
               })
         }
       }
-}
-
-/**
- * Composable function that displays a row of 5 stars, the n first are filled then the rest are
- * empty stars.
- *
- * @param rating A [Int] from 1 to 5, used to know how many filled star should be displayed
- */
-@Composable
-private fun DisplayStarReview(rating: Int) {
-  for (i in 1..rating) {
-    Icon(
-        imageVector = Icons.Filled.Star,
-        contentDescription = "Star Icon",
-        tint = Color.Black,
-        modifier = Modifier.size(STAR_SIZE_DP.dp).testTag("mapDraggableMenuBookBoxStar"))
-  }
-  for (i in rating + 1..MAX_RATING) {
-    // Hollow star
-    // Icons.Outlined.Star doesn't work, it displays the
-    // Icons.Filled.Star
-    Box(modifier = Modifier.width(STAR_SIZE_DP.dp).testTag("mapDraggableMenuBookBoxEmptyStar")) {
-      Icon(
-          imageVector = Icons.Filled.Star,
-          contentDescription = "Star Icon",
-          tint = Color.Black,
-          modifier = Modifier.size(STAR_SIZE_DP.dp))
-      Icon(
-          imageVector = Icons.Filled.Star,
-          contentDescription = "Star Icon",
-          tint = ColorVariable.BackGround,
-          modifier = Modifier.size(STAR_INNER_SIZE_DP.dp).align(Alignment.Center))
-    }
-  }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,6 +78,7 @@
     <string name="map_screen_title">Map</string>
     <string name="map_screen_please_connect_to_internet">Please connect to Internet to actualise</string>
     <string name="map_screen_your_location">Your Location</string>
+    <string name="map_screen_window_user">User Profile</string>
     <!-- Edit Profile Screen -->
     <string name="edit_profile_screen_title">Edit Profile</string>
     <string name="edit_profile_greeting">Greeting</string>


### PR DESCRIPTION
This PR removes the problem where clicking on a marker would navigate to the user profile linked to the marker. It was supposed to do the navigation only when doing a long press but was instead put in the onClick which was already used to display the infoWindow. As the Marker, doesn't have a modifier, the button to go to the user profile was put inside the InfoWindow as a new box.
This PR also removed the unused DisplayStarReview composable.