### PR TITLE
Fix new breaking change to sign-android-release

### DIFF
--- a/.github/workflows/buildApk.yml
+++ b/.github/workflows/buildApk.yml
@@ -52,6 +52,7 @@ jobs:
           keyAlias: ${{ secrets.ANDROID_KEY_ALIAS }}
           keyStorePassword: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           keyPassword: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          buildToolsVersion: 34.0.0
       - name: Upload Release Build to Artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
No idea why, but since two days ago this bug started to affect the build apk ci... : https://github.com/ilharp/sign-android-release/issues/24

I can confirm that this solve the apk build error.