### PR TITLE
Fix users marker and book display

### DIFF
--- a/app/src/androidTest/java/com/android/bookswap/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/android/bookswap/ui/map/MapScreenTest.kt
@@ -129,7 +129,7 @@ class MapScreenTest : TestCase() {
 
     every { mockBookManagerViewModel.filteredUsers } returns
         MutableStateFlow(userBooksWithLocationList)
-    every { mockBookManagerViewModel.startUpdatingBooks() } just runs
+    every { mockBookManagerViewModel.startUpdatingBooks(any()) } just runs
     every { mockBookManagerViewModel.stopUpdatingBooks() } just runs
 
     mockUserRepository = mockk()

--- a/app/src/main/java/com/android/bookswap/model/map/BookManagerViewModel.kt
+++ b/app/src/main/java/com/android/bookswap/model/map/BookManagerViewModel.kt
@@ -8,9 +8,9 @@ import com.android.bookswap.data.DataUser
 import com.android.bookswap.data.UserBooksWithLocation
 import com.android.bookswap.data.repository.BooksRepository
 import com.android.bookswap.data.repository.UsersRepository
+import java.util.UUID
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
-import java.util.UUID
 
 private const val REFRESH_TIME_DELAY = 5000L
 private const val RETRY_TIME_DELAY = 250L

--- a/app/src/main/java/com/android/bookswap/model/map/BookManagerViewModel.kt
+++ b/app/src/main/java/com/android/bookswap/model/map/BookManagerViewModel.kt
@@ -114,7 +114,7 @@ class BookManagerViewModel(
         launch {
           booksRepository.getBook { books ->
             if (books.isSuccess) {
-              _allBooks.value = books.getOrThrow().filter { it.userId != currentUserUUID }
+              _allBooks.value = books.getOrThrow()
               successBooks = true
             } else {
               Log.e(

--- a/app/src/main/java/com/android/bookswap/ui/map/Map.kt
+++ b/app/src/main/java/com/android/bookswap/ui/map/Map.kt
@@ -136,7 +136,7 @@ fun MapScreen(
   // Start location and books updates
   LaunchedEffect(Unit) {
     if (isOnline) {
-      bookManagerViewModel.startUpdatingBooks()
+      bookManagerViewModel.startUpdatingBooks(userVM.getUser().userUUID)
     } else {
       Toast.makeText(
               context,

--- a/app/src/test/java/com/android/bookswap/model/map/BookManagerViewModelTest.kt
+++ b/app/src/test/java/com/android/bookswap/model/map/BookManagerViewModelTest.kt
@@ -143,7 +143,7 @@ class BookManagerViewModelTest {
                 _ ->
               0.0
             }
-    bookManagerViewModel.startUpdatingBooks()
+    bookManagerViewModel.startUpdatingBooks(UUID.randomUUID())
     bookManagerViewModel.filteredBooks.first { it != emptyList<DataBook>() }
     bookManagerViewModel.filteredUsers.first { it != emptyList<UserBooksWithLocation>() }
     assertEquals(books, bookManagerViewModel.filteredBooks.value)
@@ -156,7 +156,7 @@ class BookManagerViewModelTest {
     val bookManagerViewModel =
         BookManagerViewModel(
             mockGeolocation1, mockBookRepository, mockUsersRepository, mockBookFilter, sortingTest)
-    bookManagerViewModel.startUpdatingBooks()
+    bookManagerViewModel.startUpdatingBooks(UUID.randomUUID())
     bookManagerViewModel.filteredBooks.first { it != emptyList<DataBook>() }
     bookManagerViewModel.filteredUsers.first { it != emptyList<UserBooksWithLocation>() }
     assertEquals(listOf(book3), bookManagerViewModel.filteredBooks.value)
@@ -170,10 +170,10 @@ class BookManagerViewModelTest {
         BookManagerViewModel(
             mockGeolocation1, mockBookRepository, mockUsersRepository, mockBookFilter, sortingTest)
     every { mockBookFilter.filterBooks(any()) } answers { emptyList() }
-    bookManagerViewModel.startUpdatingBooks()
+    bookManagerViewModel.startUpdatingBooks(UUID.randomUUID())
     bookManagerViewModel.stopUpdatingBooks()
     every { mockBookFilter.filterBooks(any()) } answers { listOf(book3) }
-    bookManagerViewModel.startUpdatingBooks()
+    bookManagerViewModel.startUpdatingBooks(UUID.randomUUID())
     bookManagerViewModel.filteredBooks.first { it != emptyList<DataBook>() }
     bookManagerViewModel.filteredUsers.first { it != emptyList<UserBooksWithLocation>() }
     assertEquals(listOf(book3), bookManagerViewModel.filteredBooks.value)
@@ -190,7 +190,7 @@ class BookManagerViewModelTest {
             mockUsersRepository,
             mockBookFilterEmpty,
             sortingTest)
-    bookManagerViewModel.startUpdatingBooks()
+    bookManagerViewModel.startUpdatingBooks(UUID.randomUUID())
     bookManagerViewModel.filteredBooks.first { it != emptyList<DataBook>() }
     bookManagerViewModel.filteredUsers.first { it != emptyList<UserBooksWithLocation>() }
     assertEquals(listOf(book1, book2, book3), bookManagerViewModel.filteredBooks.value)


### PR DESCRIPTION
This PR fixes an issue where the current user logged in marker was red as if he was another user and the user book where displayed as if it was other user's book.
This fix ensure the UI properly differentiates between the logged-in user and other users. And removes the logged-in user books in the list of books in the map.